### PR TITLE
Feature/fix objectmapper selection

### DIFF
--- a/plugin/src/main/kotlin/com/ritense/plugin/PluginFactory.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/PluginFactory.kt
@@ -71,7 +71,7 @@ abstract class PluginFactory<T>(
         }
 
         val pluginDefinition = configuration.pluginDefinition
-        val mapper = ObjectMapper()
+        val mapper = pluginService.getObjectMapper()
         val propertyIterator = configuration.properties!!.fields()
 
         while (propertyIterator.hasNext()) {

--- a/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
@@ -61,6 +61,10 @@ class PluginService(
     private val pluginConfigurationSearchRepository: PluginConfigurationSearchRepository
 ) {
 
+    fun getObjectMapper(): ObjectMapper {
+        return objectMapper
+    }
+
     fun getPluginDefinitions(): List<PluginDefinition> {
         return pluginDefinitionRepository.findAll()
     }

--- a/plugin/src/test/kotlin/com/ritense/plugin/PluginFactoryTest.kt
+++ b/plugin/src/test/kotlin/com/ritense/plugin/PluginFactoryTest.kt
@@ -18,6 +18,7 @@ package com.ritense.plugin
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.ritense.plugin.domain.PluginConfiguration
@@ -134,6 +135,7 @@ internal class PluginFactoryTest {
         val categoryPluginConfigurationId = PluginConfigurationId.newId()
         val pluginCategory = object : TestPluginCategory {}
         whenever(pluginService.createInstance(categoryPluginConfigurationId)).thenReturn(pluginCategory)
+        whenever((pluginService.getObjectMapper())).thenReturn(jacksonObjectMapper())
         val pluginConfiguration = PluginConfiguration(
             PluginConfigurationId.newId(),
             "title",

--- a/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginFactoryTest.kt
+++ b/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginFactoryTest.kt
@@ -18,6 +18,7 @@ package com.ritense.catalogiapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -39,6 +40,7 @@ internal class CatalogiApiPluginFactoryTest {
         val catalogiApiClient = mock<CatalogiApiClient>()
         val authenticationMock = mock<CatalogiApiAuthentication>()
         whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(authenticationMock)
+        whenever(pluginService.getObjectMapper()).thenReturn(jacksonObjectMapper())
 
         val factory = CatalogiApiPluginFactory(
             pluginService,

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginFactoryTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginFactoryTest.kt
@@ -18,6 +18,7 @@ package com.ritense.documentenapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -44,6 +45,7 @@ internal class DocumentenApiPluginFactoryTest {
         val authentication = mock<DocumentenApiAuthentication>()
 
         whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(authentication)
+        whenever(pluginService.getObjectMapper()).thenReturn(jacksonObjectMapper())
 
         val propertyString = """
           {

--- a/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/ObjectenApiPluginFactoryTest.kt
+++ b/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/ObjectenApiPluginFactoryTest.kt
@@ -18,6 +18,7 @@ package com.ritense.objectenapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -40,6 +41,7 @@ internal class ObjectenApiPluginFactoryTest {
         val objectenApiClient = mock<ObjectenApiClient>()
         val authenticationMock = mock<ObjectenApiAuthentication>()
         whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(authenticationMock)
+        whenever(pluginService.getObjectMapper()).thenReturn(jacksonObjectMapper())
 
         val factory = ObjectenApiPluginFactory(
             pluginService,

--- a/zgw/objecttypen-api/src/test/kotlin/com/ritense/objecttypenapi/ObjecttypenApiPluginFactoryTest.kt
+++ b/zgw/objecttypen-api/src/test/kotlin/com/ritense/objecttypenapi/ObjecttypenApiPluginFactoryTest.kt
@@ -18,6 +18,7 @@ package com.ritense.objecttypenapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -39,6 +40,7 @@ internal class ObjecttypenApiPluginFactoryTest {
         val objecttypenApiClient = mock<ObjecttypenApiClient>()
         val authenticationMock = mock<ObjecttypenApiAuthentication>()
         whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(authenticationMock)
+        whenever(pluginService.getObjectMapper()).thenReturn(jacksonObjectMapper())
 
         val factory = ObjecttypenApiPluginFactory(pluginService, objecttypenApiClient)
 

--- a/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginFactoryTest.kt
+++ b/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginFactoryTest.kt
@@ -2,6 +2,7 @@ package com.ritense.zakenapi
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -23,6 +24,7 @@ internal class ZakenApiPluginFactoryTest {
         val pluginService: PluginService = mock()
         val authenticationMock = mock<ZakenApiAuthentication>()
         whenever(pluginService.createInstance(any<PluginConfigurationId>())).thenReturn(authenticationMock)
+        whenever(pluginService.getObjectMapper()).thenReturn(jacksonObjectMapper())
 
         val client: ZakenApiClient = mock()
         val zaakUrlProvider: ZaakUrlProvider = mock()


### PR DESCRIPTION
**Issue**
Application errors when trying to serialize a LocalDateTime object as a plugin property, because the object mapper does not have the JSR301 modules enabled.

**Solution**
Added a getter for object mapper to the PluginService and instead of creating a new object mapper in the PluginFactory, it is now using the one from the PluginService.

**Decision**
I decided not to change the constructor of the PluginFactory to include an object mapper, as this would potentially affect backward compatibility. 
