### PR TITLE
bugfix: plugin_process_link.activity_type default value

### DIFF
--- a/plugin/src/main/resources/config/liquibase/changelog/20230131-add-activity-type-to-process-links.xml
+++ b/plugin/src/main/resources/config/liquibase/changelog/20230131-add-activity-type-to-process-links.xml
@@ -31,4 +31,13 @@
         </update>
     </changeSet>
 
+    <changeSet id="3" author="Ritense">
+        <sql>
+            UPDATE plugin_process_link
+            SET activity_type = 'SERVICE_TASK_START'
+            WHERE activity_type = 'bpmn:ServiceTask:start'
+        </sql>
+    </changeSet>
+
+
 </databaseChangeLog>


### PR DESCRIPTION
plugin_process_link.activity_type was added with a default value of 'bpmn:ServiceTask:start', but JPA cannot map that to the enum value. Changed database value to the enum name.