### PR TITLE
Bugfix Plugin deployment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ springDependencyManagementVersion=1.0.11.RELEASE
 ritenseCheckStyleLocation=https://ritense-public-assets.s3-eu-central-1.amazonaws.com/checkstyle/ritense_valtimo_only_checks.xml
 namedVolumeNameTest=valtimo-test-fixtures
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx4g
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true
 # override liquibase to fix bug see :
 # https://forum.liquibase.org/t/liquibaseexception-java-lang-classcastexception-class-java-time-localdatetime-cannot-be-cast-to-class-java-lang-string/5059/3

--- a/plugin/src/main/kotlin/com/ritense/plugin/PluginDeploymentListener.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/PluginDeploymentListener.kt
@@ -16,7 +16,6 @@
 
 package com.ritense.plugin
 
-import com.ritense.plugin.annotation.PluginProperty as PluginPropertyAnnotation
 import com.ritense.plugin.annotation.Plugin
 import com.ritense.plugin.annotation.PluginAction
 import com.ritense.plugin.annotation.PluginActionProperty
@@ -29,23 +28,30 @@ import com.ritense.plugin.exception.PluginDefinitionNotDeployedException
 import com.ritense.plugin.repository.PluginActionDefinitionRepository
 import com.ritense.plugin.repository.PluginActionPropertyDefinitionRepository
 import com.ritense.plugin.repository.PluginDefinitionRepository
+import com.ritense.plugin.repository.PluginPropertyRepository
 import mu.KotlinLogging
 import org.springframework.boot.context.event.ApplicationStartedEvent
-import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.context.event.EventListener
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Parameter
+import com.ritense.plugin.annotation.PluginProperty as PluginPropertyAnnotation
 
 class PluginDeploymentListener(
     private val pluginDefinitionResolver: PluginDefinitionResolver,
     private val pluginDefinitionRepository: PluginDefinitionRepository,
+    private val pluginPropertyRepository: PluginPropertyRepository,
     private val pluginActionDefinitionRepository: PluginActionDefinitionRepository,
     private val pluginActionPropertyDefinitionRepository: PluginActionPropertyDefinitionRepository
 ) {
 
-    @TransactionalEventListener(ApplicationStartedEvent::class)
+    @EventListener(ApplicationStartedEvent::class)
     fun deployPluginDefinitions() {
         logger.info { "Deploying plugins" }
+        pluginPropertyRepository.deleteAll()
+        pluginActionPropertyDefinitionRepository.deleteAll()
+        pluginActionDefinitionRepository.deleteAll()
+
         val classes = findPluginClasses()
 
         classes.forEach { (clazz, pluginAnnotation) ->

--- a/plugin/src/main/kotlin/com/ritense/plugin/configuration/PluginAutoConfiguration.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/configuration/PluginAutoConfiguration.kt
@@ -53,12 +53,14 @@ class PluginAutoConfiguration {
     fun pluginDeploymentListener(
         pluginDefinitionResolver: PluginDefinitionResolver,
         pluginDefinitionRepository: PluginDefinitionRepository,
+        pluginPropertyRepository: PluginPropertyRepository,
         pluginActionDefinitionRepository: PluginActionDefinitionRepository,
         pluginActionPropertyDefinitionRepository: PluginActionPropertyDefinitionRepository
     ): PluginDeploymentListener {
         return PluginDeploymentListener(
             pluginDefinitionResolver,
             pluginDefinitionRepository,
+            pluginPropertyRepository,
             pluginActionDefinitionRepository,
             pluginActionPropertyDefinitionRepository
         )

--- a/plugin/src/test/kotlin/com/ritense/plugin/PluginDeploymentListenerTest.kt
+++ b/plugin/src/test/kotlin/com/ritense/plugin/PluginDeploymentListenerTest.kt
@@ -28,6 +28,7 @@ import com.ritense.plugin.exception.PluginDefinitionNotDeployedException
 import com.ritense.plugin.repository.PluginActionDefinitionRepository
 import com.ritense.plugin.repository.PluginActionPropertyDefinitionRepository
 import com.ritense.plugin.repository.PluginDefinitionRepository
+import com.ritense.plugin.repository.PluginPropertyRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -37,6 +38,7 @@ internal class PluginDeploymentListenerTest {
 
     lateinit var pluginDefinitionResolver: PluginDefinitionResolver
     lateinit var pluginDefinitionRepository: PluginDefinitionRepository
+    lateinit var pluginPropertyRepository: PluginPropertyRepository
     lateinit var pluginActionDefinitionRepository: PluginActionDefinitionRepository
     lateinit var pluginActionPropertyDefinitionRepository: PluginActionPropertyDefinitionRepository
     lateinit var pluginDeploymentListener: PluginDeploymentListener
@@ -45,11 +47,13 @@ internal class PluginDeploymentListenerTest {
     fun beforeAll() {
         pluginDefinitionResolver = mock()
         pluginDefinitionRepository = mock()
+        pluginPropertyRepository = mock()
         pluginActionDefinitionRepository = mock()
         pluginActionPropertyDefinitionRepository = mock()
         pluginDeploymentListener = PluginDeploymentListener(
             pluginDefinitionResolver,
             pluginDefinitionRepository,
+            pluginPropertyRepository,
             pluginActionDefinitionRepository,
             pluginActionPropertyDefinitionRepository
         )


### PR DESCRIPTION
- Plugins were not always deployed. This broke the IntegrationTests. Cause: TransactionalEventListener only runs when inside a Transaction.

- Stackoverflow due to ManyToOne relation. Fix: first remove all plugin-properties/action/action-properties. Because these have a ManyToOne relation with ProcessDefinition.

- Occasional error in IntelliJ: `Expiring Daemon because JVM heap space is exhausted`. FIx: additional jvmargs.

