### PR TITLE
Add order column to search field

### DIFF
--- a/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchField.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchField.java
@@ -40,26 +40,31 @@ public class SearchField implements Persistable<SearchFieldId> {
 
     @Column(name = "datatype", nullable = false, updatable = true)
     @Enumerated(EnumType.STRING)
-    private SearchFieldDatatype datatype;
+    private SearchFieldDataType dataType;
 
     @Column(name = "fieldtype", nullable = false, updatable = true)
     @Enumerated(EnumType.STRING)
-    private SearchFieldFieldtype fieldtype;
+    private SearchFieldFieldType fieldType;
 
-    @Column(name = "matchtype", nullable = false, updatable = true)
+    @Column(name = "matchtype", nullable = true, updatable = true)
     @Enumerated(EnumType.STRING)
-    private SearchFieldMatchtype matchtype;
+    private SearchFieldMatchType matchType;
+
+    @Column(name = "search_field_order", nullable = false, updatable = true)
+    private int order;
 
     public SearchField(String key,
                        String path,
-                       SearchFieldDatatype datatype,
-                       SearchFieldFieldtype fieldtype,
-                       SearchFieldMatchtype matchtype) {
+                       SearchFieldDataType dataType,
+                       SearchFieldFieldType fieldType,
+                       SearchFieldMatchType matchType,
+                       int order) {
         this.key = key;
         this.path = path;
-        this.datatype = datatype;
-        this.fieldtype = fieldtype;
-        this.matchtype = matchtype;
+        this.dataType = dataType;
+        this.fieldType = fieldType;
+        this.matchType = matchType;
+        this.order = order;
     }
 
     public SearchField() {}
@@ -94,28 +99,36 @@ public class SearchField implements Persistable<SearchFieldId> {
         this.path = path;
     }
 
-    public SearchFieldDatatype getDatatype() {
-        return datatype;
+    public SearchFieldDataType getDataType() {
+        return dataType;
     }
 
-    public void setDatatype(SearchFieldDatatype datatype) {
-        this.datatype = datatype;
+    public void setDataType(SearchFieldDataType dataType) {
+        this.dataType = dataType;
     }
 
-    public SearchFieldFieldtype getFieldtype() {
-        return fieldtype;
+    public SearchFieldFieldType getFieldType() {
+        return fieldType;
     }
 
-    public void setFieldtype(SearchFieldFieldtype fieldtype) {
-        this.fieldtype = fieldtype;
+    public void setFieldType(SearchFieldFieldType fieldType) {
+        this.fieldType = fieldType;
     }
 
-    public SearchFieldMatchtype getMatchtype() {
-        return matchtype;
+    public SearchFieldMatchType getMatchType() {
+        return matchType;
     }
 
-    public void setMatchtype(SearchFieldMatchtype matchtype) {
-        this.matchtype = matchtype;
+    public void setMatchType(SearchFieldMatchType matchType) {
+        this.matchType = matchType;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
     }
 }
 

--- a/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldDataType.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldDataType.java
@@ -18,32 +18,35 @@ package com.ritense.document.domain.impl.searchfield;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum SearchFieldMatchtype {
-    LIKE("like"),
-    EXACT("exact");
+public enum SearchFieldDataType {
+    BOOLEAN("boolean"),
+    DATE("date"),
+    DATETIME("datetime"),
+    NUMBER("number"),
+    TEXT("text");
 
     @JsonValue private final String name;
 
-    SearchFieldMatchtype(String name) {
+    SearchFieldDataType(String name) {
         this.name = name;
     }
 
-    public static SearchFieldMatchtype fromString(String text) {
-        for (SearchFieldMatchtype matchtype : SearchFieldMatchtype.values()) {
-            if (matchtype.name.equalsIgnoreCase(text)) {
-                return matchtype;
+    public static SearchFieldDataType fromString(String text) {
+        for (SearchFieldDataType dataType : SearchFieldDataType.values()) {
+            if (dataType.name.equalsIgnoreCase(text)) {
+                return dataType;
             }
         }
-        throw new IllegalStateException(String.format("Cannot create SearchFieldMatchtype from string %s", text));
+        throw new IllegalStateException(String.format("Cannot create SearchFieldDataType from string %s", text));
     }
 
-    public static SearchFieldMatchtype fromKey(String key) {
-        for (SearchFieldMatchtype matchtype : SearchFieldMatchtype.values()) {
-            if (matchtype.name().equalsIgnoreCase(key)) {
-                return matchtype;
+    public static SearchFieldDataType fromKey(String key) {
+        for (SearchFieldDataType dataType : SearchFieldDataType.values()) {
+            if (dataType.name().equalsIgnoreCase(key)) {
+                return dataType;
             }
         }
-        throw new IllegalStateException(String.format("Cannot create SearchFieldMatchtype from string %s", key));
+        throw new IllegalStateException(String.format("Cannot create SearchFieldDataType from string %s", key));
     }
 
     @Override

--- a/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldDto.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldDto.java
@@ -21,15 +21,15 @@ public class SearchFieldDto {
 
     private String key;
     private String path;
-    private SearchFieldDatatype dataType;
-    private SearchFieldFieldtype fieldType;
-    private SearchFieldMatchtype matchType;
+    private SearchFieldDataType dataType;
+    private SearchFieldFieldType fieldType;
+    private SearchFieldMatchType matchType;
 
     public SearchFieldDto(String key,
                           String path,
-                          SearchFieldDatatype dataType,
-                          SearchFieldFieldtype fieldType,
-                          SearchFieldMatchtype matchType) {
+                          SearchFieldDataType dataType,
+                          SearchFieldFieldType fieldType,
+                          SearchFieldMatchType matchType) {
         this.key = key;
         this.path = path;
         this.dataType = dataType;
@@ -47,15 +47,15 @@ public class SearchFieldDto {
         return path;
     }
 
-    public SearchFieldDatatype getDataType() {
+    public SearchFieldDataType getDataType() {
         return dataType;
     }
 
-    public SearchFieldFieldtype getFieldType() {
+    public SearchFieldFieldType getFieldType() {
         return fieldType;
     }
 
-    public SearchFieldMatchtype getMatchType() {
+    public SearchFieldMatchType getMatchType() {
         return matchType;
     }
 
@@ -67,15 +67,15 @@ public class SearchFieldDto {
         this.path = path;
     }
 
-    public void setDataType(SearchFieldDatatype dataType) {
+    public void setDataType(SearchFieldDataType dataType) {
         this.dataType = dataType;
     }
 
-    public void setFieldType(SearchFieldFieldtype fieldType) {
+    public void setFieldType(SearchFieldFieldType fieldType) {
         this.fieldType = fieldType;
     }
 
-    public void setMatchType(SearchFieldMatchtype matchType) {
+    public void setMatchType(SearchFieldMatchType matchType) {
         this.matchType = matchType;
     }
 }

--- a/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldFieldType.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldFieldType.java
@@ -18,33 +18,33 @@ package com.ritense.document.domain.impl.searchfield;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum SearchFieldFieldtype {
+public enum SearchFieldFieldType {
     MULTIPLE("multiple"),
     RANGE("range"),
     SINGLE("single");
 
     @JsonValue private final String name;
 
-    SearchFieldFieldtype(String name) {
+    SearchFieldFieldType(String name) {
         this.name = name;
     }
 
-    public static SearchFieldFieldtype fromString(String text) {
-        for (SearchFieldFieldtype fieldtype : SearchFieldFieldtype.values()) {
-            if (fieldtype.name.equalsIgnoreCase(text)) {
-                return fieldtype;
+    public static SearchFieldFieldType fromString(String text) {
+        for (SearchFieldFieldType fieldType : SearchFieldFieldType.values()) {
+            if (fieldType.name.equalsIgnoreCase(text)) {
+                return fieldType;
             }
         }
-        throw new IllegalStateException(String.format("Cannot create SearchFieldFieldtype from string %s", text));
+        throw new IllegalStateException(String.format("Cannot create SearchFieldFieldType from string %s", text));
     }
 
-    public static SearchFieldFieldtype fromKey(String key) {
-        for (SearchFieldFieldtype fieldtype : SearchFieldFieldtype.values()) {
-            if (fieldtype.name().equalsIgnoreCase(key)) {
-                return fieldtype;
+    public static SearchFieldFieldType fromKey(String key) {
+        for (SearchFieldFieldType fieldType : SearchFieldFieldType.values()) {
+            if (fieldType.name().equalsIgnoreCase(key)) {
+                return fieldType;
             }
         }
-        throw new IllegalStateException(String.format("Cannot create SearchFieldFieldtype from string %s", key));
+        throw new IllegalStateException(String.format("Cannot create SearchFieldFieldType from string %s", key));
     }
 
     @Override

--- a/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldMatchType.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldMatchType.java
@@ -18,35 +18,32 @@ package com.ritense.document.domain.impl.searchfield;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum SearchFieldDatatype {
-    BOOLEAN("boolean"),
-    DATE("date"),
-    DATETIME("datetime"),
-    NUMBER("number"),
-    TEXT("text");
+public enum SearchFieldMatchType {
+    LIKE("like"),
+    EXACT("exact");
 
     @JsonValue private final String name;
 
-    SearchFieldDatatype(String name) {
+    SearchFieldMatchType(String name) {
         this.name = name;
     }
 
-    public static SearchFieldDatatype fromString(String text) {
-        for (SearchFieldDatatype datatype : SearchFieldDatatype.values()) {
-            if (datatype.name.equalsIgnoreCase(text)) {
-                return datatype;
+    public static SearchFieldMatchType fromString(String text) {
+        for (SearchFieldMatchType matchType : SearchFieldMatchType.values()) {
+            if (matchType.name.equalsIgnoreCase(text)) {
+                return matchType;
             }
         }
-        throw new IllegalStateException(String.format("Cannot create SearchFieldDatatype from string %s", text));
+        throw new IllegalStateException(String.format("Cannot create SearchFieldMatchType from string %s", text));
     }
 
-    public static SearchFieldDatatype fromKey(String key) {
-        for (SearchFieldDatatype datatype : SearchFieldDatatype.values()) {
-            if (datatype.name().equalsIgnoreCase(key)) {
-                return datatype;
+    public static SearchFieldMatchType fromKey(String key) {
+        for (SearchFieldMatchType matchType : SearchFieldMatchType.values()) {
+            if (matchType.name().equalsIgnoreCase(key)) {
+                return matchType;
             }
         }
-        throw new IllegalStateException(String.format("Cannot create SearchFieldDatatype from string %s", key));
+        throw new IllegalStateException(String.format("Cannot create SearchFieldMatchType from string %s", key));
     }
 
     @Override

--- a/document/src/main/java/com/ritense/document/domain/search/SearchConfigurationDto.java
+++ b/document/src/main/java/com/ritense/document/domain/search/SearchConfigurationDto.java
@@ -17,13 +17,14 @@
 package com.ritense.document.domain.search;
 
 import com.ritense.document.domain.impl.searchfield.SearchField;
-import com.ritense.document.domain.impl.searchfield.SearchFieldDatatype;
-import com.ritense.document.domain.impl.searchfield.SearchFieldFieldtype;
+import com.ritense.document.domain.impl.searchfield.SearchFieldDataType;
+import com.ritense.document.domain.impl.searchfield.SearchFieldFieldType;
 import com.ritense.document.domain.impl.searchfield.SearchFieldId;
-import com.ritense.document.domain.impl.searchfield.SearchFieldMatchtype;
+import com.ritense.document.domain.impl.searchfield.SearchFieldMatchType;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class SearchConfigurationDto {
 
@@ -36,16 +37,16 @@ public class SearchConfigurationDto {
     public static class SearchConfigurationFieldJson {
         private String key;
         private String path;
-        private SearchFieldDatatype dataType;
-        private SearchFieldFieldtype fieldType;
-        private SearchFieldMatchtype matchType;
+        private SearchFieldDataType dataType;
+        private SearchFieldFieldType fieldType;
+        private SearchFieldMatchType matchType;
 
         public SearchConfigurationFieldJson() {
             // Empty constructor needed for Jackson
         }
 
-        public SearchField toEntity(String documentDefinitionName) {
-            var searchField = new SearchField(key, path, dataType, fieldType, matchType);
+        public SearchField toEntity(String documentDefinitionName, int order) {
+            var searchField = new SearchField(key, path, dataType, fieldType, matchType, order);
             searchField.setId(SearchFieldId.newId(documentDefinitionName));
             return searchField;
         }
@@ -66,34 +67,34 @@ public class SearchConfigurationDto {
             this.path = path;
         }
 
-        public SearchFieldDatatype getDataType() {
+        public SearchFieldDataType getDataType() {
             return dataType;
         }
 
-        public void setDataType(SearchFieldDatatype dataType) {
+        public void setDataType(SearchFieldDataType dataType) {
             this.dataType = dataType;
         }
 
-        public SearchFieldFieldtype getFieldType() {
+        public SearchFieldFieldType getFieldType() {
             return fieldType;
         }
 
-        public void setFieldType(SearchFieldFieldtype fieldType) {
+        public void setFieldType(SearchFieldFieldType fieldType) {
             this.fieldType = fieldType;
         }
 
-        public SearchFieldMatchtype getMatchType() {
+        public SearchFieldMatchType getMatchType() {
             return matchType;
         }
 
-        public void setMatchType(SearchFieldMatchtype matchType) {
+        public void setMatchType(SearchFieldMatchType matchType) {
             this.matchType = matchType;
         }
     }
 
     public List<SearchField> toEntity(String documentDefinitionName) {
-        return searchFields.stream()
-            .map(searchField -> searchField.toEntity(documentDefinitionName))
+        return IntStream.range(0, searchFields.size())
+            .mapToObj(index -> searchFields.get(index).toEntity(documentDefinitionName, index))
             .collect(Collectors.toList());
     }
 

--- a/document/src/main/java/com/ritense/document/repository/SearchFieldRepository.java
+++ b/document/src/main/java/com/ritense/document/repository/SearchFieldRepository.java
@@ -19,12 +19,13 @@ package com.ritense.document.repository;
 import com.ritense.document.domain.impl.searchfield.SearchField;
 import com.ritense.document.domain.impl.searchfield.SearchFieldId;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface SearchFieldRepository extends JpaRepository<SearchField, SearchFieldId> {
 
-    List<SearchField> findAllByIdDocumentDefinitionName(String documentDefinitionName);
+    List<SearchField> findAllByIdDocumentDefinitionNameOrderByOrder(String documentDefinitionName);
 
     Optional<SearchField> findByIdDocumentDefinitionNameAndKey(String documentDefinitionName, String key);
 

--- a/document/src/main/java/com/ritense/document/service/SearchFieldService.java
+++ b/document/src/main/java/com/ritense/document/service/SearchFieldService.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class SearchFieldService {
@@ -47,22 +48,14 @@ public class SearchFieldService {
     }
 
     public List<SearchField> getSearchFields(String documentDefinitionName) {
-        return searchFieldRepository.findAllByIdDocumentDefinitionName(documentDefinitionName);
+        return searchFieldRepository.findAllByIdDocumentDefinitionNameOrderByOrder(documentDefinitionName);
     }
 
-    public void updateSearchFields(String documentDefinitionName, SearchFieldDto searchFieldDto) {
-        Optional<SearchField> fieldToUpdate = searchFieldRepository
-                .findByIdDocumentDefinitionNameAndKey(documentDefinitionName, searchFieldDto.getKey());
-        if (fieldToUpdate.isEmpty()) {
-            throw new IllegalArgumentException("No search field found for document '" + documentDefinitionName + "' and key '" + searchFieldDto.getKey() + "'.");
-        }
-        fieldToUpdate.ifPresent(searchField -> {
-            searchField.setPath(searchFieldDto.getPath());
-            searchField.setDatatype(searchFieldDto.getDataType());
-            searchField.setFieldtype(searchFieldDto.getFieldType());
-            searchField.setMatchtype(searchFieldDto.getMatchType());
-            searchFieldRepository.save(searchField);
-        });
+    public void updateSearchFields(String documentDefinitionName, List<SearchFieldDto> searchFieldDtos) {
+        var searchFields = IntStream.range(0, searchFieldDtos.size())
+            .mapToObj(index -> toOrderedSearchField(documentDefinitionName, searchFieldDtos.get(index), index))
+            .collect(Collectors.toList());
+        searchFieldRepository.saveAll(searchFields);
     }
 
     public void createSearchConfiguration(List<SearchField> searchFields) {
@@ -80,5 +73,20 @@ public class SearchFieldService {
     public void deleteSearchField(String documentDefinitionName, String key) {
         searchFieldRepository.findByIdDocumentDefinitionNameAndKey(documentDefinitionName, key).ifPresent(
                 searchFieldRepository::delete);
+    }
+
+    private SearchField toOrderedSearchField(String documentDefinitionName, SearchFieldDto searchFieldDto, int order) {
+        Optional<SearchField> fieldToUpdate = searchFieldRepository
+            .findByIdDocumentDefinitionNameAndKey(documentDefinitionName, searchFieldDto.getKey());
+        if (fieldToUpdate.isEmpty()) {
+            throw new IllegalArgumentException("No search field found for document '" + documentDefinitionName + "' and key '" + searchFieldDto.getKey() + "'.");
+        }
+        var searchField = fieldToUpdate.get();
+        searchField.setPath(searchFieldDto.getPath());
+        searchField.setDataType(searchFieldDto.getDataType());
+        searchField.setFieldType(searchFieldDto.getFieldType());
+        searchField.setMatchType(searchFieldDto.getMatchType());
+        searchField.setOrder(order);
+        return searchField;
     }
 }

--- a/document/src/main/java/com/ritense/document/web/rest/DocumentSearchFields.java
+++ b/document/src/main/java/com/ritense/document/web/rest/DocumentSearchFields.java
@@ -18,22 +18,22 @@ package com.ritense.document.web.rest;
 
 import com.ritense.document.domain.impl.searchfield.SearchFieldDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
 public interface DocumentSearchFields {
 
     ResponseEntity<Void> addSearchField(
-            @PathVariable String documentDefinitionName,
-            @RequestBody SearchFieldDto searchField);
+        String documentDefinitionName,
+        SearchFieldDto searchField);
+
     ResponseEntity<List<SearchFieldDto>> getSearchField(String documentDefinitionName);
+
     ResponseEntity<Void> updateSearchField(
-            @PathVariable String documentDefinitionName,
-            @RequestBody SearchFieldDto searchFieldDto);
+        String documentDefinitionName,
+        List<SearchFieldDto> searchFieldDto);
+
     ResponseEntity<Void> deleteSearchField(
-            @PathVariable String documentDefinitionName,
-            @RequestParam String key);
+        String documentDefinitionName,
+        String key);
 }

--- a/document/src/main/java/com/ritense/document/web/rest/impl/SearchFieldMapper.java
+++ b/document/src/main/java/com/ritense/document/web/rest/impl/SearchFieldMapper.java
@@ -22,7 +22,6 @@ import com.ritense.document.domain.impl.searchfield.SearchFieldDto;
 import java.util.ArrayList;
 import java.util.List;
 
-//todo perhaps adding Mapstruct as dependency to eliminate the need for building mappers would be a nice idea
 public class SearchFieldMapper {
 
     private SearchFieldMapper() {
@@ -31,15 +30,22 @@ public class SearchFieldMapper {
 
     public static List<SearchFieldDto> toDtoList(List<SearchField> entities){
         List<SearchFieldDto> result = new ArrayList<>();
-        entities.forEach((entity) -> result.add(SearchFieldMapper.toDto(entity)));
+        entities.forEach(entity -> result.add(SearchFieldMapper.toDto(entity)));
         return result;
     }
 
     public static SearchFieldDto toDto(SearchField searchField) {
-        return new SearchFieldDto(searchField.getKey(), searchField.getPath(),searchField.getDatatype(),searchField.getFieldtype(),searchField.getMatchtype());
+        return new SearchFieldDto(searchField.getKey(), searchField.getPath(),searchField.getDataType(),searchField.getFieldType(),searchField.getMatchType());
     }
 
-    public static SearchField toEntity(SearchFieldDto searchField) {
-        return new SearchField(searchField.getKey(), searchField.getPath(), searchField.getDataType(), searchField.getFieldType(), searchField.getMatchType());
+    public static SearchField toEntity(SearchFieldDto searchField, int order) {
+        return new SearchField(
+            searchField.getKey(),
+            searchField.getPath(),
+            searchField.getDataType(),
+            searchField.getFieldType(),
+            searchField.getMatchType(),
+            order
+        );
     }
 }

--- a/document/src/main/java/com/ritense/document/web/rest/impl/SearchFieldResource.java
+++ b/document/src/main/java/com/ritense/document/web/rest/impl/SearchFieldResource.java
@@ -52,7 +52,7 @@ public class SearchFieldResource implements DocumentSearchFields {
                 || searchField.getKey().trim().isEmpty()) {
             return ResponseEntity.badRequest().build();
         }
-        searchFieldService.addSearchField(documentDefinitionName, SearchFieldMapper.toEntity(searchField));
+        searchFieldService.addSearchField(documentDefinitionName, SearchFieldMapper.toEntity(searchField, -1));
         return ResponseEntity.ok().build();
     }
 
@@ -68,11 +68,11 @@ public class SearchFieldResource implements DocumentSearchFields {
     @PutMapping("/v1/document-search/{documentDefinitionName}/fields")
     public ResponseEntity<Void> updateSearchField(
             @PathVariable String documentDefinitionName,
-            @RequestBody SearchFieldDto searchFieldDto) {
-        if (searchFieldDto.getKey() == null || searchFieldDto.getKey().trim().isEmpty()) {
+            @RequestBody List<SearchFieldDto> searchFieldDtos) {
+        if (searchFieldDtos.stream().anyMatch(searchFieldDto -> searchFieldDto.getKey() == null || searchFieldDto.getKey().trim().isEmpty())) {
             return ResponseEntity.badRequest().build();
         }
-        searchFieldService.updateSearchFields(documentDefinitionName, searchFieldDto);
+        searchFieldService.updateSearchFields(documentDefinitionName, searchFieldDtos);
         return ResponseEntity.ok().build();
     }
 

--- a/document/src/main/resources/config/liquibase/changelog/20221021-add-search-field-table.xml
+++ b/document/src/main/resources/config/liquibase/changelog/20221021-add-search-field-table.xml
@@ -25,4 +25,17 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet author="Ritense" id="2">
+        <dropNotNullConstraint tableName="search_field" columnName="matchtype" columnDataType="varchar(20)"/>
+    </changeSet>
+
+    <changeSet author="Ritense" id="3">
+        <addColumn tableName="search_field">
+            <column name="search_field_order" type="${intType}" defaultValue="-1">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/document/src/main/resources/config/liquibase/document-master.xml
+++ b/document/src/main/resources/config/liquibase/document-master.xml
@@ -26,6 +26,9 @@
     <property name="jsonType" value="JSON" dbms="mysql"/>
     <property name="jsonType" value="JSONB" dbms="postgresql"/>
 
+    <property name="intType" value="int" dbms="mysql"/>
+    <property name="intType" value="integer" dbms="postgresql"/>
+
     <include file="changelog/20190712-create-document-domain-changelog.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20190815-document-dates-added-changelog.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20190916-document-created-by-added-changelog.xml" relativeToChangelogFile="true"/>

--- a/document/src/test/java/com/ritense/document/service/impl/SearchConfigurationDeploymentServiceIntTest.java
+++ b/document/src/test/java/com/ritense/document/service/impl/SearchConfigurationDeploymentServiceIntTest.java
@@ -18,9 +18,6 @@ package com.ritense.document.service.impl;
 
 import com.ritense.document.BaseIntegrationTest;
 import com.ritense.document.domain.impl.searchfield.SearchField;
-import com.ritense.document.domain.impl.searchfield.SearchFieldDatatype;
-import com.ritense.document.domain.impl.searchfield.SearchFieldFieldtype;
-import com.ritense.document.domain.impl.searchfield.SearchFieldMatchtype;
 import com.ritense.document.service.SearchFieldService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +26,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.ritense.document.domain.impl.searchfield.SearchFieldDataType.TEXT;
+import static com.ritense.document.domain.impl.searchfield.SearchFieldFieldType.SINGLE;
+import static com.ritense.document.domain.impl.searchfield.SearchFieldMatchType.EXACT;
+import static com.ritense.document.domain.impl.searchfield.SearchFieldMatchType.LIKE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -44,13 +45,21 @@ class SearchConfigurationDeploymentServiceIntTest extends BaseIntegrationTest {
 
         var searchFields = searchFieldService.getSearchFields(documentDefinitionName);
 
-        assertThat(searchFields).hasSize(1);
+        assertThat(searchFields).hasSize(2);
         assertThat(searchFields.get(0).getId().getDocumentDefinitionName()).isEqualTo("profile");
-        assertThat(searchFields.get(0).getKey()).isEqualTo("lastname");
-        assertThat(searchFields.get(0).getPath()).isEqualTo("/lastname");
-        assertThat(searchFields.get(0).getDatatype()).isEqualTo(SearchFieldDatatype.TEXT);
-        assertThat(searchFields.get(0).getFieldtype()).isEqualTo(SearchFieldFieldtype.SINGLE);
-        assertThat(searchFields.get(0).getMatchtype()).isEqualTo(SearchFieldMatchtype.LIKE);
+        assertThat(searchFields.get(0).getKey()).isEqualTo("firstName");
+        assertThat(searchFields.get(0).getPath()).isEqualTo("doc:firstName");
+        assertThat(searchFields.get(0).getDataType()).isEqualTo(TEXT);
+        assertThat(searchFields.get(0).getFieldType()).isEqualTo(SINGLE);
+        assertThat(searchFields.get(0).getMatchType()).isEqualTo(LIKE);
+        assertThat(searchFields.get(0).getOrder()).isZero();
+        assertThat(searchFields.get(1).getId().getDocumentDefinitionName()).isEqualTo("profile");
+        assertThat(searchFields.get(1).getKey()).isEqualTo("lastName");
+        assertThat(searchFields.get(1).getPath()).isEqualTo("doc:lastName");
+        assertThat(searchFields.get(1).getDataType()).isEqualTo(TEXT);
+        assertThat(searchFields.get(1).getFieldType()).isEqualTo(SINGLE);
+        assertThat(searchFields.get(1).getMatchType()).isEqualTo(LIKE);
+        assertThat(searchFields.get(1).getOrder()).isOne();
     }
 
     @Test
@@ -58,30 +67,33 @@ class SearchConfigurationDeploymentServiceIntTest extends BaseIntegrationTest {
         List<SearchField> searchFields = new ArrayList<>();
         searchFields.add(new SearchField(
                 "someKey",
-                "/some/path",
-                SearchFieldDatatype.TEXT,
-                SearchFieldFieldtype.SINGLE,
-                SearchFieldMatchtype.EXACT
+                "doc:some.path",
+                TEXT,
+                SINGLE,
+                EXACT,
+               0
         ));
         searchFields.add(new SearchField(
                 "someKey",
-                "/some/path",
-                SearchFieldDatatype.TEXT,
-                SearchFieldFieldtype.SINGLE,
-                SearchFieldMatchtype.LIKE
+                "doc:some.path",
+                TEXT,
+                SINGLE,
+                LIKE,
+                1
         ));
         searchFieldService.createSearchConfiguration(searchFields);
         searchFields = searchFieldService.getSearchFields("aDefinitionName");
-        assertThat(searchFields.isEmpty()).isTrue();
+        assertThat(searchFields).isEmpty();
     }
 
     @Test
     void shouldThrowExceptionDueToDuplicateKey() {
         SearchField searchField = new SearchField("someKey",
-                "somePath",
-                SearchFieldDatatype.TEXT,
-                SearchFieldFieldtype.SINGLE,
-                SearchFieldMatchtype.LIKE);
+                "doc:somePath",
+                TEXT,
+                SINGLE,
+                LIKE,
+                0);
         searchFieldService.addSearchField("aDefinitionName", searchField);
         assertThrows(IllegalArgumentException.class,
                 () -> searchFieldService.addSearchField("aDefinitionName", searchField));

--- a/document/src/test/java/com/ritense/document/web/rest/searchfields/SearchFieldResourceIntegrationTest.java
+++ b/document/src/test/java/com/ritense/document/web/rest/searchfields/SearchFieldResourceIntegrationTest.java
@@ -19,11 +19,10 @@ package com.ritense.document.web.rest.searchfields;
 import com.ritense.document.BaseIntegrationTest;
 import com.ritense.document.domain.impl.Mapper;
 import com.ritense.document.domain.impl.searchfield.SearchField;
-import com.ritense.document.domain.impl.searchfield.SearchFieldDatatype;
 import com.ritense.document.domain.impl.searchfield.SearchFieldDto;
-import com.ritense.document.domain.impl.searchfield.SearchFieldFieldtype;
+import com.ritense.document.domain.impl.searchfield.SearchFieldFieldType;
 import com.ritense.document.domain.impl.searchfield.SearchFieldId;
-import com.ritense.document.domain.impl.searchfield.SearchFieldMatchtype;
+import com.ritense.document.domain.impl.searchfield.SearchFieldMatchType;
 import com.ritense.document.service.SearchFieldService;
 import com.ritense.document.web.rest.impl.SearchFieldMapper;
 import com.ritense.document.web.rest.impl.SearchFieldResource;
@@ -34,9 +33,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.ritense.document.domain.impl.searchfield.SearchFieldDataType.TEXT;
+import static com.ritense.document.domain.impl.searchfield.SearchFieldFieldType.SINGLE;
+import static com.ritense.document.domain.impl.searchfield.SearchFieldMatchType.LIKE;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,10 +61,11 @@ class SearchFieldResourceIntegrationTest extends BaseIntegrationTest {
     private static final String DOCUMENT_DEFINITION_NAME = "test_document";
     private static final SearchField SEARCH_FIELD = new SearchField(
             "someKey",
-            "/some/path",
-            SearchFieldDatatype.TEXT,
-            SearchFieldFieldtype.SINGLE,
-            SearchFieldMatchtype.EXACT
+            "doc:some.path",
+            TEXT,
+            SINGLE,
+            SearchFieldMatchType.EXACT,
+            0
     );
 
     @BeforeEach()
@@ -85,7 +89,7 @@ class SearchFieldResourceIntegrationTest extends BaseIntegrationTest {
                 .andExpect(status().isOk());
 
         // The search field should have been stored in the database
-        var storedSearchFields = searchFieldRepository.findAllByIdDocumentDefinitionName("test_document");
+        var storedSearchFields = searchFieldRepository.findAllByIdDocumentDefinitionNameOrderByOrder("test_document");
 
         assertNotNull(storedSearchFields);
         assertEquals(1, storedSearchFields.size());
@@ -93,10 +97,10 @@ class SearchFieldResourceIntegrationTest extends BaseIntegrationTest {
         var storedSearchField = storedSearchFields.get(0);
 
         assertEquals("someKey", storedSearchField.getKey());
-        assertEquals("/some/path", storedSearchField.getPath());
-        assertEquals(SearchFieldDatatype.TEXT, storedSearchField.getDatatype());
-        assertEquals(SearchFieldFieldtype.SINGLE, storedSearchField.getFieldtype());
-        assertEquals(SearchFieldMatchtype.EXACT, storedSearchField.getMatchtype());
+        assertEquals("doc:some.path", storedSearchField.getPath());
+        assertEquals(TEXT, storedSearchField.getDataType());
+        assertEquals(SINGLE, storedSearchField.getFieldType());
+        assertEquals(SearchFieldMatchType.EXACT, storedSearchField.getMatchType());
     }
 
     @Test
@@ -115,27 +119,27 @@ class SearchFieldResourceIntegrationTest extends BaseIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].key", is("someKey")))
-                .andExpect(jsonPath("$[0].path", is("/some/path")))
-                .andExpect(jsonPath("$[0].datatype", is(SearchFieldDatatype.TEXT.toString())))
-                .andExpect(jsonPath("$[0].fieldtype", is(SearchFieldFieldtype.SINGLE.toString())))
-                .andExpect(jsonPath("$[0].matchtype", is(SearchFieldMatchtype.EXACT.toString())));
+                .andExpect(jsonPath("$[0].path", is("doc:some.path")))
+                .andExpect(jsonPath("$[0].dataType", is(TEXT.toString())))
+                .andExpect(jsonPath("$[0].fieldType", is(SINGLE.toString())))
+                .andExpect(jsonPath("$[0].matchType", is(SearchFieldMatchType.EXACT.toString())));
     }
 
     @Test
     void shouldUpdateSearchField() throws Exception {
         searchFieldService.addSearchField(DOCUMENT_DEFINITION_NAME, SEARCH_FIELD);
-        SearchFieldId searchFieldId = searchFieldRepository.findAllByIdDocumentDefinitionName(DOCUMENT_DEFINITION_NAME).get(0).getId();
+        SearchFieldId searchFieldId = searchFieldRepository.findAllByIdDocumentDefinitionNameOrderByOrder(DOCUMENT_DEFINITION_NAME).get(0).getId();
         SearchFieldDto searchFieldToUpdate = new SearchFieldDto(
                 SEARCH_FIELD.getKey(),
                 SEARCH_FIELD.getPath(),
-                SEARCH_FIELD.getDatatype(),
-                SearchFieldFieldtype.RANGE, //This is the change
-                SEARCH_FIELD.getMatchtype());
+                SEARCH_FIELD.getDataType(),
+                SearchFieldFieldType.RANGE, //This is the change
+                SEARCH_FIELD.getMatchType());
 
         mockMvc.perform(
                         put("/api/v1/document-search/{documentDefinitionName}/fields",
                                 DOCUMENT_DEFINITION_NAME)
-                                .content(Mapper.INSTANCE.get().writeValueAsString(searchFieldToUpdate))
+                                .content(Mapper.INSTANCE.get().writeValueAsString(List.of(searchFieldToUpdate)))
                                 .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andDo(print())
                 .andExpect(status().isOk());
@@ -147,9 +151,9 @@ class SearchFieldResourceIntegrationTest extends BaseIntegrationTest {
         assertEquals(searchFieldId.getId(), Objects.requireNonNull(searchFieldUpdated.orElseGet(SearchField::new).getId()).getId());
         assertEquals(searchFieldToUpdate.getKey(), searchFieldUpdated.orElseGet(SearchField::new).getKey());
         assertEquals(searchFieldToUpdate.getPath(), searchFieldUpdated.orElseGet(SearchField::new).getPath());
-        assertEquals(searchFieldToUpdate.getDataType(), searchFieldUpdated.orElseGet(SearchField::new).getDatatype());
-        assertEquals(searchFieldToUpdate.getFieldType(), SearchFieldFieldtype.RANGE);
-        assertEquals(searchFieldToUpdate.getMatchType(), searchFieldUpdated.orElseGet(SearchField::new).getMatchtype());
+        assertEquals(searchFieldToUpdate.getDataType(), searchFieldUpdated.orElseGet(SearchField::new).getDataType());
+        assertEquals(SearchFieldFieldType.RANGE, searchFieldToUpdate.getFieldType());
+        assertEquals(searchFieldToUpdate.getMatchType(), searchFieldUpdated.orElseGet(SearchField::new).getMatchType());
     }
 
     @Test
@@ -159,10 +163,31 @@ class SearchFieldResourceIntegrationTest extends BaseIntegrationTest {
         mockMvc.perform(
                         put("/api/v1/document-search/{documentDefinitionName}/fields",
                                 DOCUMENT_DEFINITION_NAME)
-                                .content(Mapper.INSTANCE.get().writeValueAsString(searchFieldDto))
+                                .content(Mapper.INSTANCE.get().writeValueAsString(List.of(searchFieldDto)))
                                 .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnChangeOrderingWhenUpdateSearchFields() throws Exception {
+        var searchFields = List.of(
+            new SearchFieldDto("lastName", "doc:customer.lastName", TEXT, SINGLE, LIKE),
+            new SearchFieldDto("firstName", "doc:customer.firstName", TEXT, SINGLE, LIKE)
+        );
+        mockMvc.perform(
+                put("/api/v1/document-search/{documentDefinitionName}/fields",
+                    "profile")
+                    .content(Mapper.INSTANCE.get().writeValueAsString(searchFields))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andDo(print())
+            .andExpect(status().isOk());
+
+        var searchFieldsResult = searchFieldRepository.findAllByIdDocumentDefinitionNameOrderByOrder("profile");
+        assertEquals("lastName", searchFieldsResult.get(0).getKey());
+        assertEquals(0, searchFieldsResult.get(0).getOrder());
+        assertEquals("firstName", searchFieldsResult.get(1).getKey());
+        assertEquals(1, searchFieldsResult.get(1).getOrder());
     }
 
     @Test

--- a/document/src/test/resources/config/search/profile.json
+++ b/document/src/test/resources/config/search/profile.json
@@ -1,8 +1,15 @@
 {
     "searchFields": [
         {
-            "key": "lastname",
-            "path": "/lastname",
+            "key": "firstName",
+            "path": "doc:firstName",
+            "dataType": "text",
+            "fieldType": "single",
+            "matchType": "like"
+        },
+        {
+            "key": "lastName",
+            "path": "doc:lastName",
             "dataType": "text",
             "fieldType": "single",
             "matchType": "like"


### PR DESCRIPTION
- The `search_field` table now contains an extra 'order' column.
- The new 'order' property is never returned in an endpoint.
- The `GET /fields` endpoint will now respond with ordered search fields.
- The `PUT /fields` endpoint now accepts an array. The order of search fields in the array decides the ordering.
- All changes above have been discussed with FE.