### PR TITLE
License report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id "checkstyle"
     id "jacoco"
     id "com.avast.gradle.docker-compose" version "0.14.9"
+    id "com.github.jk1.dependency-license-report" version "2.1"
 }
 
 /*

--- a/gradle/license-report/allowed-licenses.json
+++ b/gradle/license-report/allowed-licenses.json
@@ -1,0 +1,25 @@
+{
+    "allowedLicenses": [
+        {
+            "moduleLicense": "Apache License, Version 2.0",
+            "moduleName": "org.jetbrains.kotlin:kotlin-stdlib",
+            "moduleVersion": "1.2.60"
+        },
+        {
+            "moduleLicense": "Apache License, Version 2.0",
+            "moduleName": "org.jetbrains.kotlin*",
+            "moduleVersion": ".*"
+        },
+        {
+            "moduleLicense": "MIT License",
+            "moduleName": ".*"
+        },
+        {
+            "moduleLicense": "MIT License"
+        },
+        {
+            "moduleLicense": "MIT License",
+            "moduleName": ""
+        }
+    ]
+}

--- a/gradle/license-report/build.gradle
+++ b/gradle/license-report/build.gradle
@@ -24,3 +24,10 @@ rootProject.configure(rootProject, {
         filters = [new LicenseBundleNormalizer(bundlePath: "$projectDir/gradle/license-report/license-normalizer-bundle.json")]
     }
 })
+
+tasks.withType(PublishToMavenRepository) {
+    enabled = false
+}
+tasks.withType(PublishToMavenLocal) {
+    enabled = false
+}

--- a/gradle/license-report/build.gradle
+++ b/gradle/license-report/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2020 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.github.jk1.license.render.*
+import com.github.jk1.license.filter.*
+
+//plugins {
+//    id "com.github.jk1.dependency-license-report"
+//}
+
+rootProject.configure(rootProject, {
+    licenseReport {
+        renderers = [new InventoryHtmlReportRenderer('index.html', null, new File(projectDir,"gradle/license-report/unknown-license-details.txt"))]
+        allowedLicensesFile = new File("$projectDir/gradle/license-report/allowed-licenses.json")
+        filters = [new LicenseBundleNormalizer(bundlePath: "$projectDir/gradle/license-report/license-normalizer-bundle.json")]
+    }
+})

--- a/gradle/license-report/build.gradle
+++ b/gradle/license-report/build.gradle
@@ -17,10 +17,6 @@
 import com.github.jk1.license.render.*
 import com.github.jk1.license.filter.*
 
-//plugins {
-//    id "com.github.jk1.dependency-license-report"
-//}
-
 rootProject.configure(rootProject, {
     licenseReport {
         renderers = [new InventoryHtmlReportRenderer('index.html', null, new File(projectDir,"gradle/license-report/unknown-license-details.txt"))]

--- a/gradle/license-report/license-normalizer-bundle.json
+++ b/gradle/license-report/license-normalizer-bundle.json
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+    "bundles" : [
+        { "bundleName" : "Apache-1.0", "licenseName" : "Apache Software License, Version 1.1", "licenseUrl" : "https://www.apache.org/licenses/LICENSE-1.1" },
+        { "bundleName" : "Apache-2.0", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "https://www.apache.org/licenses/LICENSE-2.0" },
+        { "bundleName" : "0BSD", "licenseName" : "BSD Zero Clause License", "licenseUrl" : "https://opensource.org/licenses/0BSD" },
+        { "bundleName" : "BSD-2-Clause", "licenseName" : "The 2-Clause BSD License", "licenseUrl" : "https://opensource.org/licenses/BSD-2-Clause" },
+        { "bundleName" : "BSD-3-Clause", "licenseName" : "The 3-Clause BSD License", "licenseUrl" : "https://opensource.org/licenses/BSD-3-Clause" },
+        { "bundleName" : "CC0-1.0", "licenseName" : "Creative Commons Legal Code", "licenseUrl" : "https://creativecommons.org/publicdomain/zero/1.0/legalcode" },
+        { "bundleName" : "CDDL-1.0", "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0", "licenseUrl" : "https://oss.oracle.com/licenses/CDDL" },
+        { "bundleName" : "CDDL-1.1", "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1", "licenseUrl" : "https://oss.oracle.com/licenses/CDDL-1.1" },
+        { "bundleName" : "CDDL-1.1-GPLv2-CE", "licenseName" : "CDDL v 1.1 + GPLv2 with classpath exception", "licenseUrl" : "https://github.com/javaee/javax.transaction/blob/master/LICENSE" },
+        { "bundleName" : "CPL-1.0", "licenseName" : "Common Public License - v 1.0", "licenseUrl" : "https://www.eclipse.org/legal/cpl-v10.html" },
+        { "bundleName" : "EPL-1.0", "licenseName" : "Eclipse Public License - v 1.0", "licenseUrl" : "http://www.eclipse.org/legal/epl-v10.html" },
+        { "bundleName" : "EPL-2.0", "licenseName" : "Eclipse Public License - v 2.0", "licenseUrl" : "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt" },
+        { "bundleName" : "EDL-1.0", "licenseName" : "Eclipse Distribution License - v 1.0", "licenseUrl" : "https://www.eclipse.org/org/documents/edl-v10.html" },
+        { "bundleName" : "GPL-1.0", "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 1", "licenseUrl" : "https://www.gnu.org/licenses/gpl-1.0" },
+        { "bundleName" : "GPL-2.0-only", "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 2", "licenseUrl" : "https://www.gnu.org/licenses/gpl-2.0" },
+        { "bundleName" : "GPL-3.0-only", "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/gpl-3.0" },
+        { "bundleName" : "GPL-2.0 WITH Classpath-exception-2.0", "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception", "licenseUrl" : "https://openjdk.java.net/legal/gplv2+ce.html" },
+        { "bundleName" : "LGPL-2.1-only", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-2.1" },
+        { "bundleName" : "LGPL-3.0-only", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-3.0" },
+        { "bundleName" : "MIT", "licenseName" : "MIT License", "licenseUrl" : "https://opensource.org/licenses/MIT" },
+        { "bundleName" : "MPL-1.1", "licenseName" : "Mozilla Public License Version 1.1", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/1.1" },
+        { "bundleName" : "MPL-2.0", "licenseName" : "Mozilla Public License, Version 2.0", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/2.0" },
+        { "bundleName" : "Public-Domain", "licenseName" : "PUBLIC DOMAIN", "licenseUrl" : "" }
+    ],
+    "transformationRules" : [
+        { "bundleName" : "0BSD", "licenseNamePattern" : "BSD Zero Clause License" },
+        { "bundleName" : "0BSD", "licenseNamePattern" : "BSD$" },
+        { "bundleName" : "0BSD", "licenseNamePattern" : "BSD[ |-]clause.*" },
+        { "bundleName" : "0BSD", "licenseNamePattern" : "BSD[ |-]license.*" },
+        { "bundleName" : "Apache-2.0", "licenseNamePattern" : ".*The Apache Software License, Version 2\\.0.*" },
+        { "bundleName" : "Apache-2.0", "licenseNamePattern" : "Apache[ |-|_]2.*" },
+        { "bundleName" : "Apache-2.0", "licenseNamePattern" : "ASL 2\\.0" },
+        { "bundleName" : "Apache-2.0", "licenseNamePattern" : ".*Apache License,?( Version)? 2.*" },
+        { "bundleName" : "Apache-2.0", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/Apache-2\\.0.*" },
+        { "bundleName" : "Apache-2.0", "licenseUrlPattern" : ".*www\\.apache\\.org/licenses/LICENSE-2\\.0.*" },
+        { "bundleName" : "LGPL-2.1-only", "licenseUrlPattern" : ".*www\\.gnu\\.org/licenses/old-licenses/lgpl-2\\.1\\.html" },
+        { "bundleName" : "Apache-2.0", "licenseFileContentPattern" : ".*Apache License,?( Version)? 2.*" },
+        { "bundleName" : "Apache-1.0", "licenseFileContentPattern" : ".*Apache Software License, Version 1\\.1.*" },
+        { "bundleName" : "CC0-1.0", "licenseNamePattern" : "CC0([ |-]1(\\.0)?)?" },
+        { "bundleName" : "CC0-1.0", "licenseUrlPattern" : ".*(www\\.)?creativecommons\\.org/publicdomain/zero/1\\.0/" },
+        { "bundleName" : "CDDL-1.0", "licenseFileContentPattern" : ".*CDDL.*1\\.0" },
+        { "bundleName" : "CDDL-1.0", "licenseUrlPattern" : ".*CDDL.*.?1\\.0" },
+        { "bundleName" : "CDDL-1.1", "licenseUrlPattern" : ".*CDDL.*.?1\\.1" },
+        { "bundleName" : "CDDL-1.0", "licenseNamePattern" : "Common Development and Distribution License( \\(CDDL\\),?)? (version )?(.?\\s?)?1\\.0" },
+        { "bundleName" : "CDDL-1.1", "licenseNamePattern" : "Common Development and Distribution License( \\(CDDL\\),?)? (version )?(.?\\s?)?1\\.1" },
+        { "bundleName" : "CDDL-1.1-GPLv2-CE", "licenseNamePattern" : "CDDL[ |\\/]?\\+? ?GPLv2(\\+CE| with classpath exception)" },
+        { "bundleName" : "BSD-3-Clause", "licenseNamePattern" : ".*BSD[ |-]3-clause.*" },
+        { "bundleName" : "BSD-3-Clause", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/BSD-3-Clause" },
+        { "bundleName" : "BSD-3-Clause", "licenseNamePattern" : ".*?(The )New BSD License.*" },
+        { "bundleName" : "BSD-3-Clause", "licenseNamePattern" : ".*?Modified BSD License.*" },
+        { "bundleName" : "BSD-2-Clause", "licenseNamePattern" : "BSD[ |-]2-clause.*" },
+        { "bundleName" : "BSD-2-Clause", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/BSD-2-Clause" },
+        { "bundleName" : "BSD-2-Clause", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/bsd-license(\\.php)?" },
+        { "bundleName" : "CDDL-1.0", "licenseNamePattern" : "Common Development and Distribution( License)?" },
+        { "bundleName" : "CDDL-1.0", "licenseNamePattern" : "CDDL 1(\\.0)" },
+        { "bundleName" : "CDDL-1.1", "licenseNamePattern" : "CDDL 1\\.1" },
+        { "bundleName" : "CDDL-1.1", "licenseUrlPattern" : ".*(www\\.).opensource\\.org/licenses/CDDL-1\\.0" },
+        { "bundleName" : "EPL-1.0", "licenseNamePattern" : "Eclipse Publish License.*(v|version)\\.?\\s?1(\\.?0)?" },
+        { "bundleName" : "EPL-1.0", "licenseNamePattern" : "Eclipse Public License.*(v|version)\\.?\\s?1(\\.?0)?" },
+        { "bundleName" : "EPL-2.0", "licenseNamePattern" : "Eclipse Public License.*(v|version)\\.?\\s?2(\\.?0)?" },
+        { "bundleName" : "EPL-2.0", "licenseUrlPattern" : ".*(www\\.).opensource\\.org/licenses/EPL-2\\.0" },
+        { "bundleName" : "EPL-2.0", "licenseUrlPattern" : ".*http.?://www\\.eclipse\\.org/legal/epl-.?2\\.?0.*" },
+        { "bundleName" : "EPL-2.0", "licenseUrlPattern" : ".*http.?://www\\.eclipse\\.org/org.*/epl-.?2\\.?0.*" },
+        { "bundleName" : "EPL-2.0", "licenseUrlPattern" : ".*http.?://projects\\.eclipse\\.org/.*/epl-.?2\\.?0.*" },
+        { "bundleName" : "EDL-1.0", "licenseNamePattern" : "Eclipse Distribution License.*(v|version)\\.?\\s?1(\\.0)?" },
+        { "bundleName" : "EDL-1.0", "licenseUrlPattern" : ".*http.?://(www\\.)?eclipse\\.org/org.*/edl-.?1\\.?0.*" },
+        { "bundleName" : "GPL-2.0-only", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/GPL-2\\.0" },
+        { "bundleName" : "GPL-2.0 WITH Classpath-exception-2.0", "licenseNamePattern" : "(The )?GNU General Public License( \\(GPL\\))?, (?i)version 2.*(?i)classpath (?i)exception" },
+        { "bundleName" : "GPL-2.0 WITH Classpath-exception-2.0", "licenseNamePattern" : "GNU General Public License, version 2.*cp?e" },
+        { "bundleName" : "GPL-2.0 WITH Classpath-exception-2.0", "licenseNamePattern" : "GNU General Public License, version 2.*, with the classpath exception" },
+        { "bundleName" : "GPL-2.0 WITH Classpath-exception-2.0", "licenseNamePattern" : "GPL2 w/ CPE" },
+        { "bundleName" : "GPL-3.0-only", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/GPL-3\\.0" },
+        { "bundleName" : "LGPL-2.1-only", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/LGPL-2\\.1" },
+        { "bundleName" : "LGPL-2.1-only", "licenseUrlPattern" : ".*(www\\.)?gnu\\.org/licenses(/old-licenses)?/lgpl-2\\.1(\\.(html|txt))?" },
+        { "bundleName" : "LGPL-2.1-only", "licenseNamePattern" : "LGPL 2\\.1" },
+        { "bundleName" : "LGPL-2.1-only", "licenseNamePattern" : "LGPL.*(v|version)\\.?\\s?2\\.1" },
+        { "bundleName" : "LGPL-2.1-only", "licenseUrlPattern" : ".*(www\\.)?repository.jboss.org/licenses/lgpl-2.1\\.txt" },
+        { "bundleName" : "LGPL-3.0-only", "licenseUrlPattern" : ".*(www\\.).opensource\\.org/licenses/LGPL-3\\.0" },
+        { "bundleName" : "LGPL-3.0-only", "licenseNamePattern" : "lgplv?3" },
+        { "bundleName" : "LGPL-3.0-only", "licenseUrlPattern" : ".*(www\\.)?gnu\\.org/licenses(/old-licenses)?/lgpl(-3)?(\\.0)?(\\.(html|txt))?" },
+        { "bundleName" : "MIT", "licenseNamePattern" : "(The\\s)?MIT(\\slicen[c|s]e)?(\\s\\(MIT\\))?" },
+        { "bundleName" : "MIT", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/MIT(\\.php)?" },
+        { "bundleName" : "MPL-1.1", "licenseNamePattern" : "MPL 1\\.1" },
+        { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.).opensource\\.org/licenses/MPL-2\\.0" },
+        { "bundleName" : "Public-Domain", "licenseNamePattern" : "((public)\\s(domain)).*", "transformUrl" : false },
+        { "bundleName" : "Public-Domain", "licenseFileContentPattern" : ".*(Creative)\\s(Commons).*", "transformUrl" : false },
+        { "bundleName" : "Public-Domain", "licenseFileContentPattern" : ".*((Public)\\s(Domain)).*", "transformUrl" : false }
+    ]
+}

--- a/gradle/license-report/unknown-license-details.txt
+++ b/gradle/license-report/unknown-license-details.txt
@@ -1,0 +1,7 @@
+com.fasterxml.jackson:jackson-bom:2.12.5|https://github.com/FasterXML/jackson-bom|The Apache Software License, Version 2.0|https://www.apache.org/licenses/LICENSE-2.0
+io.github.microutils:kotlin-logging:2.0.4|https://github.com/MicroUtils/kotlin-logging|The Apache Software License, Version 2.0|https://www.apache.org/licenses/LICENSE-2.0
+io.github.microutils:kotlin-logging:2.1.21|https://github.com/MicroUtils/kotlin-logging|The Apache Software License, Version 2.0|https://www.apache.org/licenses/LICENSE-2.0
+org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.0|https://github.com/Kotlin/kotlinx.coroutines|The Apache Software License, Version 2.0|https://www.apache.org/licenses/LICENSE-2.0
+org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2|https://github.com/Kotlin/kotlinx.coroutines|The Apache Software License, Version 2.0|https://www.apache.org/licenses/LICENSE-2.0
+org.junit:junit-bom:5.7.2|https://github.com/junit-team/junit5|Eclipse Public License - v 2.0|https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+org.mapstruct:mapstruct-jdk8:1.3.0.Final|https://github.com/mapstruct/mapstruct|The Apache Software License, Version 2.0|https://www.apache.org/licenses/LICENSE-2.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -54,6 +54,6 @@ include(
         "test-utils-common",
         "besluit",
         "haalcentraal",
-        "plugin"
+        "plugin",
+        ":gradle:license-report"
 )
-


### PR DESCRIPTION
To have a better view on the used dependencies and have an automated check if any dependencies make use of not allowed licenses I've added and configured the [jk1 Gradle License Report](https://github.com/jk1/Gradle-License-Report).

This is still a WIP.