### PR TITLE
Updated the Keycloak dependencies to resolve CVE-2022-1245

### DIFF
--- a/keycloak-iam/build.gradle
+++ b/keycloak-iam/build.gradle
@@ -45,8 +45,8 @@ dependencies {
 
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
-    implementation group: 'org.keycloak', name: 'keycloak-spring-boot-starter', version: '15.0.0'
-    implementation group: 'org.keycloak', name: 'keycloak-admin-client', version: '15.0.0'
+    implementation group: 'org.keycloak', name: 'keycloak-spring-boot-starter', version: '19.0.1'
+    implementation group: 'org.keycloak', name: 'keycloak-admin-client', version: '19.0.1'
 
     testImplementation project(":core")
     testImplementation "io.jsonwebtoken:jjwt-impl:0.11.2"


### PR DESCRIPTION
CVE-2022-1245 has been resolved in version 18.0.0. See https://nvd.nist.gov/vuln/detail/CVE-2022-1245