### PR TITLE
Bugfix: Flowmailer subject and sender not supplied causing NPE

### DIFF
--- a/mail/flowmailer/src/main/kotlin/com/ritense/mail/flowmailer/domain/SubmitMessage.kt
+++ b/mail/flowmailer/src/main/kotlin/com/ritense/mail/flowmailer/domain/SubmitMessage.kt
@@ -60,13 +60,13 @@ data class SubmitMessage(
             templatedMailMessage.recipients.get().forEach {
                 val submitMessage = SubmitMessage(
                     flowSelector = templatedMailMessage.templateIdentifier.get(),
-                    headerFromAddress = templatedMailMessage.sender.email.get(),
+                    headerFromAddress = templatedMailMessage.sender.email.get().orEmpty(),
                     headerFromName = templatedMailMessage.sender.name.get().orEmpty(),
                     headerToAddress = it.email.get(),
                     headerToName = it.name.get().orEmpty(),
                     recipientAddress = it.email.get(),
-                    senderAddress = templatedMailMessage.sender.email.get(),
-                    subject = templatedMailMessage.subject.get(),
+                    senderAddress = templatedMailMessage.sender.email.get().orEmpty(),
+                    subject = templatedMailMessage.subject.get().orEmpty(),
                     data = templatedMailMessage.placeholders
                 )
 

--- a/mail/flowmailer/src/test/kotlin/com/ritense/mail/flowmailer/domain/SubmitMessageTest.kt
+++ b/mail/flowmailer/src/test/kotlin/com/ritense/mail/flowmailer/domain/SubmitMessageTest.kt
@@ -19,8 +19,11 @@ package com.ritense.mail.flowmailer.domain
 import com.ritense.mail.flowmailer.BaseTest
 import com.ritense.valtimo.contract.basictype.EmailAddress
 import com.ritense.valtimo.contract.basictype.SimpleName
+import com.ritense.valtimo.contract.mail.model.TemplatedMailMessage
 import com.ritense.valtimo.contract.mail.model.value.Attachment
+import com.ritense.valtimo.contract.mail.model.value.MailTemplateIdentifier
 import com.ritense.valtimo.contract.mail.model.value.Recipient
+import com.ritense.valtimo.contract.mail.model.value.Subject
 import com.ritense.valtimo.contract.mail.model.value.attachment.Content
 import com.ritense.valtimo.contract.mail.model.value.attachment.Name
 import com.ritense.valtimo.contract.mail.model.value.attachment.Type
@@ -71,4 +74,26 @@ class SubmitMessageTest : BaseTest() {
         assertThat(submitMessages[0].attachments[0].contentType).isEqualTo(Tika().detect(attachment.content.get()))
         assertThat(submitMessages[0].attachments[0].content).isNotNull
     }
+
+    @Test
+    fun `should create SubmitMessage with default empty values`() {
+        val templatedMailMessage = TemplatedMailMessage.with(
+            Recipient.to(
+                EmailAddress.from("emailAddress"),
+                SimpleName.from("name")
+            ),
+            MailTemplateIdentifier.from("templateIdentifier"))
+            .placeholders(emptyMap())
+            .subject(Subject.none())
+            .build()
+
+        val submitMessages = SubmitMessage.from(templatedMailMessage)
+
+        assertThat(submitMessages[0]).isNotNull
+        assertThat(submitMessages[0].senderAddress).isEmpty()
+        assertThat(submitMessages[0].subject).isEmpty()
+        assertThat(submitMessages[0].headerFromAddress).isEmpty()
+        assertThat(submitMessages[0].data).isEmpty()
+    }
+
 }


### PR DESCRIPTION
See https://ritense.tpondemand.com/entity/33110-bug-sender-null-pointer-ex

ed by: java.lang.NullPointerException: get() must not be null
    at com.ritense.mail.flowmailer.domain.SubmitMessage$Companion.from(SubmitMessage.kt:63)
    at com.ritense.mail.flowmailer.service.FlowmailerMailDispatcher.send(FlowmailerDispatcher.kt:50)
    at com.ritense.mail.service.FilteredMailSender.send(FilteredMailSender.kt:49)
    at com.ritense.valtimo.implementation.service.GemeenteBredaMailService.send(GemeenteBredaMailService.java:77)
    at com.ritense.valtimo.implementation.evenementen.EvenementenAanmeldenRkMailService.stuurOntvangstbevestiging(EvenementenAanmeldenRkMailService.java:64)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)