### PR TITLE
#33042 fix conflicting beans name

### DIFF
--- a/document/src/main/java/com/ritense/document/autoconfigure/DocumentAutoConfiguration.java
+++ b/document/src/main/java/com/ritense/document/autoconfigure/DocumentAutoConfiguration.java
@@ -172,7 +172,7 @@ public class DocumentAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(SpringContextHelper.class)
-    public SpringContextHelper springContextHelper() {
+    public SpringContextHelper springContextHelper2() {
         return new SpringContextHelper();
     }
 }

--- a/document/src/main/java/com/ritense/document/autoconfigure/DocumentAutoConfiguration.java
+++ b/document/src/main/java/com/ritense/document/autoconfigure/DocumentAutoConfiguration.java
@@ -170,9 +170,9 @@ public class DocumentAutoConfiguration {
         return new JsonSchemaDocumentVariableService();
     }
 
-    @Bean
+    @Bean("documentSpringContextHelper")
     @ConditionalOnMissingBean(SpringContextHelper.class)
-    public SpringContextHelper springContextHelper2() {
+    public SpringContextHelper springContextHelper() {
         return new SpringContextHelper();
     }
 }


### PR DESCRIPTION
Er is een andere bean die ook SpringContextHelper heet:
```
Caused by: org.springframework.beans.factory.support.BeanDefinitionOverrideException
```