### PR TITLE
Feature/32606 Store changes when document is edited

### DIFF
--- a/document/src/main/java/com/ritense/document/config/SpringContextHelper.java
+++ b/document/src/main/java/com/ritense/document/config/SpringContextHelper.java
@@ -1,0 +1,21 @@
+package com.ritense.document.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringContextHelper implements ApplicationContextAware {
+    private static ApplicationContext context;
+
+    @Override
+    public void setApplicationContext(@NotNull ApplicationContext applicationContext) throws BeansException {
+        context = applicationContext;
+    }
+
+    public static <T> T getProperty(String property, Class<T> targetClass) {
+        return context.getEnvironment().getProperty(property, targetClass);
+    }
+}

--- a/document/src/main/java/com/ritense/document/config/SpringContextHelper.java
+++ b/document/src/main/java/com/ritense/document/config/SpringContextHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.document.config;
 
 import org.jetbrains.annotations.NotNull;

--- a/document/src/main/java/com/ritense/document/domain/event/DocumentModifiedEvent.java
+++ b/document/src/main/java/com/ritense/document/domain/event/DocumentModifiedEvent.java
@@ -17,6 +17,7 @@
 package com.ritense.document.domain.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ritense.document.config.SpringContextHelper;
 import com.ritense.document.domain.Document;
 
 import java.util.List;
@@ -27,5 +28,19 @@ public interface DocumentModifiedEvent {
     Document.Id documentId();
 
     List<? extends DocumentFieldChangedEvent> changes();
+
+    @JsonProperty(value = "changes")
+    default List<? extends DocumentFieldChangedEvent> registeredChanges() {
+        List<? extends DocumentFieldChangedEvent> changes = null;
+
+        Boolean registerDocumentChanges = SpringContextHelper
+            .getProperty("valtimo.audit.auditDocumentChanges", Boolean.class);
+
+        if (registerDocumentChanges != null && registerDocumentChanges) {
+            changes = changes();
+        }
+
+        return changes;
+    }
 
 }

--- a/document/src/main/java/com/ritense/document/domain/impl/JsonSchemaDocumentId.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/JsonSchemaDocumentId.java
@@ -22,17 +22,18 @@ import com.ritense.document.domain.Document;
 import com.ritense.valtimo.contract.domain.AbstractId;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import java.util.Objects;
 import java.util.UUID;
 
 import static com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentNotNull;
 
 @Embeddable
 @Data
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class JsonSchemaDocumentId extends AbstractId<JsonSchemaDocumentId> implements Document.Id {
 

--- a/document/src/test/java/com/ritense/document/domain/event/DocumentModifiedEventTest.java
+++ b/document/src/test/java/com/ritense/document/domain/event/DocumentModifiedEventTest.java
@@ -1,0 +1,81 @@
+package com.ritense.document.domain.event;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ritense.document.config.SpringContextHelper;
+import com.ritense.document.domain.impl.JsonSchemaDocumentFieldChangedEvent;
+import com.ritense.document.domain.impl.JsonSchemaDocumentId;
+import com.ritense.document.domain.impl.event.JsonSchemaDocumentModifiedEvent;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+class DocumentModifiedEventTest {
+    private ApplicationContext applicationContext;
+    private MockEnvironment environment;
+
+    @BeforeEach
+    public void setUp() {
+        applicationContext = mock(ApplicationContext.class);
+        environment = new MockEnvironment();
+    }
+
+    @Test
+    void shouldReturnChangesWhenPropertyIsSet() throws NoSuchFieldException, IllegalAccessException {
+        environment.setProperty("valtimo.audit.auditDocumentChanges", "true");
+
+        Field field = SpringContextHelper.class.getDeclaredField("context");
+        injectMock(field, applicationContext);
+        when(applicationContext.getEnvironment()).thenReturn(environment);
+
+        List<JsonSchemaDocumentFieldChangedEvent> changes = List
+            .of(new JsonSchemaDocumentFieldChangedEvent("type", "path", null, null));
+
+        JsonSchemaDocumentModifiedEvent documentModifiedEvent = createDocumentModifiedEvent(changes);
+
+        assertEquals(1, documentModifiedEvent.registeredChanges().size());
+
+    }
+
+    @Test
+    void shouldReturnNothingWhenPropertyIsNotSet() throws NoSuchFieldException, IllegalAccessException {
+        Field field = SpringContextHelper.class.getDeclaredField("context");
+        injectMock(field, applicationContext);
+        when(applicationContext.getEnvironment()).thenReturn(environment);
+
+        List<JsonSchemaDocumentFieldChangedEvent> changes = List
+            .of(new JsonSchemaDocumentFieldChangedEvent("type", "path", null, null));
+
+        JsonSchemaDocumentModifiedEvent documentModifiedEvent = createDocumentModifiedEvent(changes);
+
+        assertNull(documentModifiedEvent.registeredChanges());
+
+    }
+
+    private void injectMock(Field field, Object newValue) throws IllegalAccessException {
+        field.setAccessible(true);
+        field.set(null, newValue);
+
+    }
+
+    private JsonSchemaDocumentModifiedEvent createDocumentModifiedEvent(
+        List<JsonSchemaDocumentFieldChangedEvent> changes) {
+        return new JsonSchemaDocumentModifiedEvent(
+            UUID.randomUUID(),
+            "some-origin",
+            LocalDateTime.now(),
+            "some-user",
+            JsonSchemaDocumentId.existingId(UUID.randomUUID()),
+            changes
+        );
+    }
+}

--- a/document/src/test/java/com/ritense/document/domain/event/DocumentModifiedEventTest.java
+++ b/document/src/test/java/com/ritense/document/domain/event/DocumentModifiedEventTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.document.domain.event;
 
 


### PR DESCRIPTION
Added a property "valtimo.audit.auditDocumentChanges" which, when set to true, audits document changes. Default is false.