### PR TITLE
bug: FormIoFormDefinition::extractNodeValue incorrectly parsing types

### DIFF
--- a/form/src/main/java/com/ritense/form/domain/FormIoFormDefinition.java
+++ b/form/src/main/java/com/ritense/form/domain/FormIoFormDefinition.java
@@ -21,9 +21,13 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.ritense.form.domain.event.FormRegisteredEvent;
+import static com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentLength;
+import static com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentNotNull;
+import static com.ritense.valtimo.contract.utils.AssertionConcern.assertStateTrue;
 import org.hibernate.annotations.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,10 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-
-import static com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentLength;
-import static com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentNotNull;
-import static com.ritense.valtimo.contract.utils.AssertionConcern.assertStateTrue;
 
 @Entity
 @Table(name = "form_io_form_definition")
@@ -104,7 +104,7 @@ public class FormIoFormDefinition extends AbstractAggregateRoot<FormIoFormDefini
         registerEvent(new FormRegisteredEvent(id, name));
     }
 
-    private FormIoFormDefinition() {
+    protected FormIoFormDefinition() {
     }
 
     public void setReadOnly(Boolean value) {
@@ -408,9 +408,14 @@ public class FormIoFormDefinition extends AbstractAggregateRoot<FormIoFormDefini
     }
 
     private Object extractNodeValue(JsonNode node) {
-        if (node.isValueNode()) {
+        var nodeType = node.getNodeType();
+        if (nodeType == JsonNodeType.STRING) {
             return node.textValue();
-        } else if (node.isArray()) {
+        } else if (nodeType == JsonNodeType.NUMBER) {
+            return node.numberValue();
+        } else if (nodeType == JsonNodeType.BOOLEAN) {
+            return node.booleanValue();
+        } else if (nodeType == JsonNodeType.ARRAY) {
             List<String> values = new ArrayList<>();
             node.forEach(childNode -> values.add(childNode.textValue()));
             return values;

--- a/form/src/test/java/com/ritense/form/domain/FormIoFormDefinitionTest.java
+++ b/form/src/test/java/com/ritense/form/domain/FormIoFormDefinitionTest.java
@@ -23,24 +23,23 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.ritense.form.BaseTest;
+import com.ritense.valtimo.contract.form.DataResolvingContext;
 import com.ritense.valtimo.contract.form.FormFieldDataResolver;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.springframework.context.ApplicationContext;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-
-import com.ritense.valtimo.contract.form.DataResolvingContext;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.context.ApplicationContext;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class FormIoFormDefinitionTest extends BaseTest {
 
@@ -54,19 +53,26 @@ public class FormIoFormDefinitionTest extends BaseTest {
         final var formDefinition = formDefinitionOf("process-variables-form-example");
         final List<String> processVarsNames = formDefinition.extractProcessVarNames();
 
-        assertThat(processVarsNames).hasSize(1);
+        assertThat(processVarsNames).hasSize(3);
         assertThat(processVarsNames).contains("firstName");
+        assertThat(processVarsNames).contains("age");
+        assertThat(processVarsNames).contains("isRetired");
     }
 
     @Test
     public void shouldPreFill() throws IOException {
         final var formDefinition = formDefinitionOf("process-variables-form-example");
 
-        var content = content(Map.of("pv", Map.of("firstName", "John")));
+        var content = content(Map.of("pv", Map.of(
+            "firstName", "John", "age",90, "isRetired",true
+        )));
 
         final var formDefinitionPreFilled = formDefinition.preFill(content);
 
-        assertThat(formDefinitionPreFilled.getFormDefinition().get("components").get(0).get("defaultValue").asText()).isEqualTo("John");
+        var preFilledFormComponents = formDefinitionPreFilled.getFormDefinition().get("components");
+        assertThat(preFilledFormComponents.get(0).get("defaultValue").asText()).isEqualTo("John");
+        assertThat(preFilledFormComponents.get(1).get("defaultValue").asInt()).isEqualTo(90);
+        assertThat(preFilledFormComponents.get(2).get("defaultValue").asBoolean()).isTrue();
     }
 
     @Test
@@ -101,11 +107,15 @@ public class FormIoFormDefinitionTest extends BaseTest {
         final ObjectNode formData = JsonNodeFactory.instance.objectNode();
         final ObjectNode processVarsData = JsonNodeFactory.instance.objectNode();
         processVarsData.put("firstName", "John");
+        processVarsData.put("age", 90);
+        processVarsData.put("isRetired", true);
         formData.set("pv", processVarsData);
 
         final Map<String, Object> stringObjectMap = formDefinition.extractProcessVars(formData);
 
         assertThat(stringObjectMap).contains(entry("firstName", "John"));
+        assertThat(stringObjectMap).contains(entry("age", 90));
+        assertThat(stringObjectMap).contains(entry("isRetired", true));
     }
 
     @Test

--- a/form/src/test/resources/config/form/process-variables-form-example.json
+++ b/form/src/test/resources/config/form/process-variables-form-example.json
@@ -8,9 +8,34 @@
     },
     "components": [
         {
-            "label": "Naam",
+            "label": "Name",
             "key": "pv.firstName",
             "type": "textfield",
+            "input": true
+        },
+        {
+            "label": "age",
+            "key": "pv.age",
+            "type": "textfield",
+            "input": true
+        },
+        {
+            "label": "Is retired?",
+            "optionsLabelPosition": "right",
+            "inline": false,
+            "tableView": false,
+            "values": [
+                {
+                    "label": "Yes",
+                    "value": true
+                },
+                {
+                    "label": "No",
+                    "value": false
+                }
+            ],
+            "key": "pv.isRetired",
+            "type": "radio",
             "input": true
         },
         {


### PR DESCRIPTION
* modified type checks to be more specific and added handling for number and boolean nodes
* updated tests and test form definition
* made private constructor protected as per a jpa requirement