### PR TITLE
Add constraint to process definition id

### DIFF
--- a/view-configurator/src/main/resources/config/liquibase/changelog/20221202-add-constraint-to-process-defintion-id.xml
+++ b/view-configurator/src/main/resources/config/liquibase/changelog/20221202-add-constraint-to-process-defintion-id.xml
@@ -1,0 +1,29 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2015-2020 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="add_constraint_process_definition_id" author="Dillon Rochford">
+        <addUniqueConstraint columnNames="process_definition_id"
+                             constraintName="unique_process_definition_id"
+                             tableName="view_config"/>
+    </changeSet>
+</databaseChangeLog>
+

--- a/view-configurator/src/main/resources/config/liquibase/changelog/20221202-add-constraint-to-process-defintion-id.xml
+++ b/view-configurator/src/main/resources/config/liquibase/changelog/20221202-add-constraint-to-process-defintion-id.xml
@@ -22,7 +22,9 @@
 
     <changeSet id="add_constraint_process_definition_id" author="Dillon Rochford">
         <preConditions onFail="MARK_RAN">
-            <indexExists tableName="view_config" columnNames="process_definition_id"/>
+            <not>
+                <indexExists tableName="view_config" columnNames="process_definition_id"/>
+            </not>
         </preConditions>
         <addUniqueConstraint columnNames="process_definition_id"
                              constraintName="unique_process_definition_id"

--- a/view-configurator/src/main/resources/config/liquibase/changelog/20221202-add-constraint-to-process-defintion-id.xml
+++ b/view-configurator/src/main/resources/config/liquibase/changelog/20221202-add-constraint-to-process-defintion-id.xml
@@ -21,6 +21,9 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet id="add_constraint_process_definition_id" author="Dillon Rochford">
+        <preConditions onFail="MARK_RAN">
+            <indexExists tableName="view_config" columnNames="process_definition_id"/>
+        </preConditions>
         <addUniqueConstraint columnNames="process_definition_id"
                              constraintName="unique_process_definition_id"
                              tableName="view_config"/>

--- a/view-configurator/src/main/resources/config/liquibase/view-configurator-master.xml
+++ b/view-configurator/src/main/resources/config/liquibase/view-configurator-master.xml
@@ -24,5 +24,6 @@
     <include file="changelog/20180628-process-definition-variable.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20180629-view-var-ordering.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20181102-view-var-groups.xml" relativeToChangelogFile="true"/>
+    <include file="changelog/20221202-add-constraint-to-process-defintion-id.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Liquibase script for putting a unique constraint on the process_definition_id. Also added precondition if it already exists from the implementation's side.