### PR TITLE
Bugfix: Search on date

### DIFF
--- a/contract/src/main/java/com/ritense/valtimo/contract/database/PostgresQueryDialectHelper.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/database/PostgresQueryDialectHelper.java
@@ -37,8 +37,13 @@ public class PostgresQueryDialectHelper implements QueryDialectHelper {
             column,
             cb.function("jsonpath", String.class, cb.literal(jsonPath))
         );
-        if (String.class.isAssignableFrom(type) || TemporalAccessor.class.isAssignableFrom(type)) {
+        if (String.class.isAssignableFrom(type)) {
             return cb.trim('"', jsonValue.as(String.class)).as(type);
+        } else if (TemporalAccessor.class.isAssignableFrom(type)) {
+            return cb.selectCase()
+                .when(jsonValue.as(String.class).in("\"\""), null)
+                .otherwise(cb.trim('"', jsonValue.as(String.class)))
+                .as(type);
         } else {
             return jsonValue.as(type);
         }

--- a/contract/src/main/java/com/ritense/valtimo/contract/database/PostgresQueryDialectHelper.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/database/PostgresQueryDialectHelper.java
@@ -37,10 +37,8 @@ public class PostgresQueryDialectHelper implements QueryDialectHelper {
             column,
             cb.function("jsonpath", String.class, cb.literal(jsonPath))
         );
-        if (String.class.isAssignableFrom(type)) {
+        if (String.class.isAssignableFrom(type) || TemporalAccessor.class.isAssignableFrom(type)) {
             return cb.trim('"', jsonValue.as(String.class)).as(type);
-        } else if (TemporalAccessor.class.isAssignableFrom(type)) {
-            return jsonValue.as(String.class).as(type);
         } else {
             return jsonValue.as(type);
         }


### PR DESCRIPTION
Searching on a date gives an error when the date is saved as an empty string in the document JSON.

The error Postgres SQL look a little like this:
```
SELECT jsonb_path_query_first('{"myDate": ""}','$.myDate')::TEXT::DATE
```
Gives error:
```
SQL Error [22007]: ERROR: invalid input syntax for type date: """"
```


Solution:
```
SELECT CASE WHEN(jsonb_path_query_first('{"myDate": ""}','$.myDate')::TEXT) IN('""') THEN null ELSE BTRIM(jsonb_path_query_first('{"myDate": ""}','$.myDate')::TEXT, '"')::DATE END
```


Its beautiful