### PR TITLE
Fix postgres: ERROR: function gen_random_uuid() does not exist

### DIFF
--- a/form-link/src/main/resources/config/liquibase/changelog/20230221-association-id-datatype-change.xml
+++ b/form-link/src/main/resources/config/liquibase/changelog/20230221-association-id-datatype-change.xml
@@ -39,6 +39,15 @@
                         newDataType="varchar(255)"/>
     </changeSet>
 
+    <changeSet author="Ritense" id="12">
+        <preConditions onFail="MARK_RAN">
+            <dbms type="postgresql"/>
+        </preConditions>
+        <sql>
+            CREATE EXTENSION pgcrypto;
+        </sql>
+    </changeSet>
+
     <changeSet author="Ritense" id="8">
         <update tableName="process_form_association_v2">
             <column name="form_association_id" valueComputed="${generateUuid}"/>


### PR DESCRIPTION
Error on postgres below version 13:
```
 ERROR: function gen_random_uuid() does not exist
```

Solution: https://stackoverflow.com/questions/35959265/postgresql-function-gen-random-uuid-not-working#answer-35960732