### PR TITLE
Fix RC: Make ObjectManagementInfoProvider optional

### DIFF
--- a/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/ObjectenApiAutoConfiguration.kt
+++ b/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/ObjectenApiAutoConfiguration.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.form.service.FormDefinitionService
 import com.ritense.objectenapi.client.ObjectenApiClient
 import com.ritense.objectenapi.listener.ZaakObjectListener
+import com.ritense.objectenapi.management.ErrorObjectManagementInfoProvider
 import com.ritense.objectenapi.security.ObjectenApiHttpSecurityConfigurer
 import com.ritense.objectenapi.service.ZaakObjectDataResolver
 import com.ritense.objectenapi.service.ZaakObjectService
@@ -30,6 +31,7 @@ import com.ritense.zakenapi.ZaakUrlProvider
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.web.reactive.function.client.WebClient
 
@@ -94,5 +96,12 @@ class ObjectenApiAutoConfiguration {
     @ConditionalOnMissingBean(ObjectResource::class)
     fun objectResource(zaakObjectService: ZaakObjectService): ObjectResource {
         return ObjectResource(zaakObjectService)
+    }
+
+    @Order(Ordered.LOWEST_PRECEDENCE)
+    @Bean
+    @ConditionalOnMissingBean(ObjectManagementInfoProvider::class)
+    fun errorObjectManagementInfoProvider(): ObjectManagementInfoProvider {
+        return ErrorObjectManagementInfoProvider()
     }
 }

--- a/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/management/ErrorObjectManagementInfoProvider.kt
+++ b/zgw/objecten-api/src/main/kotlin/com/ritense/objectenapi/management/ErrorObjectManagementInfoProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.objectenapi.management
+
+import java.util.UUID
+
+class ErrorObjectManagementInfoProvider : ObjectManagementInfoProvider {
+
+    override fun getObjectManagementInfo(objectManagementId: UUID): ObjectManagementInfo {
+        throw RuntimeException("No objectManagementInfo available. Consider importing 'com.ritense.valtimo:object-management'.")
+    }
+}


### PR DESCRIPTION
Hari got this error after trying the new RC
```
Parameter 3 of method zaakObjectService in com.ritense.objectenapi.ObjectenApiAutoConfiguration required a bean of type 'com.ritense.objectenapi.management.ObjectManagementInfoProvider' that could not be found.
```