### PR TITLE
Bugfix: added transaction timeout on modifyDocument

### DIFF
--- a/document/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentService.java
+++ b/document/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentService.java
@@ -155,7 +155,7 @@ public class JsonSchemaDocumentService implements DocumentService {
     }
 
     @Override
-    @Transactional
+    @Transactional(timeout = 30, rollbackFor = { Exception.class })
     public synchronized JsonSchemaDocument.ModifyDocumentResultImpl modifyDocument(
         ModifyDocumentRequest request
     ) {


### PR DESCRIPTION
Bugfix: the modifyDocument method can block the whole application when a query hangs indefinitely due to locking. Added a timeout on the transaction which will rollback on every type of exception.