### PR TITLE
36388 - foreignKeyConstraintExists fix

### DIFF
--- a/core/src/main/resources/config/liquibase/changelog/20170530-auditevents.xml
+++ b/core/src/main/resources/config/liquibase/changelog/20170530-auditevents.xml
@@ -90,7 +90,8 @@
     <changeSet id="5" author="jhipster">
         <preConditions onFail="MARK_RAN">
             <not>
-                <foreignKeyConstraintExists foreignKeyName="fk_evt_pers_audit_evt_data"/>
+                <foreignKeyConstraintExists foreignKeyTableName="jhi_persistent_audit_evt_data"
+                                            foreignKeyName="fk_evt_pers_audit_evt_data"/>
             </not>
         </preConditions>
 

--- a/core/src/main/resources/config/liquibase/changelog/initial-domain-tables.xml
+++ b/core/src/main/resources/config/liquibase/changelog/initial-domain-tables.xml
@@ -110,7 +110,8 @@
             <and>
                 <and>
                     <not>
-                        <foreignKeyConstraintExists foreignKeyName="fk_choicefieldvalue_choicefield_id"/>
+                        <foreignKeyConstraintExists foreignKeyTableName="choice_field_values"
+                                                    foreignKeyName="fk_choicefieldvalue_choicefield_id"/>
                     </not>
                     <columnExists tableName="choice_field_values" columnName="choice_field_id"/>
                 </and>
@@ -190,7 +191,8 @@
 
     <changeSet id="13" author="Niels Leemburg">
         <preConditions onFail="MARK_RAN">
-            <foreignKeyConstraintExists foreignKeyName="fk_choicefieldvalue_choicefield_id"/>
+            <foreignKeyConstraintExists foreignKeyTableName="choice_field_values"
+                                        foreignKeyName="fk_choicefieldvalue_choicefield_id"/>
         </preConditions>
         <dropForeignKeyConstraint
                 baseTableName="choice_field_values"


### PR DESCRIPTION
foreignKeyTableName is required foreignKeyConstraintExists on Liquibase 3.8.x and higher