### PR TITLE
Override versions for snakeyaml and netty-codec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ allprojects {
             mavenBom "com.fasterxml.jackson:jackson-bom:${jacksonVersion}"
             mavenBom "org.junit:junit-bom:${junitVersion}"
         }
+        dependencies {
+            dependency "org.yaml:snakeyaml:${snakeYamlVersionOverride}"
+            dependency "io.netty:netty-codec:${nettyCodecVersionOverride}"
+        }
     }
 
     bootJar.enabled = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -83,4 +83,11 @@ mapstructVersion=1.5.3.Final
 kotestVersion=5.5.4
 shedlockVersion=4.42.0
 
+# version overrides
+
+nettyCodecVersionOverride=4.1.86.Final
+snakeYamlVersionOverride=1.33
+
+# project version
+
 projectVersion=10.0.0.RELEASE


### PR DESCRIPTION
snakeyaml and netty-codec contain vulnerabilities. these have been upgraded to safe versions