### PR TITLE
Plugin added for dependency report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id "jacoco"
     id "com.avast.gradle.docker-compose" version "${dockerComposePluginVersion}"
     id "com.github.jk1.dependency-license-report" version "${dependencyLicenseReportVersion}"
+    id "project-report"
 }
 
 /*


### PR DESCRIPTION
TP story 46399 - To let external customers have insight in the used third party dependencies of Valtimo we want to publish an HTML dependency report to an S3 bucket