### PR TITLE
Task forms cannot be prefilled in case of multiple processes with the same variable name

### DIFF
--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/handler/FormFlowStepTypeFormHandler.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/handler/FormFlowStepTypeFormHandler.kt
@@ -70,7 +70,10 @@ class FormFlowStepTypeFormHandler(
         val document = documentService.get(documentId)
         val documentContent = document.content().asJson() as ObjectNode
 
-        camundaFormAssociationService.prefillProcessVariables(formDefinition, document)
+        if (taskInstanceId == null) {
+            camundaFormAssociationService.prefillProcessVariables(formDefinition, document)
+        }
+
         camundaFormAssociationService.prefillDataResolverFields(formDefinition, document, documentContent)
 
         if (taskInstanceId != null) {

--- a/form-link/src/main/java/com/ritense/formlink/service/impl/CamundaFormAssociationService.java
+++ b/form-link/src/main/java/com/ritense/formlink/service/impl/CamundaFormAssociationService.java
@@ -328,7 +328,9 @@ public class CamundaFormAssociationService implements FormAssociationService {
         final ObjectNode extendedDocumentContent = (ObjectNode) document.content().asJson();
         extendedDocumentContent.set("metadata", buildMetaDataObject(document));
 
-        prefillProcessVariables(formDefinition, document);
+        if (taskInstanceId.isEmpty()) {
+            prefillProcessVariables(formDefinition, document);
+        }
         prefillDataResolverFields(formDefinition, document, extendedDocumentContent);
         if (camundaFormAssociation.isPresent() && camundaFormAssociation.get() instanceof UserTaskFormAssociation) {
             taskInstanceId
@@ -403,6 +405,7 @@ public class CamundaFormAssociationService implements FormAssociationService {
     public void prefillTaskVariables(FormIoFormDefinition formDefinition, String taskInstanceId, JsonNode extendedDocumentContent) {
         final Map<String, Object> taskVariables = taskService.getVariables(taskInstanceId);
         final ObjectNode placeholders = Mapper.INSTANCE.objectMapper().valueToTree(taskVariables);
+        formDefinition.preFillWith("pv", taskVariables);
         submissionTransformerService.prePreFillTransform(formDefinition, placeholders, extendedDocumentContent);
     }
 


### PR DESCRIPTION
Made prefillTaskVariables actually fill using process variables as well.
Removed prefilling using all processes when a task ID is present.