### PR TITLE
feat: 47087 interfacing with Notificaties API

### DIFF
--- a/plugin/src/main/kotlin/com/ritense/plugin/PluginFactory.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/PluginFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Ritense BV, the Netherlands.
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,19 +26,20 @@ import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.domain.PluginProperty
 import com.ritense.plugin.service.PluginService
 import java.util.UUID
-import org.apache.commons.lang3.reflect.FieldUtils
 import kotlin.reflect.KClass
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaType
+import org.apache.commons.lang3.reflect.FieldUtils
 
 /**
  *  This factory is meant to be extended for a specific type of plugin. It can create a plugin of type T given a
  *  configuration. The class extending this factory has to be registered as a bean of type PluginFactory<T>.
  */
 abstract class PluginFactory<T : Any>(
-    var pluginService: PluginService
+    var pluginService: PluginService,
 ) {
     private var fullyQualifiedClassName: String = ""
+    lateinit var pluginConfigurationId: PluginConfigurationId
 
     /**
      * Create the base plugin instance, without any additional plugin properties.
@@ -54,6 +55,7 @@ abstract class PluginFactory<T : Any>(
      * @return plugin instance of type T
      */
     fun create(configuration: PluginConfiguration): T {
+        pluginConfigurationId = configuration.id
         val instance = create()
 
         injectProperties(instance, configuration)
@@ -108,7 +110,8 @@ abstract class PluginFactory<T : Any>(
 
             pluginService.createInstance(pluginConfigurationId)
         } else if (propertyType.typeParameters.isNotEmpty()) {
-            val propertyTypeWithGeneric = getPropertyTypeWithGeneric(instance::class, propertyDefinition.fieldName, mapper)
+            val propertyTypeWithGeneric =
+                getPropertyTypeWithGeneric(instance::class, propertyDefinition.fieldName, mapper)
             assert(propertyType == propertyTypeWithGeneric.rawClass)
             mapper.treeToValue(
                 configuredProperty,

--- a/zgw/notificaties-api/build.gradle
+++ b/zgw/notificaties-api/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     //test
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation "org.junit.jupiter:junit-jupiter"
-    testImplementation "org.springframework.boot:spring-boot-starter-webflux"
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testImplementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${mockitoKotlinVersion}"

--- a/zgw/notificaties-api/build.gradle
+++ b/zgw/notificaties-api/build.gradle
@@ -22,22 +22,28 @@ dockerCompose {
 }
 
 dependencies {
+    implementation project(':contract')
     implementation project(':plugin')
     implementation project(':openzaak')
 
-    implementation "io.github.microutils:kotlin-logging:${kotlinLoggingVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-webflux"
     implementation "org.springframework.boot:spring-boot-starter-security"
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    implementation "org.springframework.boot:spring-boot-starter-webflux"
+    implementation "io.github.microutils:kotlin-logging:${kotlinLoggingVersion}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion"
 
-    testImplementation project(":contract")
-
+    //test
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation "org.junit.jupiter:junit-jupiter"
-    testImplementation "org.springframework.boot:spring-boot-starter-test"
+    testImplementation "org.springframework.boot:spring-boot-starter-webflux"
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
     testImplementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
-    //Kotlin
     testImplementation "org.mockito.kotlin:mockito-kotlin:${mockitoKotlinVersion}"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
+
+
 
     jar {
         enabled = true

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPlugin.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPlugin.kt
@@ -21,7 +21,7 @@ import com.ritense.notificatiesapi.domain.Abonnement
 import com.ritense.notificatiesapi.domain.Kanaal
 import com.ritense.notificatiesapi.domain.NotificatiesApiAbonnementLink
 import com.ritense.notificatiesapi.domain.NotificatiesApiConfigurationId
-import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
+import com.ritense.notificatiesapi.repository.NotificatiesApiAbonnementLinkRepository
 import com.ritense.plugin.annotation.Plugin
 import com.ritense.plugin.annotation.PluginProperty
 import com.ritense.plugin.domain.PluginConfigurationId
@@ -39,7 +39,7 @@ import mu.KotlinLogging
 )
 class NotificatiesApiPlugin(
     private val client: NotificatiesApiClient,
-    private val abonnementLinkRepository: AbonnementLinkRepository
+    private val abonnementLinkRepository: NotificatiesApiAbonnementLinkRepository
 ) {
     @PluginProperty(key = "url", secret = false)
     lateinit var url: URI

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPlugin.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPlugin.kt
@@ -16,19 +16,105 @@
 
 package com.ritense.notificatiesapi
 
+import com.ritense.notificatiesapi.client.NotificatiesApiClient
+import com.ritense.notificatiesapi.domain.Abonnement
+import com.ritense.notificatiesapi.domain.Kanaal
+import com.ritense.notificatiesapi.domain.NotificatiesApiAbonnementLink
+import com.ritense.notificatiesapi.domain.NotificatiesApiConfigurationId
+import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
 import com.ritense.plugin.annotation.Plugin
 import com.ritense.plugin.annotation.PluginProperty
+import com.ritense.plugin.domain.PluginConfigurationId
 import java.net.URI
+import java.security.SecureRandom
+import java.util.Base64
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
 
 @Plugin(
     key = "notificatiesapi",
     title = "Notificaties API",
     description = "Enable interfacing with Notificaties API specification compliant APIs"
 )
-class NotificatiesApiPlugin {
+class NotificatiesApiPlugin(
+    private val client: NotificatiesApiClient,
+    private val abonnementLinkRepository: AbonnementLinkRepository
+) {
     @PluginProperty(key = "url", secret = false)
     lateinit var url: URI
 
     @PluginProperty(key = "authenticationPluginConfiguration", secret = false)
     lateinit var authenticationPluginConfiguration: NotificatiesApiAuthentication
+
+    fun createAbonnement(
+        pluginConfigurationId: PluginConfigurationId,
+        callbackUrl: String,
+        kanaalNames: Set<String> = DEFAULT_KANALEN_NAMES
+    ) {
+        ensureKanalenExist(kanaalNames)
+        runBlocking {
+            client.createAbonnement(
+                authenticationPluginConfiguration,
+                url,
+                Abonnement(
+                    callbackUrl = callbackUrl,
+                    auth = createRandomKey(),
+                    url = url.toASCIIString(),
+                    kanalen = kanaalNames.map { Abonnement.Kanaal(naam = it) }
+                )
+            )
+        }.let {
+            abonnementLinkRepository.save(
+                NotificatiesApiAbonnementLink(
+                    pluginConfigurationId = pluginConfigurationId,
+                    url = it.url!!,
+                    auth = it.auth
+                )
+            )
+        }
+    }
+
+    fun deleteAbonnement(pluginConfigurationId: PluginConfigurationId) {
+        val pluginId = NotificatiesApiConfigurationId(pluginConfigurationId.id)
+
+        abonnementLinkRepository.findById(pluginId)
+            .ifPresent {
+                try {
+                    runBlocking {
+                        client.deleteAbonnement(
+                            authenticationPluginConfiguration,
+                            url,
+                            it.url.substringAfterLast("/")
+                        )
+                    }
+                } catch (e: Exception) {
+                    logger.warn(e) { "Abonnement could not be deleted in Notificaties API" }
+                }
+                abonnementLinkRepository.deleteById(pluginId)
+            }
+    }
+
+    fun ensureKanalenExist(kanalen: Set<String>): Unit = runBlocking {
+        val existingKanalen = client.getKanalen(authenticationPluginConfiguration, url).map { kanaal -> kanaal.naam }
+
+        kanalen
+            .filter { !existingKanalen.contains(it) }
+            .forEach { kanaalNaam ->
+                launch { client.createKanaal(authenticationPluginConfiguration, url, Kanaal(naam = kanaalNaam)) }
+            }
+    }
+
+
+    private fun createRandomKey(): String {
+        val random = SecureRandom()
+        val bytes = ByteArray(32)
+        random.nextBytes(bytes)
+        return Base64.getEncoder().encodeToString(bytes)
+    }
+
+    companion object {
+        val DEFAULT_KANALEN_NAMES = setOf("objecten")
+        val logger = KotlinLogging.logger {}
+    }
 }

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPlugin.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPlugin.kt
@@ -79,7 +79,7 @@ class NotificatiesApiPlugin(
         val pluginId = NotificatiesApiConfigurationId(pluginConfigurationId.id)
 
         abonnementLinkRepository.findById(pluginId)
-            .ifPresent {
+            .ifPresentOrElse({
                 try {
                     runBlocking {
                         client.deleteAbonnement(
@@ -92,6 +92,12 @@ class NotificatiesApiPlugin(
                     logger.warn(e) { "Abonnement could not be deleted in Notificaties API" }
                 }
                 abonnementLinkRepository.deleteById(pluginId)
+            }
+            ) {
+                logger.warn {
+                    "Abonnement link was not found in the NotificatiesApiAbonnementLinkRepository" +
+                        "for plugin configuration with id: $pluginConfigurationId"
+                }
             }
     }
 

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactory.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactory.kt
@@ -29,6 +29,7 @@ class NotificatiesApiPluginFactory(
 ) : PluginFactory<NotificatiesApiPlugin>(pluginService) {
 
     override fun create(): NotificatiesApiPlugin {
-        return NotificatiesApiPlugin(client, abonnementLinkRepository)
+        val pluginConfigurationId = super.pluginConfigurationId
+        return NotificatiesApiPlugin(pluginConfigurationId, client, abonnementLinkRepository)
     }
 }

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactory.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactory.kt
@@ -18,14 +18,14 @@
 package com.ritense.notificatiesapi
 
 import com.ritense.notificatiesapi.client.NotificatiesApiClient
-import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
+import com.ritense.notificatiesapi.repository.NotificatiesApiAbonnementLinkRepository
 import com.ritense.plugin.PluginFactory
 import com.ritense.plugin.service.PluginService
 
 class NotificatiesApiPluginFactory(
     pluginService: PluginService,
     private val client: NotificatiesApiClient,
-    private val abonnementLinkRepository: AbonnementLinkRepository
+    private val abonnementLinkRepository: NotificatiesApiAbonnementLinkRepository
 ) : PluginFactory<NotificatiesApiPlugin>(pluginService) {
 
     override fun create(): NotificatiesApiPlugin {

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactory.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactory.kt
@@ -17,14 +17,18 @@
 
 package com.ritense.notificatiesapi
 
+import com.ritense.notificatiesapi.client.NotificatiesApiClient
+import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
 import com.ritense.plugin.PluginFactory
 import com.ritense.plugin.service.PluginService
 
 class NotificatiesApiPluginFactory(
-    pluginService: PluginService
+    pluginService: PluginService,
+    private val client: NotificatiesApiClient,
+    private val abonnementLinkRepository: AbonnementLinkRepository
 ) : PluginFactory<NotificatiesApiPlugin>(pluginService) {
 
     override fun create(): NotificatiesApiPlugin {
-        return NotificatiesApiPlugin()
+        return NotificatiesApiPlugin(client, abonnementLinkRepository)
     }
 }

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/autoconfigure/NotificatiesApiAutoConfiguration.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/autoconfigure/NotificatiesApiAutoConfiguration.kt
@@ -1,23 +1,24 @@
 /*
-* Copyright 2015-2022 Ritense BV, the Netherlands.
-*
-* Licensed under EUPL, Version 1.2 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" basis,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package com.ritense.notificatiesapi
+package com.ritense.notificatiesapi.autoconfigure
 
+import com.ritense.notificatiesapi.NotificatiesApiPluginFactory
 import com.ritense.notificatiesapi.client.NotificatiesApiClient
-import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
+import com.ritense.notificatiesapi.repository.NotificatiesApiAbonnementLinkRepository
 import com.ritense.plugin.repository.PluginConfigurationRepository
 import com.ritense.plugin.service.PluginService
 import io.netty.handler.logging.LogLevel
@@ -47,7 +48,7 @@ class NotificatiesApiAutoConfiguration {
         pluginService: PluginService,
         pluginConfigurationRepository: PluginConfigurationRepository,
         client: NotificatiesApiClient,
-        abonnementLinkRepository: AbonnementLinkRepository
+        abonnementLinkRepository: NotificatiesApiAbonnementLinkRepository
     ): NotificatiesApiPluginFactory {
         return NotificatiesApiPluginFactory(
             pluginService,

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/autoconfigure/NotificatiesApiLiquibaseAutoConfiguration.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/autoconfigure/NotificatiesApiLiquibaseAutoConfiguration.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.autoconfigure
+
+import com.ritense.valtimo.contract.config.LiquibaseMasterChangeLogLocation
+import javax.sql.DataSource
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+
+@Configuration
+@ConditionalOnClass(DataSource::class)
+class NotificatiesApiLiquibaseAutoConfiguration {
+
+    @Order(Ordered.HIGHEST_PRECEDENCE + 12)
+    @Bean
+    fun notificatiesApiLiquibaseChangeLogLocation(): LiquibaseMasterChangeLogLocation {
+        return LiquibaseMasterChangeLogLocation("config/liquibase/notificaties-api-master.xml")
+    }
+}

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/autoconfigure/NotificatiesApiLiquibaseAutoConfiguration.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/autoconfigure/NotificatiesApiLiquibaseAutoConfiguration.kt
@@ -28,7 +28,7 @@ import org.springframework.core.annotation.Order
 @ConditionalOnClass(DataSource::class)
 class NotificatiesApiLiquibaseAutoConfiguration {
 
-    @Order(Ordered.HIGHEST_PRECEDENCE + 12)
+    @Order(Ordered.HIGHEST_PRECEDENCE + 25)
     @Bean
     fun notificatiesApiLiquibaseChangeLogLocation(): LiquibaseMasterChangeLogLocation {
         return LiquibaseMasterChangeLogLocation("config/liquibase/notificaties-api-master.xml")

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClient.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClient.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.client
+
+import com.ritense.notificatiesapi.NotificatiesApiAuthentication
+import com.ritense.notificatiesapi.domain.Abonnement
+import com.ritense.notificatiesapi.domain.Kanaal
+import java.net.URI
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBodilessEntity
+import org.springframework.web.reactive.function.client.awaitBody
+
+
+class NotificatiesApiClient(
+    private val webclient: WebClient
+) {
+
+    internal suspend fun createAbonnement(
+        authentication: NotificatiesApiAuthentication,
+        baseUrl: URI,
+        abonnement: Abonnement
+    ): Abonnement {
+
+        return buildNotificatiesWebClient(authentication, baseUrl)
+            .post()
+            .uri("/api/v1/abonnement")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(abonnement)
+            .retrieve()
+            .awaitBody()
+    }
+
+    internal suspend fun deleteAbonnement(
+        authentication: NotificatiesApiAuthentication,
+        baseUrl: URI,
+        abonnementId: String
+    ) {
+
+        buildNotificatiesWebClient(authentication, baseUrl)
+            .delete()
+            .uri("/api/v1/abonnement/$abonnementId")
+            .retrieve()
+            .awaitBodilessEntity()
+    }
+
+    internal suspend fun createKanaal(authentication: NotificatiesApiAuthentication, baseUrl: URI, kanaal: Kanaal): Kanaal {
+        return buildNotificatiesWebClient(authentication, baseUrl)
+            .post()
+            .uri("/api/v1/kanaal")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(kanaal)
+            .retrieve()
+            .awaitBody()
+    }
+
+    internal suspend fun getKanalen(authentication: NotificatiesApiAuthentication, baseUrl: URI): List<Kanaal> {
+        return buildNotificatiesWebClient(authentication, baseUrl)
+            .get()
+            .uri("/api/v1/kanaal")
+            .retrieve()
+            .awaitBody()
+    }
+
+    private fun buildNotificatiesWebClient(authentication: NotificatiesApiAuthentication, baseUrl: URI): WebClient =
+        webclient
+            .mutate()
+            .filter(authentication)
+            .baseUrl(baseUrl.toASCIIString())
+            .build()
+}

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/Abonnement.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/Abonnement.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.domain
+
+data class Abonnement(
+    val url: String?,
+    val callbackUrl: String,
+    val auth: String,
+    val kanalen: List<Kanaal> = listOf(),
+) {
+    data class Kanaal(
+        val filters: Map<String, String> = mapOf(),
+        val naam: String
+    )
+}

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/Kanaal.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/Kanaal.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.domain
+
+data class Kanaal(
+    val url: String? = null,
+    val naam: String,
+    val documentatieLink: String? = null,
+    val filters: List<String> = listOf(),
+)

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/NotificatiesApiAbonnementLink.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/NotificatiesApiAbonnementLink.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.domain
+
+import com.ritense.plugin.domain.PluginConfigurationId
+import javax.persistence.Column
+import javax.persistence.EmbeddedId
+import javax.persistence.Entity
+import javax.persistence.Table
+
+@Entity
+@Table(name = "notificaties_api_abonnement_link")
+class NotificatiesApiAbonnementLink(
+    @EmbeddedId
+    val pluginConfigurationId: PluginConfigurationId,
+
+    @Column(name = "abonnement_url")
+    val url: String,
+
+    @Column(name = "abonnement_auth_key")
+    val auth: String
+)

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/NotificatiesApiConfigurationId.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/NotificatiesApiConfigurationId.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.domain
+
+import com.fasterxml.jackson.annotation.JsonValue
+import com.ritense.plugin.domain.PluginConfigurationId
+import com.ritense.valtimo.contract.domain.AbstractId
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class NotificatiesApiConfigurationId(
+    @Column(name = "plugin_configuration_id")
+    @JsonValue
+    val id: UUID
+): AbstractId<PluginConfigurationId>(){
+
+    companion object {
+
+        fun existingId(id: UUID): PluginConfigurationId {
+            return PluginConfigurationId(id)
+        }
+
+        fun newId(): PluginConfigurationId {
+            return PluginConfigurationId(UUID.randomUUID()).newIdentity()
+        }
+    }
+}

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/repository/AbonnementLinkRepository.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/repository/AbonnementLinkRepository.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.repository
+
+import com.ritense.notificatiesapi.domain.NotificatiesApiAbonnementLink
+import com.ritense.notificatiesapi.domain.NotificatiesApiConfigurationId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AbonnementLinkRepository : JpaRepository<NotificatiesApiAbonnementLink, NotificatiesApiConfigurationId>

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/repository/NotificatiesApiAbonnementLinkRepository.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/repository/NotificatiesApiAbonnementLinkRepository.kt
@@ -20,4 +20,4 @@ import com.ritense.notificatiesapi.domain.NotificatiesApiAbonnementLink
 import com.ritense.notificatiesapi.domain.NotificatiesApiConfigurationId
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface AbonnementLinkRepository : JpaRepository<NotificatiesApiAbonnementLink, NotificatiesApiConfigurationId>
+interface NotificatiesApiAbonnementLinkRepository : JpaRepository<NotificatiesApiAbonnementLink, NotificatiesApiConfigurationId>

--- a/zgw/notificaties-api/src/main/resources/META-INF/spring.factories
+++ b/zgw/notificaties-api/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.ritense.notificatiesapi.NotificatiesApiAutoConfiguration, \
+  com.ritense.notificatiesapi.autoconfigure.NotificatiesApiAutoConfiguration, \
   com.ritense.notificatiesapi.autoconfigure.NotificatiesApiLiquibaseAutoConfiguration

--- a/zgw/notificaties-api/src/main/resources/META-INF/spring.factories
+++ b/zgw/notificaties-api/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.ritense.notificatiesapi.NotificatiesApiAutoConfiguration
+  com.ritense.notificatiesapi.NotificatiesApiAutoConfiguration, \
+  com.ritense.notificatiesapi.autoconfigure.NotificatiesApiLiquibaseAutoConfiguration

--- a/zgw/notificaties-api/src/main/resources/config/liquibase/changelog/20230105-add-notificaties-api-abonnement-link-table.xml
+++ b/zgw/notificaties-api/src/main/resources/config/liquibase/changelog/20230105-add-notificaties-api-abonnement-link-table.xml
@@ -1,0 +1,35 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2015-2023 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+    <changeSet id="1" author="Ritense">
+        <createTable tableName="notificaties_api_abonnement_link">
+            <column name="plugin_configuration_id" type="${uuidType}">
+                <constraints  primaryKey="true" nullable="false"/>
+            </column>
+            <column name="abonnement_url" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="abonnement_auth_key" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/zgw/notificaties-api/src/main/resources/config/liquibase/notificaties-api-master.xml
+++ b/zgw/notificaties-api/src/main/resources/config/liquibase/notificaties-api-master.xml
@@ -1,0 +1,28 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2015-2023 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <property name="uuidType" value="BINARY(16)" dbms="mysql"/>
+    <property name="uuidType" value="uuid" dbms="h2,postgresql"/>
+
+    <include file="changelog/20230105-add-notificaties-api-abonnement-link-table.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactoryTest.kt
+++ b/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactoryTest.kt
@@ -17,6 +17,8 @@
 package com.ritense.notificatiesapi
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ritense.notificatiesapi.client.NotificatiesApiClient
+import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
 import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.domain.PluginDefinition
@@ -33,10 +35,15 @@ internal class NotificatiesApiPluginFactoryTest {
     @Test
     fun `should create NotificatiesApiPlugin`() {
         val pluginService = mock<PluginService>()
+        val client = mock<NotificatiesApiClient>()
+        val abonnementLinkRepository = mock<AbonnementLinkRepository>()
+
         whenever(pluginService.getObjectMapper()).thenReturn(jacksonObjectMapper())
 
         val factory = NotificatiesApiPluginFactory(
-            pluginService
+            pluginService,
+            client,
+            abonnementLinkRepository
         )
 
         val notificatiesApiPluginProperties: String = """

--- a/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactoryTest.kt
+++ b/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginFactoryTest.kt
@@ -18,7 +18,7 @@ package com.ritense.notificatiesapi
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ritense.notificatiesapi.client.NotificatiesApiClient
-import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
+import com.ritense.notificatiesapi.repository.NotificatiesApiAbonnementLinkRepository
 import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.domain.PluginDefinition
@@ -36,7 +36,7 @@ internal class NotificatiesApiPluginFactoryTest {
     fun `should create NotificatiesApiPlugin`() {
         val pluginService = mock<PluginService>()
         val client = mock<NotificatiesApiClient>()
-        val abonnementLinkRepository = mock<AbonnementLinkRepository>()
+        val abonnementLinkRepository = mock<NotificatiesApiAbonnementLinkRepository>()
 
         whenever(pluginService.getObjectMapper()).thenReturn(jacksonObjectMapper())
 

--- a/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginTest.kt
+++ b/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginTest.kt
@@ -21,7 +21,7 @@ import com.ritense.notificatiesapi.domain.Abonnement
 import com.ritense.notificatiesapi.domain.Kanaal
 import com.ritense.notificatiesapi.domain.NotificatiesApiAbonnementLink
 import com.ritense.notificatiesapi.domain.NotificatiesApiConfigurationId
-import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
+import com.ritense.notificatiesapi.repository.NotificatiesApiAbonnementLinkRepository
 import com.ritense.plugin.domain.PluginConfigurationId
 import java.net.URI
 import java.util.Optional
@@ -42,7 +42,7 @@ import org.mockito.kotlin.whenever
 
 internal class NotificatiesApiPluginTest {
     lateinit var notificatiesApiClient: NotificatiesApiClient
-    lateinit var abonnementLinkRepository: AbonnementLinkRepository
+    lateinit var abonnementLinkRepository: NotificatiesApiAbonnementLinkRepository
     lateinit var plugin: NotificatiesApiPlugin
 
     @BeforeEach

--- a/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginTest.kt
+++ b/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/NotificatiesApiPluginTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2015-2022 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi
+
+import com.ritense.notificatiesapi.client.NotificatiesApiClient
+import com.ritense.notificatiesapi.domain.Abonnement
+import com.ritense.notificatiesapi.domain.Kanaal
+import com.ritense.notificatiesapi.domain.NotificatiesApiAbonnementLink
+import com.ritense.notificatiesapi.domain.NotificatiesApiConfigurationId
+import com.ritense.notificatiesapi.repository.AbonnementLinkRepository
+import com.ritense.plugin.domain.PluginConfigurationId
+import java.net.URI
+import java.util.Optional
+import java.util.UUID
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+
+internal class NotificatiesApiPluginTest {
+    lateinit var notificatiesApiClient: NotificatiesApiClient
+    lateinit var abonnementLinkRepository: AbonnementLinkRepository
+    lateinit var plugin: NotificatiesApiPlugin
+
+    @BeforeEach
+    fun setup() {
+        notificatiesApiClient = mock()
+        abonnementLinkRepository = mock()
+
+        plugin = NotificatiesApiPlugin(notificatiesApiClient, abonnementLinkRepository)
+            .apply {
+                url = URI("http://example.com")
+                authenticationPluginConfiguration = mock()
+            }
+    }
+
+
+    @Test
+    fun `ensure kanaal exists creates kanaal when kanaal doesnt exist`(): Unit = runBlocking {
+        whenever(notificatiesApiClient.getKanalen(any(), any()))
+            .thenReturn(
+                listOf(
+                    Kanaal(naam = "objecten")
+                )
+            )
+
+        plugin.ensureKanalenExist(setOf("objecten", "taken", "test-kanaal"))
+
+        verify(notificatiesApiClient, times(1)).getKanalen(any(), any())
+        verify(notificatiesApiClient, times(2)).createKanaal(any(), any(), any())
+    }
+
+    @Test
+    fun `ensure kanaal exists doesnt create kanaal when kanaal exists`(): Unit = runBlocking {
+
+        whenever(notificatiesApiClient.getKanalen(any(), any()))
+            .thenReturn(
+                listOf(
+                    Kanaal(naam = "objecten"),
+                    Kanaal(naam = "test-kanaal"),
+                    Kanaal(naam = "taken")
+                )
+            )
+
+        plugin.ensureKanalenExist(setOf("objecten", "taken", "test-kanaal"))
+
+        verify(notificatiesApiClient, times(1)).getKanalen(any(), any())
+        verify(notificatiesApiClient, never()).createKanaal(any(), any(), any())
+    }
+
+    @Test
+    fun `createAbonnement should create abonnement and save entity`(): Unit = runBlocking {
+        val pluginId = PluginConfigurationId(UUID.randomUUID())
+        val abonnementId = UUID.randomUUID()
+        val abonnement = Abonnement(
+            url = "http://example.com/abonnement/$abonnementId",
+            callbackUrl = "http://example.com/callback",
+            auth = "some-key",
+            kanalen = listOf(
+                Abonnement.Kanaal(
+                    naam = "test-kanaal"
+                )
+            )
+        )
+        val linkCaptor = ArgumentCaptor.forClass(NotificatiesApiAbonnementLink::class.java)
+
+        whenever(notificatiesApiClient.createAbonnement(any(), any(), any()))
+            .thenReturn(abonnement)
+        whenever(notificatiesApiClient.getKanalen(any(), any()))
+            .thenReturn(
+                listOf(
+                    Kanaal(naam = "test-kanaal")
+                )
+            )
+
+        plugin.createAbonnement(
+            callbackUrl = "http://example.com/callback",
+            pluginConfigurationId = pluginId,
+            kanaalNames = setOf("test-kanaal")
+        )
+
+        verify(abonnementLinkRepository, times(1)).save(linkCaptor.capture())
+        assertContains(linkCaptor.value.url, abonnementId.toString())
+        assertEquals("some-key", linkCaptor.value.auth)
+    }
+
+    @Test
+    fun `deleteAbonnement should delete abonnement in Notificaties API and repository`() {
+        val pluginId = PluginConfigurationId(UUID.randomUUID())
+        val abonnementId = UUID.randomUUID()
+        val notificatiesApiConfigurationIdCaptor = ArgumentCaptor.forClass(NotificatiesApiConfigurationId::class.java)
+        val abonnementLink = NotificatiesApiAbonnementLink(
+            pluginConfigurationId = pluginId,
+            url = "http://example.com/abonnement/$abonnementId",
+            auth = "some-key"
+        )
+
+        whenever(abonnementLinkRepository.findById(notificatiesApiConfigurationIdCaptor.capture()))
+            .thenReturn(
+                Optional.of(abonnementLink)
+            )
+
+        plugin.deleteAbonnement(pluginConfigurationId = pluginId)
+
+        verifyBlocking(notificatiesApiClient, times(1)) {
+            deleteAbonnement(
+                plugin.authenticationPluginConfiguration, plugin.url, abonnementId.toString()
+            )
+        }
+        verify(abonnementLinkRepository, times(1)).deleteById(notificatiesApiConfigurationIdCaptor.value)
+    }
+
+    @Test
+    fun `deleteAbonnement should do nothing if abonnement link does not exist`() {
+        val pluginId = PluginConfigurationId(UUID.randomUUID())
+
+        whenever(abonnementLinkRepository.findById(any()))
+            .thenReturn(
+                Optional.empty()
+            )
+
+        plugin.deleteAbonnement(pluginConfigurationId = pluginId)
+
+        verifyBlocking(notificatiesApiClient, never()) {
+            deleteAbonnement(any(), any(), any())
+        }
+        verify(abonnementLinkRepository, never()).deleteById(any())
+    }
+}

--- a/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClientTest.kt
+++ b/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClientTest.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.notificatiesapi.client
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.ritense.notificatiesapi.NotificatiesApiAuthentication
+import com.ritense.notificatiesapi.domain.Abonnement
+import com.ritense.notificatiesapi.domain.Kanaal
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NotificatiesApiClientTest {
+    lateinit var mockNotificatiesApi: MockWebServer
+    lateinit var webClient: WebClient
+    lateinit var client: NotificatiesApiClient
+
+    @BeforeEach
+    fun setup() {
+        mockNotificatiesApi = MockWebServer()
+        mockNotificatiesApi.start()
+        webClient = WebClient.create()
+        client = NotificatiesApiClient(webClient)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockNotificatiesApi.shutdown()
+    }
+
+    @Test
+    fun `should create Kanaal in Notificaties API`() {
+
+        mockNotificatiesApi.enqueue(
+            mockResponse(
+                """
+            {
+              "url": "http://example.com/kanaal/test-kanaal",
+              "naam": "Test Kanaal",
+              "documentatieLink": "http://example.com/documentatie",
+              "filters": [
+                  "url",
+                  "someid"
+              ]
+            }
+        """.trimIndent()
+            )
+        )
+
+        val result = runBlocking {
+            client.createKanaal(
+                authentication = TestAuthentication(),
+                baseUrl = mockNotificatiesApi.url("/").toUri(),
+                kanaal = Kanaal(naam = "Test Kanaal")
+            )
+        }
+        val recordedRequest = mockNotificatiesApi.takeRequest()
+        val requestBody = jacksonObjectMapper().readValue<Map<String, Any>>(
+            recordedRequest.body.readUtf8()
+        )
+
+        assertEquals("Bearer test", recordedRequest.getHeader("Authorization"))
+        assertEquals("/api/v1/kanaal", recordedRequest.path)
+
+        assertNull(requestBody["url"])
+        assertEquals("Test Kanaal", requestBody.get("naam"))
+        assertNull(requestBody["documentatieLink"])
+        assertEquals(emptyList<String>(), requestBody["filters"])
+
+        assertEquals("http://example.com/kanaal/test-kanaal", result.url)
+        assertEquals("Test Kanaal", result.naam)
+        assertEquals("http://example.com/documentatie", result.documentatieLink)
+        assertEquals(listOf("url", "someid"), result.filters)
+
+    }
+
+    @Test
+    fun `should get Kanalen from Notificaties API`() {
+
+        mockNotificatiesApi.enqueue(
+            mockResponse(
+                """
+            [
+  {
+    "url": "http://example.com",
+    "naam": "string",
+    "documentatieLink": "http://example.com",
+    "filters": [
+      "string"
+    ]
+  },
+  {
+    "url": "http://example.com",
+    "naam": "objecten",
+    "documentatieLink": "http://example.com",
+    "filters": [
+      "objecten"
+    ]
+  }
+]
+        """.trimIndent()
+            )
+        )
+
+        val result = runBlocking {
+            client.getKanalen(
+                authentication = TestAuthentication(),
+                baseUrl = mockNotificatiesApi.url("/").toUri(),
+            )
+        }
+        val recordedRequest = mockNotificatiesApi.takeRequest()
+
+        assertEquals("Bearer test", recordedRequest.getHeader("Authorization"))
+        assertEquals("/api/v1/kanaal", recordedRequest.path)
+
+        assertEquals("http://example.com", result[0].url)
+        assertEquals("string", result[0].naam)
+        assertEquals("http://example.com", result[0].documentatieLink)
+        assertEquals(listOf("string"), result[0].filters)
+
+        assertEquals("http://example.com", result[1].url)
+        assertEquals("objecten", result[1].naam)
+        assertEquals("http://example.com", result[1].documentatieLink)
+        assertEquals(listOf("objecten"), result[1].filters)
+
+    }
+
+    @Test
+    fun `should create Abonnement in Notificaties API`() {
+
+        mockNotificatiesApi.enqueue(
+            mockResponse(
+                """
+                    {
+                      "url": "http://example.com/abonnement/test-abonnement",
+                      "callbackUrl": "http://example.com/callback",
+                      "auth": "Bearer token",
+                      "kanalen": [
+                        {
+                          "filters": {
+                            "url": "http://example.com",
+                            "someid": "1234"
+                          },
+                          "naam": "Test Kanaal"
+                        }
+                      ]
+                    }
+        """.trimIndent()
+            )
+        )
+
+        val result = runBlocking {
+            client.createAbonnement(
+                authentication = TestAuthentication(),
+                baseUrl = mockNotificatiesApi.url("/").toUri(),
+                abonnement = Abonnement(
+                    url = "http://example.com",
+                    callbackUrl = "http://example.com/callback",
+                    auth = "Bearer token",
+                    kanalen = listOf(
+                        Abonnement.Kanaal(
+                            filters = mapOf(
+                                "url" to "http://example.com",
+                                "someid" to "1234"
+                            ),
+                            naam = "Test Kanaal"
+                        )
+                    )
+                )
+            )
+        }
+        val recordedRequest = mockNotificatiesApi.takeRequest()
+        val requestBody = jacksonObjectMapper().readValue<Map<String, Any>>(
+            recordedRequest.body.readUtf8()
+        )
+
+        assertEquals("Bearer test", recordedRequest.getHeader("Authorization"))
+        assertEquals("/api/v1/abonnement", recordedRequest.path)
+
+        assertEquals("http://example.com", requestBody["url"])
+        assertEquals("http://example.com/callback", requestBody.get("callbackUrl"))
+        assertEquals("Bearer token", requestBody.get("auth"))
+        assertEquals(
+            listOf(
+                mapOf(
+                    "filters" to mapOf(
+                        "url" to "http://example.com",
+                        "someid" to "1234"
+                    ),
+                    "naam" to "Test Kanaal"
+                )
+            ), requestBody["kanalen"]
+        )
+
+        assertEquals("http://example.com/abonnement/test-abonnement", result.url)
+        assertEquals("http://example.com/callback", result.callbackUrl)
+        assertEquals("Bearer token", result.auth)
+        assertEquals("Test Kanaal", result.kanalen[0].naam)
+        assertEquals(
+            mapOf(
+                "url" to "http://example.com",
+                "someid" to "1234"
+            ), result.kanalen[0].filters
+        )
+
+    }
+
+    @Test
+    fun `should delete Abonnement from Notificaties API`() {
+        val abonnementId = UUID.randomUUID().toString()
+
+        mockNotificatiesApi.enqueue(
+            response = MockResponse().setResponseCode(204)
+        )
+
+        runBlocking {
+            client.deleteAbonnement(
+                authentication = TestAuthentication(),
+                baseUrl = mockNotificatiesApi.url("/").toUri(),
+                abonnementId = abonnementId
+            )
+        }
+        val recordedRequest = mockNotificatiesApi.takeRequest()
+
+        assertEquals("Bearer test", recordedRequest.getHeader("Authorization"))
+        assertEquals("/api/v1/abonnement/$abonnementId", recordedRequest.path)
+    }
+
+    private fun mockResponse(body: String): MockResponse {
+        return MockResponse()
+            .addHeader("Content-Type", "application/json")
+            .setBody(body)
+    }
+
+    class TestAuthentication : NotificatiesApiAuthentication {
+        override fun filter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
+            val filteredRequest = ClientRequest.from(request).headers { headers ->
+                headers.setBearerAuth("test")
+            }.build()
+            return next.exchange(filteredRequest)
+        }
+    }
+}


### PR DESCRIPTION
* adds liquibase configuration for creating new `notificaties_api_abonnement_link` table so that created subsciptions can be stored in the database
* adds client for communicating with Notificaties Api. The client implements createKanaal, getKanalen, createAbonnement and deleteAbonnement methods
* adds methods to the plugin for creating and deleting subscriptions so that other plugins can make use of Notificaties API