### PR TITLE
fix: NullPointerException for zaak_type_url

### DIFF
--- a/openzaak/build.gradle
+++ b/openzaak/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.boot:spring-boot-starter-validation"
+    implementation "org.springframework.boot:spring-boot-starter-webflux"
 
     implementation "com.fasterxml.jackson.module:jackson-module-afterburner"
     implementation "com.fasterxml.jackson.module:jackson-module-parameter-names"

--- a/openzaak/src/main/kotlin/com/ritense/openzaak/liquibase/changelog/ChangeLog20220415ZaakInstanceLinkSetZaakTypeUrl.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/liquibase/changelog/ChangeLog20220415ZaakInstanceLinkSetZaakTypeUrl.kt
@@ -21,19 +21,17 @@ class ChangeLog20220415ZaakInstanceLinkSetZaakTypeUrl : CustomTaskChange {
 
         val zaakToken = getOpenZaakToken(connection)
         val zaakWebClient = getOpenZaakWebClient(zaakToken)
-        var statement = connection.prepareStatement("SELECT zaak_type_url, zaak_instance_url FROM zaak_instance_link")
+        var statement = connection.prepareStatement("SELECT zaak_instance_url FROM zaak_instance_link WHERE zaak_type_url IS NULL")
         val result = statement.executeQuery()
 
         while (result.next()) {
-            val zaakTypeUrl = result.getString(1)
-            if (zaakTypeUrl == null) {
-                val zaakInstanceUrl = result.getString(2)
+            val zaakInstanceUrl = result.getString(1)
+            val zaakTypeUrl = getZaakTypeUrl(zaakWebClient, zaakInstanceUrl)
                 statement =
                     connection.prepareStatement("UPDATE zaak_instance_link SET zaak_type_url = ? WHERE zaak_instance_url = ?")
-                statement.setString(1, getZaakTypeUrl(zaakWebClient, zaakInstanceUrl))
+                statement.setString(1, zaakTypeUrl)
                 statement.setString(2, zaakInstanceUrl)
                 statement.execute()
-            }
         }
     }
 

--- a/openzaak/src/main/kotlin/com/ritense/openzaak/liquibase/changelog/ChangeLog20220415ZaakInstanceLinkSetZaakTypeUrl.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/liquibase/changelog/ChangeLog20220415ZaakInstanceLinkSetZaakTypeUrl.kt
@@ -1,0 +1,95 @@
+package com.ritense.openzaak.liquibase.changelog
+
+import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.ADMIN
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import liquibase.change.custom.CustomTaskChange
+import liquibase.database.Database
+import liquibase.database.jvm.JdbcConnection
+import liquibase.exception.ValidationErrors
+import liquibase.resource.ResourceAccessor
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import java.nio.charset.Charset
+import java.util.Date
+
+class ChangeLog20220415ZaakInstanceLinkSetZaakTypeUrl : CustomTaskChange {
+
+    override fun execute(database: Database?) {
+        val connection = database!!.connection as JdbcConnection
+
+        val zaakToken = getOpenZaakToken(connection)
+        val zaakWebClient = getOpenZaakWebClient(zaakToken)
+        var statement = connection.prepareStatement("SELECT zaak_type_url, zaak_instance_url FROM zaak_instance_link")
+        val result = statement.executeQuery()
+
+        while (result.next()) {
+            val zaakTypeUrl = result.getString(1)
+            if (zaakTypeUrl == null) {
+                val zaakInstanceUrl = result.getString(2)
+                statement =
+                    connection.prepareStatement("UPDATE zaak_instance_link SET zaak_type_url = ? WHERE zaak_instance_url = ?")
+                statement.setString(1, getZaakTypeUrl(zaakWebClient, zaakInstanceUrl))
+                statement.setString(2, zaakInstanceUrl)
+                statement.execute()
+            }
+        }
+    }
+
+    private fun getOpenZaakToken(connection: JdbcConnection): String {
+        val connectorProperties = getZaakConnectorProperties(connection)
+        val clientId = getFieldFromJson("clientId", connectorProperties)
+        val secret = getFieldFromJson("secret", connectorProperties)
+
+        val signingKey = Keys.hmacShaKeyFor(secret.toByteArray(Charset.forName("UTF-8")))
+
+        val jwtBuilder = Jwts.builder().setIssuer(clientId).setIssuedAt(Date()).claim("client_id", clientId)
+            .claim("user_id", "SYSTEM").claim("user_representation", "SYSTEM").claim("roles", listOf(ADMIN))
+
+        return jwtBuilder.signWith(signingKey, SignatureAlgorithm.HS256).compact()
+    }
+
+    private fun getZaakConnectorProperties(connection: JdbcConnection): String {
+        var statement =
+            connection.prepareStatement("SELECT connector_type_id FROM connector_type WHERE name = 'OpenZaak'")
+        var result = statement.executeQuery()
+        result.next()
+        val connectorTypeId = result.getBytes(1)
+
+        statement =
+            connection.prepareStatement("SELECT connector_properties FROM connector_instance WHERE connector_type_id = ?")
+        statement.setBytes(1, connectorTypeId)
+        result = statement.executeQuery()
+        result.next()
+        return result.getString(1)
+    }
+
+    private fun getOpenZaakWebClient(openZaakToken: String): WebClient {
+        return WebClient.builder().defaultHeader("Authorization", "Bearer $openZaakToken")
+            .defaultHeader("Accept-Crs", "EPSG:4326").build()
+    }
+
+    private fun getZaakTypeUrl(webClient: WebClient, zaakInstanceUrl: String): String {
+        val zaakJson = webClient.get().uri(zaakInstanceUrl).retrieve().bodyToMono<String>().block()!!
+        return getFieldFromJson("zaaktype", zaakJson)
+    }
+
+    private fun getFieldFromJson(field: String, json: String): String {
+        return """"$field": ?"(.+?)"""".toRegex().find(json)!!.groupValues[1]
+    }
+
+    override fun getConfirmationMessage(): String {
+        return "${this::class.simpleName} executed."
+    }
+
+    override fun setUp() {
+    }
+
+    override fun setFileOpener(resourceAccessor: ResourceAccessor?) {
+    }
+
+    override fun validate(database: Database?): ValidationErrors {
+        return ValidationErrors()
+    }
+}

--- a/openzaak/src/main/resources/config/liquibase/changelog/20211108-zaak-instance-link-changelog.xml
+++ b/openzaak/src/main/resources/config/liquibase/changelog/20211108-zaak-instance-link-changelog.xml
@@ -50,4 +50,22 @@
     <changeSet id="3" author="Rick Veenstra">
         <dropColumn tableName="zaak_type_link" columnName="zaak_instance_links"/>
     </changeSet>
+
+    <changeSet id="4" author="Ritense">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT COUNT(1)
+                    FROM zaak_instance_link
+                    WHERE zaak_type_url IS NULL
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <customChange class="com.ritense.openzaak.liquibase.changelog.ChangeLog20220415ZaakInstanceLinkSetZaakTypeUrl"/>
+    </changeSet>
+
+    <changeSet id="5" author="Ritense">
+        <addNotNullConstraint tableName="zaak_instance_link" columnDataType="VARCHAR(512)" columnName="zaak_type_url"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
```
org.camunda.bpm.engine.ProcessEngineException: org.springframework.orm.jpa.JpaSystemException: Error attempting to apply AttributeConverter; nested exception is javax.persistence.PersistenceException: Error attempting to apply AttributeConverter
...
	at com.ritense.openzaak.service.impl.ZaakInstanceLinkService.getByDocumentId(ZaakInstanceLinkService.kt:53)
	at com.ritense.openzaak.listener.ServiceTaskListener.notify(ServiceTaskListener.kt:55)
...
Caused by: java.lang.NullPointerException: Parameter specified as non-null is null: method com.ritense.openzaak.repository.converter.UriAttributeConverter.convertToEntityAttribute, parameter dbData
	at com.ritense.openzaak.repository.converter.UriAttributeConverter.convertToEntityAttribute(UriAttributeConverter.kt)
	at com.ritense.openzaak.repository.converter.UriAttributeConverter.convertToEntityAttribute(UriAttributeConverter.kt:22)
...
```