### PR TITLE
Fixed issue with classloading plugin

### DIFF
--- a/openzaak/src/main/kotlin/com/ritense/openzaak/autoconfigure/OpenZaakPluginAutoConfiguration.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/autoconfigure/OpenZaakPluginAutoConfiguration.kt
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnClass(PluginService::class)
+@ConditionalOnClass(PluginService::class, ZaakUrlProvider::class)
 class OpenZaakPluginAutoConfiguration {
 
     @Bean


### PR DESCRIPTION
This fix is needed because unlike the the other components the plugins are not loaded through spring. This allows you to create plugins that are loaded optionally based on the classes present on the classpath.