### PR TITLE
Reverse proxy support for OpenZaak resource service

### DIFF
--- a/resource/openzaak-resource/src/main/kotlin/com/ritense/resource/service/OpenZaakService.kt
+++ b/resource/openzaak-resource/src/main/kotlin/com/ritense/resource/service/OpenZaakService.kt
@@ -164,7 +164,14 @@ class OpenZaakService(
     }
 
     private fun getDownloadUrl(resource: OpenZaakResource): URL {
-        val currentRequestUrl = URL(request.requestURL.toString())
+        var currentRequestUrl = URL(request.requestURL.toString())
+
+        val forwardedProtocol = request.getHeader("x-forwarded-proto")
+        if(forwardedProtocol != null && forwardedProtocol.equals("https")) {
+            currentRequestUrl = URL("https", currentRequestUrl.host, currentRequestUrl.port,
+                currentRequestUrl.file);
+        }
+
         return URL(currentRequestUrl, "/api/resource/${resource.resourceId.id}/download")
     }
 }


### PR DESCRIPTION
Added reverse proxy support in OpenZaak resource service, serving an HTTPS URL in the response if the source requests was reverse proxies with x-forwarded-proto: https