### PR TITLE
Fix plugin http security configurer

### DIFF
--- a/plugin/src/main/kotlin/com/ritense/plugin/configuration/PluginAutoConfiguration.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/configuration/PluginAutoConfiguration.kt
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @Configuration
@@ -57,7 +58,9 @@ class PluginAutoConfiguration {
         return PluginDefinitionResolver()
     }
 
+    @Order(420)
     @Bean
+    @ConditionalOnMissingBean(PluginHttpSecurityConfigurer::class)
     fun pluginHttpSecurityConfigurer(): PluginHttpSecurityConfigurer {
         return PluginHttpSecurityConfigurer()
     }


### PR DESCRIPTION
```
Caused by: java.lang.IllegalStateException: Can't configure antMatchers after anyRequest
   at org.springframework.util.Assert.state(Assert.java:76)
   at org.springframework.security.config.annotation.web.AbstractRequestMatcherRegistry.antMatchers(AbstractRequestMatcherRegistry.java:105)
   at com.ritense.plugin.security.config.PluginHttpSecurityConfigurer.configure(PluginHttpSecurityConfigurer.kt:14)
```