### PR TITLE
Updated Gradle config to increase published artefact quality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,18 +100,21 @@ subprojects { subproject ->
     apply from: "$rootProject.projectDir/gradle/test.gradle"
     apply plugin: "com.avast.gradle.docker-compose"
     apply plugin: "maven-publish"
+    apply plugin: "org.jetbrains.dokka"
 
     task allDeps(type: DependencyReportTask) {}
 
-    task sourceJar(type: Jar) {
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-        from sourceSets.main.allSource
-        classifier "sources"
+    java {
+        withSourcesJar()
+        withJavadocJar()
     }
 
-    task javadocJar(type: Jar) {
-        from dokkaJavadoc
-        classifier "javadoc"
+    ext.javaSubProjectPath = subproject.projectDir.getAbsolutePath() + "/src/main/java"
+    ext.kotlinSubProjectPath = subproject.projectDir.getAbsolutePath() + "/src/main/kotlin"
+    if (new File(ext.kotlinSubProjectPath).exists() && !new File(ext.javaSubProjectPath).exists()) {
+        tasks.getByName('javadocJar') {
+            from dokkaJavadoc
+        }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {


### PR DESCRIPTION
Updated Gradle config to make use of convenience methods 'withSourcesJar' and 'withJavadocJar'.

This adds a reference to the sources jar in the published .module file (Gradle's .pom on steroids). Also, updated the config to have Dokka Javadocs for modules that have kotlin code. Java and mixed (w Kotlin) modules keep having plain old javadocs.

Source config:
[BEFORE: audit-9.18.0.RELEASE.module.txt](https://github.com/valtimo-platform/valtimo-backend-libraries/files/10057309/audit-9.18.0.RELEASE.module.txt)
[AFTER: audit-9.23.0-with-sources.module.txt](https://github.com/valtimo-platform/valtimo-backend-libraries/files/10057311/audit-9.23.0-with-sources.module.txt)

Javadoc config:
![BEFORE: smartdocuments-javadoc-before](https://user-images.githubusercontent.com/54576297/203080386-b54d3566-c5ed-4c31-bbdc-4eb1e9ab67a4.png)
![AFTER: smartdocuments-javadoc-after](https://user-images.githubusercontent.com/54576297/203080403-d9b26b51-bf08-4825-98ee-87727000079b.png)

