### PR TITLE
Fix integration tests

### DIFF
--- a/zgw/object-management/build.gradle
+++ b/zgw/object-management/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation project(":core")
     testImplementation project(":resource:local-resource")
     testImplementation project(":test-utils-common")
+    testImplementation project(":zgw:catalogi-api")
     testImplementation project(':zgw:zaken-api')
 
     testImplementation "org.jetbrains.kotlin:kotlin-test"

--- a/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/BaseIntegrationTest.kt
+++ b/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/BaseIntegrationTest.kt
@@ -16,10 +16,12 @@
 
 package com.ritense.objectmanagement
 
+import com.ritense.catalogiapi.service.ZaaktypeUrlProvider
 import com.ritense.testutilscommon.junit.extension.LiquibaseRunnerExtension
 import com.ritense.valtimo.contract.authentication.UserManagementService
 import com.ritense.valtimo.contract.mail.MailSender
 import com.ritense.zakenapi.ResourceProvider
+import com.ritense.zakenapi.ZaakUrlProvider
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
@@ -39,4 +41,10 @@ abstract class BaseIntegrationTest {
 
     @MockBean
     lateinit var mailSender: MailSender
+
+    @MockBean
+    lateinit var zaaktypeUrlProvider: ZaaktypeUrlProvider
+
+    @MockBean
+    lateinit var zaakUrlProvider: ZaakUrlProvider
 }


### PR DESCRIPTION
```

ObjectManagementServiceIntTest > initializationError FAILED
    java.lang.IllegalStateException at DefaultCacheAwareContextLoaderDelegate.java:98
        Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException at ConstructorResolver.java:800
            Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException at DefaultListableBeanFactory.java:1801

```