### PR TITLE
#37531 get current user that has a full name

### DIFF
--- a/contactmoment/src/test/kotlin/com/ritense/contactmoment/BaseContactMomentIntegrationTest.kt
+++ b/contactmoment/src/test/kotlin/com/ritense/contactmoment/BaseContactMomentIntegrationTest.kt
@@ -27,8 +27,6 @@ import com.ritense.contactmoment.connector.ContactMomentConnector
 import com.ritense.contactmoment.connector.ContactMomentProperties
 import com.ritense.valtimo.contract.authentication.ManageableUser
 import com.ritense.valtimo.contract.authentication.model.ValtimoUser
-import java.util.Optional
-import java.util.UUID
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -36,6 +34,7 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
 
 class BaseContactMomentIntegrationTest : BaseIntegrationTest() {
 
@@ -76,8 +75,7 @@ class BaseContactMomentIntegrationTest : BaseIntegrationTest() {
         user.id = id
         user.email = email
         user.lastName = lastName
-        whenever(currentUserService.currentUser).thenReturn(user)
-        whenever(userManagementService.findByEmail(email)).thenReturn(Optional.of(user))
+        whenever(userManagementService.currentUser).thenReturn(user)
         return user
     }
 

--- a/contactmoment/src/test/kotlin/com/ritense/contactmoment/connector/ContactMomentConnectorIntTest.kt
+++ b/contactmoment/src/test/kotlin/com/ritense/contactmoment/connector/ContactMomentConnectorIntTest.kt
@@ -18,11 +18,9 @@ package com.ritense.contactmoment.connector
 
 import com.ritense.contactmoment.BaseContactMomentIntegrationTest
 import com.ritense.contactmoment.domain.Kanaal
-import com.ritense.valtimo.contract.authentication.model.ValtimoUser
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.mockito.Mockito.`when`
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 
 @AutoConfigureWebTestClient(timeout = "36000")
@@ -40,9 +38,7 @@ class ContactMomentConnectorIntTest : BaseContactMomentIntegrationTest() {
 
     @Test
     fun `should create contactmoment`() {
-        val medewerker = ValtimoUser()
-        medewerker.id = "test-id"
-        `when`(currentUserService.currentUser).thenReturn(medewerker)
+        mockUser(lastName = "Miller")
 
         val contactMoment = (contactMomentConnector as ContactMomentConnector).createContactMoment(Kanaal.MAIL, "content-2")
 

--- a/contract/src/main/java/com/ritense/valtimo/contract/authentication/UserManagementService.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/authentication/UserManagementService.java
@@ -17,8 +17,10 @@
 package com.ritense.valtimo.contract.authentication;
 
 import com.ritense.valtimo.contract.authentication.model.SearchByUserGroupsCriteria;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -49,4 +51,8 @@ public interface UserManagementService {
     List<ManageableUser> findByRole(String authority);
 
     List<ManageableUser> findByRoles(SearchByUserGroupsCriteria groupsCriteria);
+
+    default ManageableUser getCurrentUser() {
+        throw new NotImplementedException("Failed to get current user because method is not implemented.");
+    }
 }

--- a/contract/src/main/java/com/ritense/valtimo/contract/authentication/model/ValtimoUser.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/authentication/model/ValtimoUser.java
@@ -17,9 +17,12 @@
 package com.ritense.valtimo.contract.authentication.model;
 
 import com.ritense.valtimo.contract.authentication.ManageableUser;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
+
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 public class ValtimoUser implements Serializable, ManageableUser {
 
@@ -144,7 +147,15 @@ public class ValtimoUser implements Serializable, ManageableUser {
 
     @Override
     public String getFullName() {
-        return firstName + " " + lastName;
+        if (isEmpty(firstName) && isEmpty(lastName)) {
+            return null;
+        } else if (isEmpty(firstName)) {
+            return lastName;
+        } else  if (isEmpty(lastName)) {
+            return firstName;
+        } else {
+            return firstName + " " + lastName;
+        }
     }
 
     @Override

--- a/notes/build.gradle
+++ b/notes/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     testImplementation "org.springframework.security:spring-security-test"
 
     testImplementation "io.kotest:kotest-assertions-core:5.5.1"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
 
     jar {
         enabled = true

--- a/notes/src/main/kotlin/com/ritense/note/autoconfigure/NoteAutoConfiguration.kt
+++ b/notes/src/main/kotlin/com/ritense/note/autoconfigure/NoteAutoConfiguration.kt
@@ -21,7 +21,7 @@ import com.ritense.note.repository.NoteRepository
 import com.ritense.note.security.config.NoteHttpSecurityConfigurer
 import com.ritense.note.service.NoteService
 import com.ritense.note.web.rest.NoteResource
-import com.ritense.valtimo.contract.authentication.CurrentUserService
+import com.ritense.valtimo.contract.authentication.UserManagementService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.ApplicationEventPublisher
@@ -39,12 +39,12 @@ class NoteAutoConfiguration {
     @ConditionalOnMissingBean(NoteService::class)
     fun noteService(
         noteRepository: NoteRepository,
-        currentUserService: CurrentUserService,
+        userManagementService: UserManagementService,
         applicationEventPublisher: ApplicationEventPublisher,
     ): NoteService {
         return NoteService(
             noteRepository,
-            currentUserService,
+            userManagementService,
             applicationEventPublisher,
         )
     }

--- a/notes/src/main/kotlin/com/ritense/note/service/NoteService.kt
+++ b/notes/src/main/kotlin/com/ritense/note/service/NoteService.kt
@@ -20,7 +20,7 @@ import com.ritense.document.domain.impl.JsonSchemaDocumentId
 import com.ritense.note.domain.Note
 import com.ritense.note.event.NoteCreatedEvent
 import com.ritense.note.repository.NoteRepository
-import com.ritense.valtimo.contract.authentication.CurrentUserService
+import com.ritense.valtimo.contract.authentication.UserManagementService
 import com.ritense.valtimo.contract.utils.SecurityUtils
 import mu.KotlinLogging
 import org.springframework.context.ApplicationEventPublisher
@@ -30,7 +30,7 @@ import java.util.UUID
 
 class NoteService(
     private val noteRepository: NoteRepository,
-    private val currentUserService: CurrentUserService,
+    private val userManagementService: UserManagementService,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
 
@@ -47,7 +47,7 @@ class NoteService(
     ): Note {
         logger.debug { "Create note for document $documentId" }
         SecurityUtils.getCurrentUserLogin()
-        val user = currentUserService.currentUser
+        val user = userManagementService.currentUser
         val node = noteRepository.save(Note(documentId, user, noteContent))
         applicationEventPublisher.publishEvent(NoteCreatedEvent(documentId.id, node.id))
         return node

--- a/notes/src/test/kotlin/com/ritense/note/web/rest/NoteResourceIT.kt
+++ b/notes/src/test/kotlin/com/ritense/note/web/rest/NoteResourceIT.kt
@@ -18,6 +18,7 @@ package com.ritense.note.web.rest
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.jayway.jsonpath.JsonPath
+import com.nhaarman.mockitokotlin2.whenever
 import com.ritense.audit.service.AuditService
 import com.ritense.document.domain.impl.JsonSchemaDocumentId
 import com.ritense.document.domain.impl.Mapper
@@ -29,6 +30,7 @@ import com.ritense.note.service.NoteService
 import com.ritense.note.web.rest.dto.NoteCreateRequestDto
 import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.ADMIN
 import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.USER
+import com.ritense.valtimo.contract.authentication.model.ValtimoUserBuilder
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
@@ -77,6 +79,8 @@ internal class NoteResourceIT : BaseIntegrationTest() {
             NewDocumentRequest(PROFILE_DOCUMENT_DEFINITION_NAME, Mapper.INSTANCE.get().createObjectNode())
         ).resultingDocument().get().id()!!.id
         documentDefinitionService.putDocumentDefinitionRoles(PROFILE_DOCUMENT_DEFINITION_NAME, setOf(USER))
+        whenever(userManagementService.currentUser)
+            .thenReturn(ValtimoUserBuilder().id("anId").firstName("aFirstName").lastName("aLastName").build())
     }
 
     @Test


### PR DESCRIPTION
The existing `CurrentUserRepository.getCurrentUser()` doesn't return the name of the user. Only the email.

The new `UserManagementService.getCurrentUser()` does return the name of the user including many other properties

