### PR TITLE
fix: Unwanted SQL UPDATEs of connectors

### DIFF
--- a/besluit/src/main/kotlin/com/ritense/besluit/connector/BesluitProperties.kt
+++ b/besluit/src/main/kotlin/com/ritense/besluit/connector/BesluitProperties.kt
@@ -23,7 +23,7 @@ import com.ritense.connector.config.Encryptor
 import com.ritense.connector.domain.ConnectorProperties
 import com.ritense.openzaak.domain.configuration.Rsin
 
-class BesluitProperties(
+data class BesluitProperties(
     var url: String = "",
     @set:JsonSerialize(using = Encryptor::class)
     @get:JsonDeserialize(using = Decryptor::class)

--- a/mail/flowmailer/src/main/kotlin/com/ritense/mail/flowmailer/connector/FlowmailerConnectorProperties.kt
+++ b/mail/flowmailer/src/main/kotlin/com/ritense/mail/flowmailer/connector/FlowmailerConnectorProperties.kt
@@ -18,6 +18,6 @@ package com.ritense.mail.flowmailer.connector
 import com.ritense.connector.domain.ConnectorProperties
 import com.ritense.mail.flowmailer.config.FlowmailerProperties
 
-class FlowmailerConnectorProperties(
+data class FlowmailerConnectorProperties(
     val flowmailerProperties: FlowmailerProperties
 ) : ConnectorProperties

--- a/mail/wordpress-mail/src/main/kotlin/com/ritense/mail/wordpressmail/connector/WordpressMailConnectorProperties.kt
+++ b/mail/wordpress-mail/src/main/kotlin/com/ritense/mail/wordpressmail/connector/WordpressMailConnectorProperties.kt
@@ -17,6 +17,6 @@ package com.ritense.mail.wordpressmail.connector
 
 import com.ritense.connector.domain.ConnectorProperties
 
-class WordpressMailConnectorProperties(
+data class WordpressMailConnectorProperties(
     val url: String? = ""
 ) : ConnectorProperties

--- a/objects-api/src/main/kotlin/com/ritense/objectsapi/productaanvraag/ProductAanvraagTypeMapping.kt
+++ b/objects-api/src/main/kotlin/com/ritense/objectsapi/productaanvraag/ProductAanvraagTypeMapping.kt
@@ -16,7 +16,7 @@
 
 package com.ritense.objectsapi.productaanvraag
 
-class ProductAanvraagTypeMapping(
+data class ProductAanvraagTypeMapping(
     val productAanvraagType: String,
     val caseDefinitionKey: String,
     val processDefinitionKey: String

--- a/objects-api/src/main/kotlin/com/ritense/objectsapi/service/ServerAuthSpecification.kt
+++ b/objects-api/src/main/kotlin/com/ritense/objectsapi/service/ServerAuthSpecification.kt
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.ritense.connector.config.Decryptor
 import com.ritense.connector.config.Encryptor
 
-class ServerAuthSpecification(
+data class ServerAuthSpecification(
     var url: String = "",
     @set:JsonSerialize(using = Encryptor::class)
     @get:JsonDeserialize(using = Decryptor::class)

--- a/objects-api/src/main/kotlin/com/ritense/objectsapi/taak/TaakProperties.kt
+++ b/objects-api/src/main/kotlin/com/ritense/objectsapi/taak/TaakProperties.kt
@@ -18,7 +18,7 @@ package com.ritense.objectsapi.taak
 
 import com.ritense.connector.domain.ConnectorProperties
 
-class TaakProperties(
+data class TaakProperties(
     var openNotificatieConnectionName: String = "",
     var objectsApiConnectionName: String = "",
 ) : ConnectorProperties


### PR DESCRIPTION
What happens is:
1. Some transaction is started
2. connectorRepo.findAll() is called and returns Managed Entities
3. When transaction ends, Spring will check if managed entities have changed, if so, it will save them to the DB. Without the need of a repo.save()
4. Spring checks all fields to see if anything changed in the managed entities: ConnectorInstance and ConnectorType
5. Both entities have a connectorProperties field
6. Spring checks the connectorProperties of a manged entity and does a deepEquals to compare them to the entry from the DB
7. Some connectorProperties don't have an 'equals' method implemented. Spring will always marks those entities as 'changed'/dirty.
8. The kotlin 'data class' creates an equals method 