### PR TITLE
#33042 gzac zaak behandelen niet mogelijk

### DIFF
--- a/document/src/main/java/com/ritense/document/autoconfigure/DocumentAutoConfiguration.java
+++ b/document/src/main/java/com/ritense/document/autoconfigure/DocumentAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.ritense.document.autoconfigure;
 
+import com.ritense.document.config.SpringContextHelper;
 import com.ritense.document.domain.impl.JsonSchemaDocumentDefinition;
 import com.ritense.document.domain.impl.listener.ApplicationReadyEventListenerImpl;
 import com.ritense.document.domain.impl.listener.DocumentRelatedFileSubmittedEventListenerImpl;
@@ -167,5 +168,11 @@ public class DocumentAutoConfiguration {
     @ConditionalOnMissingBean(DocumentVariableService.class)
     public DocumentVariableService documentVariableService() {
         return new JsonSchemaDocumentVariableService();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SpringContextHelper.class)
+    public SpringContextHelper springContextHelper() {
+        return new SpringContextHelper();
     }
 }

--- a/document/src/main/java/com/ritense/document/config/SpringContextHelper.java
+++ b/document/src/main/java/com/ritense/document/config/SpringContextHelper.java
@@ -20,10 +20,9 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.stereotype.Component;
 
-@Component
 public class SpringContextHelper implements ApplicationContextAware {
+
     private static ApplicationContext context;
 
     @Override


### PR DESCRIPTION
Uit de logs van gzac-generiek-process:
```
Caused by: java.lang.NullPointerException: null
	at com.ritense.document.config.SpringContextHelper.getProperty(SpringContextHelper.java:35)
```