### PR TITLE
GET /roltype should respond with empty list

### DIFF
--- a/openzaak/src/main/kotlin/com/ritense/openzaak/plugin/OpenZaakUrlProvider.kt
+++ b/openzaak/src/main/kotlin/com/ritense/openzaak/plugin/OpenZaakUrlProvider.kt
@@ -17,6 +17,7 @@
 package com.ritense.openzaak.plugin
 
 import com.ritense.catalogiapi.service.ZaaktypeUrlProvider
+import com.ritense.catalogiapi.exception.ZaakTypeLinkNotFoundException
 import com.ritense.openzaak.service.ZaakTypeLinkService
 import com.ritense.openzaak.service.impl.ZaakInstanceLinkService
 import com.ritense.zakenapi.ZaakUrlProvider
@@ -33,17 +34,13 @@ class OpenZaakUrlProvider(
 
     override fun getZaaktypeUrl(documentDefinitionName: String): URI {
         val zaakTypeLink = zaakTypeLinkService.get(documentDefinitionName)
-        requireNotNull(zaakTypeLink) {
-            "No zaak type was found for document definition with name $documentDefinitionName"
-        }
+            ?: throw ZaakTypeLinkNotFoundException("For document definition with name $documentDefinitionName")
         return zaakTypeLink.zaakTypeUrl
     }
 
     override fun getZaaktypeUrlByCaseDefinitionName(caseDefinitionName: String): URI {
         val zaakTypeLink = zaakTypeLinkService.get(caseDefinitionName)
-        requireNotNull(zaakTypeLink) {
-            "No zaak type was found for case definition with name $caseDefinitionName"
-        }
+            ?: throw ZaakTypeLinkNotFoundException("For case definition with name $caseDefinitionName")
         return zaakTypeLink.zaakTypeUrl
     }
 }

--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/exception/ZaakTypeLinkNotFoundException.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/exception/ZaakTypeLinkNotFoundException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.catalogiapi.exception
+
+class ZaakTypeLinkNotFoundException(message: String) : RuntimeException("No zaak type was found. $message")

--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/service/CatalogiService.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/service/CatalogiService.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.ritense.catalogiapi.CatalogiApiPlugin
 import com.ritense.catalogiapi.domain.Informatieobjecttype
 import com.ritense.catalogiapi.domain.Roltype
+import com.ritense.catalogiapi.exception.ZaakTypeLinkNotFoundException
 import com.ritense.plugin.service.PluginService
 import mu.KotlinLogging
 import java.net.URI
@@ -38,8 +39,12 @@ class CatalogiService(
     }
     fun getRoltypes(caseDefinitionName: String): List<Roltype> {
         logger.debug { "Getting roltypes for case definition $caseDefinitionName" }
-        val zaakTypeUrl = zaaktypeUrlProvider.getZaaktypeUrlByCaseDefinitionName(caseDefinitionName)
-
+        val zaakTypeUrl = try {
+            zaaktypeUrlProvider.getZaaktypeUrlByCaseDefinitionName(caseDefinitionName)
+        } catch (e: ZaakTypeLinkNotFoundException) {
+            logger.debug { e }
+            return emptyList()
+        }
         val catalogiApiPluginInstance = findCatalogiApiPlugin(zaakTypeUrl)
 
         return catalogiApiPluginInstance.getRoltypes(zaakTypeUrl)


### PR DESCRIPTION
Many case definitions don't have a zaak-type-link. If so, the endpoint /roltype should respond with an empty list.
