### PR TITLE
Bugfix: fix error specified key was too long

### DIFF
--- a/form-link/src/main/java/com/ritense/formlink/autoconfigure/FormLinkAutoConfiguration.java
+++ b/form-link/src/main/java/com/ritense/formlink/autoconfigure/FormLinkAutoConfiguration.java
@@ -47,6 +47,7 @@ import com.ritense.valtimo.service.CamundaProcessService;
 import com.ritense.valtimo.service.CamundaTaskService;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.TaskService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -180,9 +181,10 @@ public class FormLinkAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(ProcessFormAssociationRepository.class)
     public JdbcProcessFormAssociationRepository processFormAssociationRepository(
-        final NamedParameterJdbcTemplate namedParameterJdbcTemplate
+        final NamedParameterJdbcTemplate namedParameterJdbcTemplate,
+        final @Value("${valtimo.database:mysql}") String valtimoDatabase
     ) {
-        return new JdbcProcessFormAssociationRepository(namedParameterJdbcTemplate);
+        return new JdbcProcessFormAssociationRepository(namedParameterJdbcTemplate, valtimoDatabase);
     }
 
 }

--- a/form-link/src/main/java/com/ritense/formlink/service/impl/CamundaFormAssociationSubmissionService.java
+++ b/form-link/src/main/java/com/ritense/formlink/service/impl/CamundaFormAssociationSubmissionService.java
@@ -40,8 +40,8 @@ import com.ritense.valtimo.service.CamundaTaskService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.UUID;
 
 public class CamundaFormAssociationSubmissionService implements FormAssociationSubmissionService {

--- a/form-link/src/main/kotlin/com/ritense/formlink/repository/impl/JdbcProcessFormAssociationRepository.kt
+++ b/form-link/src/main/kotlin/com/ritense/formlink/repository/impl/JdbcProcessFormAssociationRepository.kt
@@ -69,7 +69,7 @@ class JdbcProcessFormAssociationRepository(
         val result = namedParameterJdbcTemplate.update(
             sql,
             mapOf(
-                ID_COLUMN to SqlParameterValue(Types.BINARY, UUID.nameUUIDFromBytes(processDefinitionKey.toByteArray()).asBytes()),
+                ID_COLUMN to toUuidParameterValue(UUID.randomUUID()),
                 PROCESS_DEFINITION_KEY_COLUMN to SqlParameterValue(Types.VARCHAR, processDefinitionKey),
                 FORM_ASSOCIATION_ID to SqlParameterValue(Types.BINARY, camundaFormAssociation.id.asBytes()),
                 FORM_ASSOCIATION_TYPE to SqlParameterValue(Types.VARCHAR, camundaFormAssociation.asType()),
@@ -231,6 +231,18 @@ class JdbcProcessFormAssociationRepository(
             is StartEventFormAssociation -> FormAssociationType.START_EVENT.toString()
             else -> FormAssociationType.USER_TASK.toString()
         }
+    }
+
+    private fun toUuidParameterValue(uuid: UUID): SqlParameterValue {
+        return if (isMySQL()) {
+            SqlParameterValue(Types.BINARY, uuid.asBytes())
+        } else {
+            SqlParameterValue(Types.OTHER, uuid)
+        }
+    }
+
+    private fun isMySQL() : Boolean {
+        return namedParameterJdbcTemplate.jdbcTemplate.dataSource.connection.metaData.databaseProductName == "MySQL"
     }
 
 }

--- a/form-link/src/main/resources/config/liquibase/changelog/20220630-storage-performance-improvement-changelog.xml
+++ b/form-link/src/main/resources/config/liquibase/changelog/20220630-storage-performance-improvement-changelog.xml
@@ -135,10 +135,4 @@
         </sql>
     </changeSet>
 
-    <changeSet author="Ritense" id="5">
-        <modifyDataType tableName="process_form_association_v2"
-                        columnName="process_definition_key"
-                        newDataType="varchar(255)"/>
-    </changeSet>
-
 </databaseChangeLog>

--- a/form-link/src/main/resources/config/liquibase/changelog/20230221-association-id-datatype-change.xml
+++ b/form-link/src/main/resources/config/liquibase/changelog/20230221-association-id-datatype-change.xml
@@ -1,0 +1,63 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2015-2023 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet author="Ritense" id="1">
+        <dropPrimaryKey tableName="process_form_association_v2"
+                        constraintName="process_form_association_v2_PK"
+                        uniqueColumns="id,process_definition_key,form_association_id,form_association_form_link_element_id"/>
+    </changeSet>
+
+    <changeSet author="Ritense" id="2">
+        <dropColumn columnName="id"
+                    tableName="process_form_association_v2"/>
+    </changeSet>
+
+    <changeSet author="Ritense" id="3">
+        <addColumn tableName="process_form_association_v2">
+            <column name="id" type="${uuidType}"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="Ritense" id="4">
+        <update tableName="process_form_association_v2">
+            <column name="id" valueComputed="${generateUuid}"/>
+        </update>
+    </changeSet>
+
+    <changeSet author="Ritense" id="5">
+        <addNotNullConstraint tableName="process_form_association_v2"
+                              columnName="id"
+                              columnDataType="${uuidType}"/>
+    </changeSet>
+
+    <changeSet author="Ritense" id="6">
+        <addPrimaryKey tableName="process_form_association_v2"
+                       columnNames="id"
+                       constraintName="process_form_association_v2_PK"/>
+    </changeSet>
+
+    <changeSet author="Ritense" id="7">
+        <modifyDataType tableName="process_form_association_v2"
+                        columnName="process_definition_key"
+                        newDataType="varchar(255)"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/form-link/src/main/resources/config/liquibase/formlink-master.xml
+++ b/form-link/src/main/resources/config/liquibase/formlink-master.xml
@@ -26,10 +26,15 @@
     <property name="jsonType" value="JSON" dbms="mysql"/>
     <property name="jsonType" value="JSONB" dbms="postgresql"/>
 
+    <property name="generateUuid" value="uuid_to_bin(uuid())" dbms="mysql"/>
+    <property name="generateUuid" value="gen_random_uuid()" dbms="postgresql"/>
+    <property name="generateUuid" value="random_uuid()" dbms="h2"/>
+
     <include file="changelog/20200320-formlink-changelog.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20200413-form-association-polymorphism-support-changelog.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20200507-added-process-definition-to-link-changelog.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20200513-domain-changed-changelog.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20220630-storage-performance-improvement-changelog.xml" relativeToChangelogFile="true"/>
+    <include file="changelog/20230221-association-id-datatype-change.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/form-link/src/test/java/com/ritense/formlink/service/impl/CamundaFormAssociationServiceIntTest.java
+++ b/form-link/src/test/java/com/ritense/formlink/service/impl/CamundaFormAssociationServiceIntTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
-import javax.transaction.Transactional;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/form-link/src/test/java/com/ritense/formlink/web/rest/CamundaFormAssociationManagementResourceIntTest.java
+++ b/form-link/src/test/java/com/ritense/formlink/web/rest/CamundaFormAssociationManagementResourceIntTest.java
@@ -32,9 +32,9 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
-import javax.transaction.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 

--- a/form-link/src/test/java/com/ritense/formlink/web/rest/CamundaFormAssociationResourceIntTest.java
+++ b/form-link/src/test/java/com/ritense/formlink/web/rest/CamundaFormAssociationResourceIntTest.java
@@ -30,11 +30,11 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import javax.inject.Inject;
-import javax.transaction.Transactional;
 import java.io.IOException;
 import java.util.Collections;
 

--- a/form-link/src/test/java/com/ritense/formlink/web/rest/impl/DefaultProcessLinkResourceIT.java
+++ b/form-link/src/test/java/com/ritense/formlink/web/rest/impl/DefaultProcessLinkResourceIT.java
@@ -40,6 +40,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
 import static com.ritense.valtimo.contract.authentication.AuthoritiesConstants.USER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -49,6 +51,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Transactional
 class DefaultProcessLinkResourceIT extends BaseIntegrationTest {
 
     private final static String DOCUMENT_DEFINITION_NAME = "house";

--- a/zgw/object-management/src/main/resources/config/liquibase/changelog/20230130-switch-configuration-id-columns.xml
+++ b/zgw/object-management/src/main/resources/config/liquibase/changelog/20230130-switch-configuration-id-columns.xml
@@ -19,19 +19,25 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <changeSet id="1" author="Ritense">
+        <validCheckSum>8:006ad988501bf41c07a7d1c03de998b3</validCheckSum>
         <renameColumn tableName="object_management_configuration"
                       oldColumnName="objecttypen_api_plugin_configuration_id"
-                      newColumnName="objecten_api_plugin_configuration_id_tmp" />
+                      newColumnName="objecten_api_plugin_configuration_id_tmp"
+                      columnDataType="${uuidType}"/>
     </changeSet>
 
     <changeSet id="2" author="Ritense">
+        <validCheckSum>8:db144fdd7bb4264c32f7866306ad295b</validCheckSum>
         <renameColumn tableName="object_management_configuration"
                       oldColumnName="objecten_api_plugin_configuration_id"
-                      newColumnName="objecttypen_api_plugin_configuration_id" />
+                      newColumnName="objecttypen_api_plugin_configuration_id"
+                      columnDataType="${uuidType}"/>
     </changeSet>
     <changeSet id="3" author="Ritense">
+        <validCheckSum>8:b16baf1cf517c3cc5b096cd2457617fc</validCheckSum>
         <renameColumn tableName="object_management_configuration"
                       oldColumnName="objecten_api_plugin_configuration_id_tmp"
-                      newColumnName="objecten_api_plugin_configuration_id" />
+                      newColumnName="objecten_api_plugin_configuration_id"
+                      columnDataType="${uuidType}"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
```
Specified key was too long; max key length is 3072 bytes [Failed SQL: (1071) ALTER TABLE `some-db`.process_form_association_v2 MODIFY process_definition_key VARCHAR(255)]
```

Solution: The column `process_form_association_v2.id` wasn't used. But after this PR, it is used