### PR TITLE
feat: return collections with DocumentVariableDelegateImpl

### DIFF
--- a/process-document/src/main/java/com/ritense/processdocument/domain/impl/delegate/DocumentVariableDelegateImpl.java
+++ b/process-document/src/main/java/com/ritense/processdocument/domain/impl/delegate/DocumentVariableDelegateImpl.java
@@ -18,7 +18,6 @@ package com.ritense.processdocument.domain.impl.delegate;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.ritense.document.domain.impl.JsonSchemaDocumentId;
 import com.ritense.document.service.DocumentService;
 import com.ritense.processdocument.domain.delegate.DocumentVariableDelegate;
@@ -29,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collector;
 
 public class DocumentVariableDelegateImpl implements DocumentVariableDelegate {
 

--- a/process-document/src/main/java/com/ritense/processdocument/domain/impl/delegate/DocumentVariableDelegateImpl.java
+++ b/process-document/src/main/java/com/ritense/processdocument/domain/impl/delegate/DocumentVariableDelegateImpl.java
@@ -18,13 +18,18 @@ package com.ritense.processdocument.domain.impl.delegate;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.ritense.document.domain.impl.JsonSchemaDocumentId;
 import com.ritense.document.service.DocumentService;
 import com.ritense.processdocument.domain.delegate.DocumentVariableDelegate;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collector;
 
 public class DocumentVariableDelegateImpl implements DocumentVariableDelegate {
 
@@ -53,6 +58,10 @@ public class DocumentVariableDelegateImpl implements DocumentVariableDelegate {
                 return jsonNode.asDouble();
             case BOOLEAN:
                 return jsonNode.asBoolean();
+            case ARRAY:
+                List<Object> collection = new ArrayList<>();
+                jsonNode.elements().forEachRemaining(collection::add);
+            return collection;
             default:
                 throw new IllegalStateException("JsonNode of type \"" + jsonNode.getNodeType() + "\" cannot be converted to a value");
         }

--- a/process-document/src/test/java/com/ritense/processdocument/domain/delegate/DocumentVariableDelegateImplTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/domain/delegate/DocumentVariableDelegateImplTest.java
@@ -29,10 +29,10 @@ import org.camunda.bpm.extension.mockito.delegate.DelegateExecutionFake;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/process-document/src/test/java/com/ritense/processdocument/domain/delegate/DocumentVariableDelegateImplTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/domain/delegate/DocumentVariableDelegateImplTest.java
@@ -28,6 +28,9 @@ import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.extension.mockito.delegate.DelegateExecutionFake;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -87,6 +90,15 @@ public class DocumentVariableDelegateImplTest extends BaseTest {
     }
 
     @Test
+    public void findCollectionByJsonPointer() {
+        Optional<JsonSchemaDocument> jsonSchemaDocument = documentOptional();
+        when(documentService.findBy(any(JsonSchemaDocumentId.class))).thenReturn(jsonSchemaDocument);
+
+        List<?> value = (List<?>) documentVariableDelegate.findValueByJsonPointer("/cars", delegateExecutionFake);
+        assertEquals(value.size(), 2);
+    }
+
+    @Test
     public void incorrectPathShouldNotFindValue() {
         Optional<JsonSchemaDocument> jsonSchemaDocument = documentOptional();
         when(documentService.findBy(any(JsonSchemaDocumentId.class))).thenReturn(jsonSchemaDocument);
@@ -99,9 +111,14 @@ public class DocumentVariableDelegateImplTest extends BaseTest {
     private Optional<JsonSchemaDocument> documentOptional() {
         return JsonSchemaDocument.create(
             definition,
-            new JsonDocumentContent("{\"applicant\": {\"street\": \"" + NAAM_VAN_DE_STRAAT + "\"," +
-                "\"number\": " + HOUSE_NUMBER + "," +
-                "\"prettyHouse\": " + NO + "} }"
+            new JsonDocumentContent("{\"applicant\": " +
+                "{\"street\": \"" + NAAM_VAN_DE_STRAAT + "\"," +
+                    "\"number\": " + HOUSE_NUMBER + "," +
+                    "\"prettyHouse\": " + NO + "}," +
+                "\"cars\":[ \n" +
+                    "{ \"mark\":\"volvo\", \"year\": 1991 }," +
+                    "{ \"mark\":\"audi\", \"year\": 2016 }" +
+                    "]}"
             ),
             "USERNAME",
             documentSequenceGeneratorService,


### PR DESCRIPTION
* added handling for jsonNodes of type ARRAY to DocumentVariableDelegateImpl. Delegate will now return a collection instead of throwing an Exception.