### PR TITLE
Fix integration test

### DIFF
--- a/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakDocumentResourceTest.kt
+++ b/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/web/rest/ZaakDocumentResourceTest.kt
@@ -86,7 +86,7 @@ class ZaakDocumentResourceTest : BaseIntegrationTest() {
         fileId = UUID.fromString(uri.path.substringAfterLast("/")),
         fileName = "titel",
         sizeInBytes = 1337L,
-        createdOn = LocalDateTime.now(),
+        createdOn = LocalDateTime.parse("2023-01-01T12:10:01"),
         createdBy = "y",
         pluginConfigurationId = UUID.fromString("1f925112-f090-404a-bee7-b20fd8047a72"),
     )


### PR DESCRIPTION
The integration test `should get zaak-documenten by document` had a 1 in 100 chance of failing with this error:
```
JSON path "$.[0].createdOn" expected:<2023-03-31T16:01> but was:<2023-03-31T16:01:00>
Expected :2023-03-31T16:01
Actual   :2023-03-31T16:01:00
```