### PR TITLE
Added a new /api/ping endpoint that always returns a 200

### DIFF
--- a/core/src/main/java/com/ritense/valtimo/autoconfigure/HttpSecurityAutoConfiguration.java
+++ b/core/src/main/java/com/ritense/valtimo/autoconfigure/HttpSecurityAutoConfiguration.java
@@ -34,6 +34,7 @@ import com.ritense.valtimo.security.config.DenyAllHttpSecurityConfigurer;
 import com.ritense.valtimo.security.config.EmailNotificationSettingsSecurityConfigurer;
 import com.ritense.valtimo.security.config.ErrorHttpSecurityConfigurer;
 import com.ritense.valtimo.security.config.JwtHttpSecurityConfigurer;
+import com.ritense.valtimo.security.config.PingHttpSecurityConfigurer;
 import com.ritense.valtimo.security.config.ProcessHttpSecurityConfigurer;
 import com.ritense.valtimo.security.config.ProcessInstanceHttpSecurityConfigurer;
 import com.ritense.valtimo.security.config.PublicProcessHttpSecurityConfigurer;
@@ -109,6 +110,13 @@ public class HttpSecurityAutoConfiguration {
     }
 
     //CORE ENDPOINT CONFIGURATION
+
+    @Order(260)
+    @Bean
+    @ConditionalOnMissingBean(PingHttpSecurityConfigurer.class)
+    public PingHttpSecurityConfigurer pingHttpSecurityConfigurer() {
+        return new PingHttpSecurityConfigurer();
+    }
 
     @Order(270)
     @Bean

--- a/core/src/main/java/com/ritense/valtimo/security/config/PingHttpSecurityConfigurer.java
+++ b/core/src/main/java/com/ritense/valtimo/security/config/PingHttpSecurityConfigurer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.security.config;
+
+import com.ritense.valtimo.contract.security.config.HttpConfigurerConfigurationException;
+import com.ritense.valtimo.contract.security.config.HttpSecurityConfigurer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+import static org.springframework.http.HttpMethod.GET;
+
+public class PingHttpSecurityConfigurer implements HttpSecurityConfigurer {
+
+    @Override
+    public void configure(HttpSecurity http) {
+        try {
+            http.authorizeRequests()
+                .antMatchers(GET, "/api/ping").permitAll();
+        } catch (Exception e) {
+            throw new HttpConfigurerConfigurationException(e);
+        }
+    }
+
+}

--- a/core/src/main/java/com/ritense/valtimo/web/rest/PingResource.java
+++ b/core/src/main/java/com/ritense/valtimo/web/rest/PingResource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.web.rest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * A simple endpoint that always returns HTTP Status Code 200 regardless of authentication.
+ * This can be used for health checks (whether the application is running or not).
+ * In contrast to Spring Actuator's /management/health, this endpoint doesn't fail on underlying problems,
+ * nor does it require authentication to access (which is important for some types of health checks).
+ */
+@RestController
+@RequestMapping(value = "/api/ping")
+public class PingResource {
+
+    private static final String PING_RESPONSE = "pong";
+
+    @GetMapping(produces = MediaType.TEXT_PLAIN_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    public String pingPong() {
+        return PING_RESPONSE;
+    }
+
+}


### PR DESCRIPTION
Added a new `/api/ping` endpoint that always returns a HTTP status code 200, regardless of the authentication.

This one is needed because Spring Actuator's `/management/health` requires authentication, but for AWS's load balancer health checks, we need an endpoint that is always accessible when the application is running (we can't pass extra headers or create JWT tokens on the fly). Also unlike `/management/health` it should remain up even when underlaying services have problems, so that the load balancer still allows traffic to go through to the web server.