### PR TITLE
#46573 move endpoints for zaakInstanceLinks

### DIFF
--- a/openzaak/src/main/kotlin/com/ritense/openzaak/autoconfigure/OpenZaakAutoConfiguration.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/autoconfigure/OpenZaakAutoConfiguration.kt
@@ -47,6 +47,7 @@ import com.ritense.openzaak.service.impl.ZaakService
 import com.ritense.openzaak.service.impl.ZaakStatusService
 import com.ritense.openzaak.service.impl.ZaakTypeLinkService
 import com.ritense.openzaak.service.impl.ZaakTypeService
+import com.ritense.openzaak.web.rest.ZaakInstanceLinkResource
 import com.ritense.openzaak.web.rest.impl.InformatieObjectTypeLinkResource
 import com.ritense.openzaak.web.rest.impl.InformatieObjectTypeResource
 import com.ritense.openzaak.web.rest.impl.OpenZaakConfigResource
@@ -300,6 +301,14 @@ class OpenZaakAutoConfiguration {
         openZaakConfigService: OpenZaakConfigService
     ): OpenZaakConfigResource {
         return OpenZaakConfigResource(openZaakConfigService)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ZaakInstanceLinkResource::class)
+    fun zaakInstanceLinkResource(
+        zaakInstanceLinkService: ZaakInstanceLinkService
+    ): ZaakInstanceLinkResource {
+        return ZaakInstanceLinkResource(zaakInstanceLinkService)
     }
 
     @Bean

--- a/openzaak/src/main/kotlin/com/ritense/openzaak/autoconfigure/OpenZaakSecurityAutoConfiguration.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/autoconfigure/OpenZaakSecurityAutoConfiguration.kt
@@ -21,6 +21,7 @@ import com.ritense.openzaak.security.config.InformatieObjectTypeLinkHttpSecurity
 import com.ritense.openzaak.security.config.OpenZaakConfigHttpSecurityConfigurer
 import com.ritense.openzaak.security.config.ResultaatHttpSecurityConfigurer
 import com.ritense.openzaak.security.config.StatusHttpSecurityConfigurer
+import com.ritense.openzaak.security.config.ZaakInstanceLinkHttpSecurityConfigurer
 import com.ritense.openzaak.security.config.ZaakTypeHttpSecurityConfigurer
 import com.ritense.openzaak.security.config.ZaakTypeLinkHttpSecurityConfigurer
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -57,6 +58,13 @@ class OpenZaakSecurityAutoConfiguration {
     @ConditionalOnMissingBean(StatusHttpSecurityConfigurer::class)
     fun statusHttpSecurityConfigurer(): StatusHttpSecurityConfigurer {
         return StatusHttpSecurityConfigurer()
+    }
+
+    @Bean
+    @Order(270)
+    @ConditionalOnMissingBean(ZaakInstanceLinkHttpSecurityConfigurer::class)
+    fun zaakInstanceLinkHttpSecurityConfigurer(): ZaakInstanceLinkHttpSecurityConfigurer {
+        return ZaakInstanceLinkHttpSecurityConfigurer()
     }
 
     @Bean

--- a/openzaak/src/main/kotlin/com/ritense/openzaak/security/config/ZaakInstanceLinkHttpSecurityConfigurer.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/security/config/ZaakInstanceLinkHttpSecurityConfigurer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Ritense BV, the Netherlands.
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.ritense.objectenapi.security
+package com.ritense.openzaak.security.config
 
 import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.USER
 import com.ritense.valtimo.contract.security.config.HttpConfigurerConfigurationException
@@ -22,15 +22,14 @@ import com.ritense.valtimo.contract.security.config.HttpSecurityConfigurer
 import org.springframework.http.HttpMethod.GET
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 
-class ObjectenApiHttpSecurityConfigurer: HttpSecurityConfigurer {
+class ZaakInstanceLinkHttpSecurityConfigurer : HttpSecurityConfigurer {
 
     override fun configure(http: HttpSecurity) {
         try {
             http.authorizeRequests()
-                .antMatchers(GET, "/api/v1/document/{documentId}/zaak/objecttype").hasAuthority(USER)
-                .antMatchers(GET, "/api/v1/document/{documentId}/zaak/object").hasAuthority(USER)
-                .antMatchers(GET, "/api/v1/document/{documentId}/zaak/object/form").hasAuthority(USER)
-        } catch(e: Exception) {
+                .antMatchers(GET, "/api/v1/zaakinstancelink/zaak").hasAuthority(USER)
+                .antMatchers(GET, "/api/v1/zaakinstancelink/document").hasAuthority(USER)
+        } catch (e: Exception) {
             throw HttpConfigurerConfigurationException(e)
         }
     }

--- a/openzaak/src/main/kotlin/com/ritense/openzaak/web/rest/ZaakInstanceLinkResource.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/web/rest/ZaakInstanceLinkResource.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Dimpact.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.openzaak.web.rest
+
+import com.ritense.openzaak.service.ZaakInstanceLinkService
+import com.ritense.openzaak.web.rest.response.ZaakInstanceLinkDTO
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+import java.util.UUID
+
+@RestController
+@RequestMapping(value = ["/api"], produces = [MediaType.APPLICATION_JSON_VALUE])
+class ZaakInstanceLinkResource(
+    val zaakInstanceLinkService: ZaakInstanceLinkService,
+) {
+
+    @GetMapping(value = ["/v1/zaakinstancelink/zaak"])
+    fun getZaakInstanceLink(
+        @RequestParam(name = "zaakInstanceUrl") zaakInstanceUrl: URI
+    ): ResponseEntity<ZaakInstanceLinkDTO> {
+        val entity = zaakInstanceLinkService.getByZaakInstanceUrl(zaakInstanceUrl)
+        return ResponseEntity.ok(
+            ZaakInstanceLinkDTO(
+                zaakInstanceUrl = entity.zaakInstanceUrl,
+                documentId = entity.documentId
+            )
+        )
+    }
+
+    @GetMapping(value = ["/v1/zaakinstancelink/document"])
+    fun getZaakInstanceLink(
+        @RequestParam(name = "documentId") documentId: UUID
+    ): ResponseEntity<ZaakInstanceLinkDTO> {
+        val entity = zaakInstanceLinkService.getByDocumentId(documentId)
+        return ResponseEntity.ok(
+            ZaakInstanceLinkDTO(
+                zaakInstanceUrl = entity.zaakInstanceUrl,
+                documentId = entity.documentId
+            )
+        )
+    }
+}

--- a/openzaak/src/main/kotlin/com/ritense/openzaak/web/rest/response/ZaakInstanceLinkDTO.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/web/rest/response/ZaakInstanceLinkDTO.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.ritense.objectenapi.web.rest.result
+package com.ritense.openzaak.web.rest.response
 
 import java.net.URI
 import java.util.UUID

--- a/openzaak/src/test/kotlin/com/ritense/openzaak/web/rest/impl/ZaakInstanceLinkResourceTest.kt
+++ b/openzaak/src/test/kotlin/com/ritense/openzaak/web/rest/impl/ZaakInstanceLinkResourceTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.openzaak.web.rest.impl
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ritense.openzaak.domain.mapping.impl.ZaakInstanceLink
+import com.ritense.openzaak.domain.mapping.impl.ZaakInstanceLinkId
+import com.ritense.openzaak.service.impl.ZaakInstanceLinkService
+import com.ritense.openzaak.web.rest.ZaakInstanceLinkResource
+import com.ritense.openzaak.web.rest.response.ZaakInstanceLinkDTO
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+internal class ZaakInstanceLinkResourceTest {
+
+    lateinit var mockMvc: MockMvc
+    lateinit var zaakInstanceLinkService: ZaakInstanceLinkService
+    lateinit var zaakInstanceLinkResource: ZaakInstanceLinkResource
+    lateinit var applicationEventPublisher: ApplicationEventPublisher
+
+    @BeforeEach
+    fun init() {
+        zaakInstanceLinkService = Mockito.mock(ZaakInstanceLinkService::class.java)
+        zaakInstanceLinkResource = ZaakInstanceLinkResource(zaakInstanceLinkService)
+        applicationEventPublisher = Mockito.mock(ApplicationEventPublisher::class.java)
+
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(zaakInstanceLinkResource)
+            .setCustomArgumentResolvers(PageableHandlerMethodArgumentResolver())
+            .build()
+    }
+
+    @Test
+    fun `should return ZaakInstaceLink for given zaakInstanceUrl`() {
+        // given:
+        val url = URI("http://localhost:8001/zaken/api/v1/zaken/df64a38e-566a-409d-8275-9207f70f79e7")
+        val documentId = UUID.randomUUID()
+
+        val entity = ZaakInstanceLink(
+            zaakInstanceLinkId = ZaakInstanceLinkId(
+                id = UUID.randomUUID()
+            ),
+            zaakInstanceUrl = url,
+            zaakInstanceId = UUID.randomUUID(),
+            documentId = documentId,
+            zaakTypeUrl = URI("http://example.com"),
+        )
+
+        //when:
+        whenever(zaakInstanceLinkService.getByZaakInstanceUrl(url)).thenReturn(
+            entity
+        )
+
+        //then:
+        val expectedDto = ZaakInstanceLinkDTO(
+            zaakInstanceUrl = url,
+            documentId = documentId
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/zaakinstancelink/zaak?zaakInstanceUrl=$url")
+                .characterEncoding(StandardCharsets.UTF_8.name())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().is2xxSuccessful)
+            .andExpect(jsonPath("$").isNotEmpty)
+            .andExpect(
+                MockMvcResultMatchers.content().json(
+                    jacksonObjectMapper().writeValueAsString(expectedDto)
+                )
+            )
+    }
+
+    @Test
+    fun `should return ZaakInstaceLink for given documentId`() {
+        // given:
+        val url = URI("http://example1.com")
+        val documentId = UUID.randomUUID()
+
+        val result = ZaakInstanceLink(
+            zaakInstanceLinkId = ZaakInstanceLinkId(
+                id = UUID.randomUUID()
+            ),
+            zaakInstanceUrl = URI("http://example1.com"),
+            zaakInstanceId = UUID.randomUUID(),
+            documentId = documentId,
+            zaakTypeUrl = URI("http://example2.com"),
+        )
+
+        //when:
+        whenever(zaakInstanceLinkService.getByDocumentId(documentId)).thenReturn(
+            result
+        )
+
+        //then:
+        val expectedDto = ZaakInstanceLinkDTO(
+            zaakInstanceUrl = url,
+            documentId = documentId
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/zaakinstancelink/document?documentId=$documentId")
+                .characterEncoding(StandardCharsets.UTF_8.name())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().is2xxSuccessful)
+            .andExpect(jsonPath("$").isNotEmpty)
+            .andExpect(
+                MockMvcResultMatchers.content().json(
+                    jacksonObjectMapper().writeValueAsString(expectedDto)
+                )
+            )
+
+    }
+
+}

--- a/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/web/rest/ZaakObjectResource.kt
+++ b/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/web/rest/ZaakObjectResource.kt
@@ -20,8 +20,6 @@ import com.ritense.form.domain.FormDefinition
 import com.ritense.objectenapi.service.ZaakObjectService
 import com.ritense.objectenapi.web.rest.result.ObjectDto
 import com.ritense.objectenapi.web.rest.result.ObjecttypeDto
-import com.ritense.objectenapi.web.rest.result.ZaakInstanceLinkDTO
-import com.ritense.openzaak.service.ZaakInstanceLinkService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -36,7 +34,6 @@ import java.util.UUID
 @RequestMapping(value = ["/api"])
 class ZaakObjectResource(
     val zaakObjectService: ZaakObjectService,
-    val zaakInstanceLinkService: ZaakInstanceLinkService
 ) {
     @GetMapping(value = ["/v1/document/{documentId}/zaak/objecttype"])
     fun getZaakObjecttypes(
@@ -64,28 +61,6 @@ class ZaakObjectResource(
     ): ResponseEntity<FormDefinition>{
         val form = zaakObjectService.getZaakObjectForm(objectUrl)
         return form?.let { ResponseEntity.ok(it) } ?: ResponseEntity.notFound().build()
-    }
-
-    @GetMapping(value = ["/v1/zaakinstancelink/zaak"])
-    fun getZaakInstanceLink(
-        @RequestParam(name = "zaakInstanceUrl") zaakInstanceUrl: URI
-    ): ResponseEntity<ZaakInstanceLinkDTO>{
-        val entity = zaakInstanceLinkService.getByZaakInstanceUrl(zaakInstanceUrl)
-        return  ResponseEntity.ok(ZaakInstanceLinkDTO(
-            zaakInstanceUrl = entity.zaakInstanceUrl,
-            documentId = entity.documentId)
-        )
-    }
-
-    @GetMapping(value = ["/v1/zaakinstancelink/document"])
-    fun getZaakInstanceLink(
-        @RequestParam(name = "documentId") documentId: UUID
-    ): ResponseEntity<ZaakInstanceLinkDTO>{
-        val entity = zaakInstanceLinkService.getByDocumentId(documentId)
-        return  ResponseEntity.ok(ZaakInstanceLinkDTO(
-            zaakInstanceUrl = entity.zaakInstanceUrl,
-            documentId = entity.documentId)
-        )
     }
 
 }

--- a/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/web/rest/ZaakObjectResourceTest.kt
+++ b/zgw/objecten-api/src/test/kotlin/com/ritense/objectenapi/web/rest/ZaakObjectResourceTest.kt
@@ -16,28 +16,22 @@
 
 package com.ritense.objectenapi.web.rest
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import com.ritense.form.domain.FormIoFormDefinition
 import com.ritense.objectenapi.client.ObjectRecord
 import com.ritense.objectenapi.client.ObjectWrapper
 import com.ritense.objectenapi.service.ZaakObjectService
-import com.ritense.objectenapi.web.rest.result.ZaakInstanceLinkDTO
 import com.ritense.objecttypenapi.client.Objecttype
-import com.ritense.openzaak.domain.mapping.impl.ZaakInstanceLink
-import com.ritense.openzaak.domain.mapping.impl.ZaakInstanceLinkId
-import com.ritense.openzaak.service.ZaakInstanceLinkService
 import com.ritense.valtimo.contract.json.Mapper
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
@@ -51,13 +45,11 @@ internal class ZaakObjectResourceTest {
     lateinit var mockMvc: MockMvc
     lateinit var zaakObjectService: ZaakObjectService
     lateinit var zaakObjectResource: ZaakObjectResource
-    lateinit var zaakInstanceLinkService: ZaakInstanceLinkService
 
     @BeforeEach
     fun init() {
         zaakObjectService = mock()
-        zaakInstanceLinkService = mock()
-        zaakObjectResource = ZaakObjectResource(zaakObjectService, zaakInstanceLinkService)
+        zaakObjectResource = ZaakObjectResource(zaakObjectService)
 
         mockMvc = MockMvcBuilders
             .standaloneSetup(zaakObjectResource)
@@ -195,90 +187,4 @@ internal class ZaakObjectResourceTest {
         return converter
     }
 
-    @Test
-    fun `should return ZaakInstaceLink for given zaakInstanceUrl`() {
-        // given:
-        val url = URI("http://localhost:8001/zaken/api/v1/zaken/df64a38e-566a-409d-8275-9207f70f79e7")
-        val documentId = UUID.randomUUID()
-
-        val entity = ZaakInstanceLink(
-            zaakInstanceLinkId = ZaakInstanceLinkId(
-                id = UUID.randomUUID()
-            ),
-            zaakInstanceUrl = url,
-            zaakInstanceId = UUID.randomUUID(),
-            documentId = documentId,
-            zaakTypeUrl = URI("http://example.com"),
-        )
-
-        //when:
-        whenever(zaakInstanceLinkService.getByZaakInstanceUrl(url)).thenReturn(
-            entity
-        )
-
-        //then:
-        val expectedDto = ZaakInstanceLinkDTO(
-            zaakInstanceUrl = url,
-            documentId = documentId
-        )
-
-        mockMvc.perform(
-            get("/api/v1/zaakinstancelink/zaak?zaakInstanceUrl=$url")
-                .characterEncoding(StandardCharsets.UTF_8.name())
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-        )
-            .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().is2xxSuccessful)
-            .andExpect(jsonPath("$").isNotEmpty)
-            .andExpect(
-                MockMvcResultMatchers.content().json(
-                    jacksonObjectMapper().writeValueAsString(expectedDto)
-                )
-            )
-    }
-
-    @Test
-    fun `should return ZaakInstaceLink for given documentId`() {
-        // given:
-        val url = URI("http://example1.com")
-        val documentId = UUID.randomUUID()
-
-        val result = ZaakInstanceLink(
-            zaakInstanceLinkId = ZaakInstanceLinkId(
-                id = UUID.randomUUID()
-            ),
-            zaakInstanceUrl = URI("http://example1.com"),
-            zaakInstanceId = UUID.randomUUID(),
-            documentId = documentId,
-            zaakTypeUrl = URI("http://example2.com"),
-        )
-
-        //when:
-        whenever(zaakInstanceLinkService.getByDocumentId(documentId)).thenReturn(
-            result
-        )
-
-        //then:
-        val expectedDto = ZaakInstanceLinkDTO(
-            zaakInstanceUrl = url,
-            documentId = documentId
-        )
-
-        mockMvc.perform(
-            get("/api/v1/zaakinstancelink/document?documentId=$documentId")
-                .characterEncoding(StandardCharsets.UTF_8.name())
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-        )
-            .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().is2xxSuccessful)
-            .andExpect(jsonPath("$").isNotEmpty)
-            .andExpect(
-                MockMvcResultMatchers.content().json(
-                    jacksonObjectMapper().writeValueAsString(expectedDto)
-                )
-            )
-
-    }
 }


### PR DESCRIPTION
By request from Thomas

This PR includes:
- Move endpoint '/v1/zaakinstancelink/zaak' from 'objecten-api' module to 'openzaak' module
- Move endpoint '/v1/zaakinstancelink/document' from 'objecten-api' module to 'openzaak' module
- Also move the tests