### PR TITLE
Fixed integration tests for Klant API

### DIFF
--- a/klant/build.gradle
+++ b/klant/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation project(':core')
     testImplementation project(':audit')
     testImplementation project(':document')
+    testImplementation project(':zgw:documenten-api')
     testImplementation project(':openzaak')
     testImplementation project(':process-document')
     testImplementation project(':resource:openzaak-resource')

--- a/klant/src/test/kotlin/com/ritense/klant/service/BaseIntegrationTest.kt
+++ b/klant/src/test/kotlin/com/ritense/klant/service/BaseIntegrationTest.kt
@@ -19,7 +19,6 @@ package com.ritense.klant.service
 import com.ritense.klant.client.OpenKlantClientProperties
 import com.ritense.openzaak.service.ZaakInstanceLinkService
 import com.ritense.openzaak.service.ZaakRolService
-import com.ritense.plugin.service.PluginService
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
@@ -39,7 +38,4 @@ abstract class BaseIntegrationTest {
 
     @MockBean
     lateinit var zaakInstanceLinkService: ZaakInstanceLinkService
-
-    @MockBean
-    lateinit var pluginService: PluginService
 }

--- a/klant/src/test/kotlin/com/ritense/klant/service/BaseIntegrationTest.kt
+++ b/klant/src/test/kotlin/com/ritense/klant/service/BaseIntegrationTest.kt
@@ -19,6 +19,7 @@ package com.ritense.klant.service
 import com.ritense.klant.client.OpenKlantClientProperties
 import com.ritense.openzaak.service.ZaakInstanceLinkService
 import com.ritense.openzaak.service.ZaakRolService
+import com.ritense.plugin.service.PluginService
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
@@ -39,4 +40,6 @@ abstract class BaseIntegrationTest {
     @MockBean
     lateinit var zaakInstanceLinkService: ZaakInstanceLinkService
 
+    @MockBean
+    lateinit var pluginService: PluginService
 }

--- a/klant/src/test/kotlin/com/ritense/klant/service/KlantTestConfiguration.kt
+++ b/klant/src/test/kotlin/com/ritense/klant/service/KlantTestConfiguration.kt
@@ -26,6 +26,7 @@ import com.ritense.document.autoconfigure.DocumentLiquibaseAutoConfiguration
 import com.ritense.document.autoconfigure.DocumentRetryAutoConfiguration
 import com.ritense.document.autoconfigure.DocumentSecurityAutoConfiguration
 import com.ritense.document.autoconfigure.DocumentSnapshotAutoConfiguration
+import com.ritense.documentenapi.DocumentenApiAutoConfiguration
 import com.ritense.openzaak.autoconfigure.OpenZaakAutoConfiguration
 import com.ritense.openzaak.autoconfigure.OpenZaakLiquibaseAutoConfiguration
 import com.ritense.openzaak.autoconfigure.OpenZaakSecurityAutoConfiguration
@@ -73,6 +74,7 @@ import org.springframework.boot.test.context.TestConfiguration
         DataSourceAutoConfiguration::class,
         DataSourceTransactionManagerAutoConfiguration::class,
         DocumentAutoConfiguration::class,
+        DocumentenApiAutoConfiguration::class,
         DocumentSnapshotAutoConfiguration::class,
         DocumentLiquibaseAutoConfiguration::class,
         DocumentSecurityAutoConfiguration::class,


### PR DESCRIPTION
Fixed integration tests for Klant API which was failing on a missing PluginService bean