### PR TITLE
Bugfix for deprecated mandrill test matchers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects { subproject ->
         classifier "javadoc"
     }
 
-    compileKotlin {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_13
         }

--- a/mail/mandrill/src/test/java/com/ritense/mail/BlacklistFilterTest.java
+++ b/mail/mandrill/src/test/java/com/ritense/mail/BlacklistFilterTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/mail/mandrill/src/test/java/com/ritense/mail/MandrillHealthIndicatorTest.java
+++ b/mail/mandrill/src/test/java/com/ritense/mail/MandrillHealthIndicatorTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.health.Health;
 
 import static com.ritense.mail.service.MandrillHealthIndicator.PONG;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;

--- a/mail/mandrill/src/test/java/com/ritense/mail/RedirectToFilterTest.java
+++ b/mail/mandrill/src/test/java/com/ritense/mail/RedirectToFilterTest.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/mail/mandrill/src/test/java/com/ritense/mail/WhitelistFilterTest.java
+++ b/mail/mandrill/src/test/java/com/ritense/mail/WhitelistFilterTest.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
fixed the usage of the deprecated junit 4 assertions in favor of the hamcrest matcher, modified the jvmTarget option setting so that the test Kotlin compilation is done with target jvm 13 as well