### PR TITLE
fix: too many stacktraces in logs 

### DIFF
--- a/objects-api/src/main/kotlin/com/ritense/objectsapi/productaanvraag/ProductAanvraagListener.kt
+++ b/objects-api/src/main/kotlin/com/ritense/objectsapi/productaanvraag/ProductAanvraagListener.kt
@@ -16,12 +16,12 @@
 
 package com.ritense.objectsapi.productaanvraag
 
-import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.databind.node.TextNode
 import com.ritense.objectsapi.opennotificaties.OpenNotificatieConnector.Companion.OBJECTEN_KANAAL_NAME
 import com.ritense.objectsapi.opennotificaties.OpenNotificatieService
 import com.ritense.objectsapi.opennotificaties.OpenNotificationEvent
+import mu.KotlinLogging
 import org.springframework.context.event.EventListener
+import javax.persistence.EntityNotFoundException
 
 class ProductAanvraagListener(
     private val productAanvraagService: ProductAanvraagService,
@@ -33,19 +33,32 @@ class ProductAanvraagListener(
         if (event.notification.kanaal == OBJECTEN_KANAAL_NAME
             && event.notification.isCreateNotification()
         ) {
-            val connector = openNotificatieService.findConnector(event.connectorId, event.authorizationKey)
+            try {
+                val connector = try {
+                    openNotificatieService.findConnector(event.connectorId, event.authorizationKey)
+                } catch (e: EntityNotFoundException) {
+                    logger.error { "Failed to find connector with id '${event.connectorId}'" }
+                    return
+                }
 
-            if (connector is ProductAanvraagConnector && connector.getObjectsApiConnector().getProperties()
-                    .objectType.url == event.notification.getObjectTypeUrl()
-            ) {
-                val productAanvraagId = event.notification.getObjectId()
-                val productAanvraag = connector.getProductAanvraag(productAanvraagId)
-                val typeMapping = connector.getTypeMapping(productAanvraag.type)
-                val aanvragerRolTypeUrl = connector.getAanvragerRolTypeUrl()
+                if (connector is ProductAanvraagConnector && connector.getObjectsApiConnector().getProperties()
+                        .objectType.url == event.notification.getObjectTypeUrl()
+                ) {
+                    val productAanvraagId = event.notification.getObjectId()
+                    val productAanvraag = connector.getProductAanvraag(productAanvraagId)
+                    val typeMapping = connector.getTypeMapping(productAanvraag.type)
+                    val aanvragerRolTypeUrl = connector.getAanvragerRolTypeUrl()
 
-                productAanvraagService.createDossier(productAanvraag, typeMapping, aanvragerRolTypeUrl)
-                connector.deleteProductAanvraag(productAanvraagId)
+                    productAanvraagService.createDossier(productAanvraag, typeMapping, aanvragerRolTypeUrl)
+                    connector.deleteProductAanvraag(productAanvraagId)
+                }
+            } catch (e: Exception) {
+                logger.error { "Failed handle ProductAanvraag. Connector id:  '${event.connectorId}'. Error: ${e.message}" }
             }
         }
+    }
+
+    companion object {
+        val logger = KotlinLogging.logger {}
     }
 }


### PR DESCRIPTION
```
javax.persistence.EntityNotFoundException: Unable to find com.ritense.connector.domain.ConnectorInstance with id...
```