### PR TITLE
Fixes

### DIFF
--- a/app/gzac/src/main/java/com/ritense/gzac/listener/ApplicationReadyEventListener.kt
+++ b/app/gzac/src/main/java/com/ritense/gzac/listener/ApplicationReadyEventListener.kt
@@ -52,6 +52,7 @@ import mu.KotlinLogging
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
+import java.lang.RuntimeException
 import java.net.URI
 import java.util.UUID
 
@@ -112,7 +113,7 @@ class ApplicationReadyEventListener(
             createSmartDocumentsPlugin()
             createPortaalTaakPlugin(notificatiesApiPluginId, taakConfigurationId)
         } catch (ex: Exception) {
-            logger.error { ex }
+            throw RuntimeException("Failed to deploy plugin configurations for development", ex)
         }
     }
 
@@ -305,6 +306,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createZakenApiAuthenticationPlugin(): UUID {
+        logger.debug { "Creating OpenZaak Authentication plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "OpenZaak Authentication",
@@ -330,6 +332,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createNotificatiesApiAuthenticationPlugin(): UUID {
+        logger.debug { "Creating OpenNotificaties Authentication plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "OpenNotificaties Authentication",
@@ -358,6 +361,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createNotificatiesApiPlugin(authenticationPluginConfigurationId: UUID): UUID {
+        logger.debug { "Creating Notificaties API plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "Notificaties API",
@@ -372,6 +376,7 @@ class ApplicationReadyEventListener(
                     """
                     {
                         "url": "http://localhost:8002/api/v1/",
+                        "callbackUrl": "http://host.docker.internal:8080/api/v1/notificatiesapi/callback",
                         "authenticationPluginConfiguration": "$authenticationPluginConfigurationId"
                     }
                     """
@@ -383,6 +388,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createObjectenApiAuthenticationPlugin(): UUID {
+        logger.debug { "Creating Objecten API Authentication plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "Objecten API Authentication",
@@ -407,6 +413,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createObjectenApiPlugin(authenticationPluginConfigurationId: UUID): UUID {
+        logger.debug { "Creating Objecten API plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "Objecten API",
@@ -432,6 +439,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createObjecttypenApiPlugin(authenticationPluginConfigurationId: UUID): UUID {
+        logger.debug { "Creating Objecttypen API plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "Objecttypen API",
@@ -457,6 +465,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createZakenApiPlugin(authenticationPluginConfigurationId: UUID): UUID {
+        logger.debug { "Creating Zaken API plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "Zaken API",
@@ -482,6 +491,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createCatalogiApiPlugin(authenticationPluginConfigurationId: UUID): UUID {
+        logger.debug { "Creating Catalogi API plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "Catalogi API",
@@ -507,6 +517,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createVerzoekPlugin(notificatiesApiPluginConfiguration: UUID, objectManagementId: UUID): UUID {
+        logger.debug { "Creating Verzoek lening plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "Verzoek lening",
@@ -541,6 +552,7 @@ class ApplicationReadyEventListener(
     }
 
     private fun createSmartDocumentsPlugin(): UUID {
+        logger.debug { "Creating SmartDocuments plugin" }
         val existing = pluginService.getPluginConfigurations(
             PluginConfigurationSearchParameters(
                 pluginConfigurationTitle = "SmartDocuments",

--- a/plugin/src/main/kotlin/com/ritense/plugin/web/rest/PluginConfigurationResource.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/web/rest/PluginConfigurationResource.kt
@@ -55,7 +55,7 @@ class PluginConfigurationResource(
                     pluginDefinitionKey = pluginDefinitionKey,
                     pluginConfigurationTitle = pluginConfigurationTitle,
                     category = category,
-                    activityType = (activityType?:ActivityType.SERVICE_TASK).mapOldActivityTypeToCurrent()
+                    activityType = activityType?.mapOldActivityTypeToCurrent()
                 )
             )
             .map { PluginConfigurationDto(it) })

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/web/rest/NotificatiesApiResource.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/web/rest/NotificatiesApiResource.kt
@@ -39,6 +39,9 @@ class NotificatiesApiResource(
         @RequestHeader("Authorization") authHeader: String?
     ): ResponseEntity<Void> {
         return if (authHeader != null) {
+            if (notification.kanaal == "test") {
+                return ResponseEntity.noContent().build()
+            }
             try {
                 notificatiesApiService.findAbonnementSubscription(authHeader)
                 notificatiesApiService.handle(notification)


### PR DESCRIPTION
- Fix: `GET /v1/plugin/configuration` didn't return all plugin configurations
- Fix: Notificaties API plugin configuration for local development. By adding 'callbackUrl'
- Fix: Creating the Notificaties API plugin configuration. Didn't work because the plugin tries to create an abonnement. And while creating the abonnement, it tests the 'callbackUrl' using a kanaal called 'test'.
- Some logging