### PR TITLE
bugfix: fixed formlink json patches not checking submission content

### DIFF
--- a/form-link/src/main/java/com/ritense/formlink/service/impl/FormIoJsonPatchSubmissionTransformerService.java
+++ b/form-link/src/main/java/com/ritense/formlink/service/impl/FormIoJsonPatchSubmissionTransformerService.java
@@ -172,7 +172,7 @@ public class FormIoJsonPatchSubmissionTransformerService implements SubmissionTr
         final List<ObjectNode> inputFields = FormIoFormDefinition.getInputFields(formDefinitionData);
 
         inputFields.forEach(field -> {
-            if (field.has(CUSTOM_PROPERTIES) && !field.get(CUSTOM_PROPERTIES).isEmpty()) {
+            if (field.has(CUSTOM_PROPERTIES) && !field.get(CUSTOM_PROPERTIES).isEmpty() && submission.has(field.get(PROPERTY_KEY).textValue())) {
                 final String container = field.get(CUSTOM_PROPERTIES).get(CONTAINER_KEY).asText();
                 final String propertyName = field.get(PROPERTY_KEY).textValue();
                 final JsonNode propertyValue = submission.at("/" + propertyName);

--- a/form-link/src/test/java/com/ritense/formlink/service/impl/FormIoJsonPatchSubmissionTransformerServiceTest.java
+++ b/form-link/src/test/java/com/ritense/formlink/service/impl/FormIoJsonPatchSubmissionTransformerServiceTest.java
@@ -122,6 +122,31 @@ public class FormIoJsonPatchSubmissionTransformerServiceTest extends BaseTest {
     }
 
     @Test
+    public void preProcessNewArrayItemMissingKeysInSubmission() throws IOException {
+
+        final var formDefinition = formDefinitionOf("new-item-array-form-example");
+
+        ObjectNode submission = emptySubmission();
+        ObjectNode placeholders = placeholders();
+        ObjectNode source = source();
+
+        JsonPatch jsonPatch = formIoJsonPatchSubmissionTransformerService.preSubmissionTransform(
+            formDefinition,
+            submission,
+            placeholders,
+            source
+        );
+
+        //Assert initial submission is cleaned up
+        assertThat(submission.get("name")).isNullOrEmpty();
+        assertThat(jsonPatch.patches().size()).isEqualTo(0);
+
+        JsonPatchService.apply(jsonPatch, source);
+        assertThat(source.at("/favorites").size()).isEqualTo(2);
+        assertThat(source.at("/favorites/2/name").isMissingNode()).isEqualTo(true);
+    }
+
+    @Test
     public void preProcessNewArrayItemCombinedPatch() throws IOException {
 
         final var formDefinition = formDefinitionOf("new-item-combined-array-form-example");
@@ -167,6 +192,10 @@ public class FormIoJsonPatchSubmissionTransformerServiceTest extends BaseTest {
         submission.put("name", "Focaccia");
         submission.put("size", "big");
         return submission;
+    }
+
+    private ObjectNode emptySubmission() {
+        return JsonNodeFactory.instance.objectNode();
     }
 
     private ObjectNode submissionNewArray() {


### PR DESCRIPTION
* added condition to skip input fields that did not submit anything.
* added test to make sure original array is not modified if submission is empty or doesn't contain addable key.