### PR TITLE
Fixes

### DIFF
--- a/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentDeploymentService.java
+++ b/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentDeploymentService.java
@@ -113,13 +113,13 @@ public class CamundaProcessJsonSchemaDocumentDeploymentService implements Proces
             processDocumentAssociationService.createProcessDocumentDefinition(request);
         }
 
-        contextService.findAll(Pageable.unpaged()).forEach(context -> {
-            context.getProcesses().removeIf(contextProcess -> contextProcess.getProcessDefinitionKey().equals(item.getProcessDefinitionKey()));
-            if (Boolean.TRUE.equals(item.getProcessIsVisibleInMenu())) {
-                context.addProcess(new ContextProcess(item.getProcessDefinitionKey(), true));
-            }
-            contextService.save(context);
-        });
+        if (item.getProcessIsVisibleInMenu() != null) {
+            contextService.findAll(Pageable.unpaged()).forEach(context -> {
+                context.getProcesses().removeIf(contextProcess -> contextProcess.getProcessDefinitionKey().equals(item.getProcessDefinitionKey()));
+                context.addProcess(new ContextProcess(item.getProcessDefinitionKey(), item.getProcessIsVisibleInMenu()));
+                contextService.save(context);
+            });
+        }
     }
 
     private String getProcessDocumentLinkResourcePath(String documentDefinitionName) {

--- a/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPlugin.kt
+++ b/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPlugin.kt
@@ -57,10 +57,10 @@ class VerzoekPlugin(
             .filter { it.copyStrategy == CopyStrategy.SPECIFIED }
             .forEach { property ->
                 property.mapping?.forEach {
-                    if (!it.value.startsWith("doc:")) {
-                        throw IllegalArgumentException("Failed to set mapping. Unknown prefix '${it.value.substringBefore(":")}:'.")
+                    if (!it.key.startsWith("doc:")) {
+                        throw IllegalArgumentException("Failed to set mapping. Unknown prefix '${it.key.substringBefore(":")}:'.")
                     }
-                    val documentPath = it.value.substringAfter(delimiter = ":")
+                    val documentPath = it.key.substringAfter(delimiter = ":")
                     documentDefinitionService.validateJsonPointer(property.caseDefinitionName, documentPath)
                 }
             }

--- a/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPlugin.kt
+++ b/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPlugin.kt
@@ -57,7 +57,11 @@ class VerzoekPlugin(
             .filter { it.copyStrategy == CopyStrategy.SPECIFIED }
             .forEach { property ->
                 property.mapping?.forEach {
-                    documentDefinitionService.validateJsonPointer(property.caseDefinitionName, it.value)
+                    if (!it.value.startsWith("doc:")) {
+                        throw IllegalArgumentException("Failed to set mapping. Unknown prefix '${it.value.substringBefore(":")}:'.")
+                    }
+                    val documentPath = it.value.substringAfter(delimiter = ":")
+                    documentDefinitionService.validateJsonPointer(property.caseDefinitionName, documentPath)
                 }
             }
     }

--- a/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
+++ b/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
@@ -164,13 +164,13 @@ class VerzoekPluginEventListener(
             val documentContent = jacksonObjectMapper().createObjectNode()
             val jsonPatchBuilder = JsonPatchBuilder()
             verzoekTypeProperties.mapping?.map {
-                val verzoekDataItem = verzoekDataData.at(it.key)
+                val verzoekDataItem = verzoekDataData.at(it.value)
                 if (verzoekDataItem.isMissingNode) {
                     throw NotificatiesNotificationEventException(
-                        "Missing Verzoek data at path '${it.key}', for Verzoek with type '${verzoekTypeProperties.type}'"
+                        "Missing Verzoek data at path '${it.value}', for Verzoek with type '${verzoekTypeProperties.type}'"
                     )
                 }
-                val documentPath = JsonPointer.valueOf(it.value.substringAfter(delimiter = ":"))
+                val documentPath = JsonPointer.valueOf(it.key.substringAfter(delimiter = ":"))
                 jsonPatchBuilder.addJsonNodeValue(documentContent, documentPath, verzoekDataItem)
             }
             JsonPatchService.apply(jsonPatchBuilder.build(), documentContent)

--- a/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
+++ b/zgw/verzoek/src/main/kotlin/com/ritense/verzoek/VerzoekPluginEventListener.kt
@@ -170,7 +170,8 @@ class VerzoekPluginEventListener(
                         "Missing Verzoek data at path '${it.key}', for Verzoek with type '${verzoekTypeProperties.type}'"
                     )
                 }
-                jsonPatchBuilder.addJsonNodeValue(documentContent, JsonPointer.valueOf(it.value), verzoekDataItem)
+                val documentPath = JsonPointer.valueOf(it.value.substringAfter(delimiter = ":"))
+                jsonPatchBuilder.addJsonNodeValue(documentContent, documentPath, verzoekDataItem)
             }
             JsonPatchService.apply(jsonPatchBuilder.build(), documentContent)
             documentContent

--- a/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginEventListenerIntTest.kt
+++ b/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginEventListenerIntTest.kt
@@ -22,7 +22,6 @@ import com.ritense.BaseIntegrationTest
 import com.ritense.document.domain.DocumentDefinition
 import com.ritense.document.service.DocumentDefinitionService
 import com.ritense.document.service.DocumentService
-import com.ritense.document.service.result.DeployDocumentDefinitionResult
 import com.ritense.notificatiesapi.event.NotificatiesApiNotificationReceivedEvent
 import com.ritense.objectenapi.ObjectenApiPlugin
 import com.ritense.objectenapi.client.ObjectRecord
@@ -31,10 +30,6 @@ import com.ritense.objectmanagement.domain.ObjectManagement
 import com.ritense.objectmanagement.service.ObjectManagementService
 import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.plugin.domain.PluginConfigurationId
-import java.net.URI
-import java.time.LocalDate
-import java.util.*
-import javax.transaction.Transactional
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.camunda.bpm.engine.RuntimeService
@@ -50,6 +45,10 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
+import java.net.URI
+import java.time.LocalDate
+import java.util.UUID
+import javax.transaction.Transactional
 
 @Transactional
 internal class VerzoekPluginEventListenerIntTest : BaseIntegrationTest() {
@@ -179,7 +178,7 @@ internal class VerzoekPluginEventListenerIntTest : BaseIntegrationTest() {
                 "copyStrategy": "specified",
                 "mapping": [{
                     "key": "/name",
-                    "value": "/fullname"
+                    "value": "doc:/fullname"
                 }]
               }]
             }

--- a/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginEventListenerIntTest.kt
+++ b/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginEventListenerIntTest.kt
@@ -177,8 +177,8 @@ internal class VerzoekPluginEventListenerIntTest : BaseIntegrationTest() {
                 "initiatorRolDescription": "Initiator",
                 "copyStrategy": "specified",
                 "mapping": [{
-                    "key": "/name",
-                    "value": "doc:/fullname"
+                    "key": "doc:/fullname",
+                    "value": "/name"
                 }]
               }]
             }

--- a/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginFactoryIntTest.kt
+++ b/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginFactoryIntTest.kt
@@ -131,8 +131,8 @@ internal class VerzoekPluginFactoryIntTest : BaseIntegrationTest() {
                 "initiatorRolDescription": "Initiator",
                 "copyStrategy": "specified",
                 "mapping": [{
-                    "key": "/name",
-                    "value": "doc:/fullname"
+                    "key": "doc:/fullname",
+                    "value": "/name"
                 }]
               }]
             }
@@ -156,7 +156,7 @@ internal class VerzoekPluginFactoryIntTest : BaseIntegrationTest() {
         assertEquals("https://example.com/my-role-type", plugin.verzoekProperties[0].initiatorRoltypeUrl.toString())
         assertEquals("Initiator", plugin.verzoekProperties[0].initiatorRolDescription)
         assertEquals(CopyStrategy.SPECIFIED, plugin.verzoekProperties[0].copyStrategy)
-        assertEquals(listOf(Mapping("/name", "doc:/fullname")), plugin.verzoekProperties[0].mapping)
+        assertEquals(listOf(Mapping("doc:/fullname", "/name")), plugin.verzoekProperties[0].mapping)
     }
 
     private fun mockResponse(body: String): MockResponse {

--- a/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginFactoryIntTest.kt
+++ b/zgw/verzoek/src/test/kotlin/com/ritense/verzoek/VerzoekPluginFactoryIntTest.kt
@@ -18,12 +18,10 @@ package com.ritense.verzoek
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.ritense.BaseIntegrationTest
-import com.ritense.document.repository.DocumentDefinitionRepository
 import com.ritense.notificatiesapiauthentication.NotificatiesApiAuthenticationPlugin
 import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.verzoek.domain.CopyStrategy
 import com.ritense.verzoek.domain.Mapping
-import java.net.URI
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -33,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.springframework.beans.factory.annotation.Autowired
+import java.net.URI
 
 internal class VerzoekPluginFactoryIntTest : BaseIntegrationTest() {
 
@@ -133,7 +132,7 @@ internal class VerzoekPluginFactoryIntTest : BaseIntegrationTest() {
                 "copyStrategy": "specified",
                 "mapping": [{
                     "key": "/name",
-                    "value": "/fullname"
+                    "value": "doc:/fullname"
                 }]
               }]
             }
@@ -157,7 +156,7 @@ internal class VerzoekPluginFactoryIntTest : BaseIntegrationTest() {
         assertEquals("https://example.com/my-role-type", plugin.verzoekProperties[0].initiatorRoltypeUrl.toString())
         assertEquals("Initiator", plugin.verzoekProperties[0].initiatorRolDescription)
         assertEquals(CopyStrategy.SPECIFIED, plugin.verzoekProperties[0].copyStrategy)
-        assertEquals(listOf(Mapping("/name", "/fullname")), plugin.verzoekProperties[0].mapping)
+        assertEquals(listOf(Mapping("/name", "doc:/fullname")), plugin.verzoekProperties[0].mapping)
     }
 
     private fun mockResponse(body: String): MockResponse {

--- a/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -33,16 +33,16 @@ import com.ritense.zakenapi.domain.ZaakObject
 import com.ritense.zakenapi.domain.rol.BetrokkeneType
 import com.ritense.zakenapi.domain.rol.Rol
 import com.ritense.zakenapi.domain.rol.RolNatuurlijkPersoon
-import com.ritense.zakenapi.repository.ZaakInstanceLinkRepository
 import com.ritense.zakenapi.domain.rol.RolType
+import com.ritense.zakenapi.repository.ZaakInstanceLinkRepository
 import com.ritense.zgw.Page
 import com.ritense.zgw.Rsin
+import mu.KLogger
+import mu.KotlinLogging
 import org.camunda.bpm.engine.delegate.DelegateExecution
 import java.net.URI
 import java.time.LocalDate
 import java.util.UUID
-import mu.KLogger
-import mu.KotlinLogging
 
 @Plugin(
     key = ZakenApiPlugin.PLUGIN_KEY,
@@ -123,6 +123,12 @@ class ZakenApiPlugin(
         @PluginActionProperty zaaktypeUrl: URI,
     ) {
         val documentId = UUID.fromString(execution.businessKey)
+
+        val zaakInstanceLink = zaakInstanceLinkRepository.findByDocumentId(documentId)
+        if (zaakInstanceLink != null) {
+            logger.warn { "SKIPPING ZAAK CREATION. Reason: a zaak already exists for this case. Case id '$documentId'. Zaak URL '${zaakInstanceLink.zaakInstanceUrl}'." }
+            return
+        }
 
         val zaak = client.createZaak(
             authenticationPluginConfiguration,


### PR DESCRIPTION
3 fixes:
1. Don't override the context when `processIsVisibleInMenu` isn't set.
2. Verzoek plugin mapping now requires prefix `doc:`
3. 'Create zaak' process link won't create zaak-link when it already exists