### PR TITLE
Fixed a few issues with process-links

### DIFF
--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/mapper/FormFlowProcessLinkMapper.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/mapper/FormFlowProcessLinkMapper.kt
@@ -87,6 +87,6 @@ class FormFlowProcessLinkMapper(
     }
 
     companion object {
-        const val PROCESS_LINK_TYPE_FORM_FLOW = "form_flow"
+        const val PROCESS_LINK_TYPE_FORM_FLOW = "form-flow"
     }
 }

--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/dto/FormFlowProcessLinkCreateRequestDto.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/dto/FormFlowProcessLinkCreateRequestDto.kt
@@ -16,14 +16,18 @@
 
 package com.ritense.valtimo.formflow.web.rest.dto
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
 import com.ritense.valtimo.formflow.mapper.FormFlowProcessLinkMapper.Companion.PROCESS_LINK_TYPE_FORM_FLOW
 
+@JsonTypeName(PROCESS_LINK_TYPE_FORM_FLOW)
 data class FormFlowProcessLinkCreateRequestDto(
     override val processDefinitionId: String,
     override val activityId: String,
     override val activityType: ActivityTypeWithEventName,
-    override val processLinkType: String = PROCESS_LINK_TYPE_FORM_FLOW,
     val formFlowDefinitionId: String,
-) : ProcessLinkCreateRequestDto
+) : ProcessLinkCreateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_FORM_FLOW
+}

--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/dto/FormFlowProcessLinkUpdateRequestDto.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/dto/FormFlowProcessLinkUpdateRequestDto.kt
@@ -16,12 +16,16 @@
 
 package com.ritense.valtimo.formflow.web.rest.dto
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import com.ritense.valtimo.formflow.mapper.FormFlowProcessLinkMapper.Companion.PROCESS_LINK_TYPE_FORM_FLOW
 import java.util.UUID
 
+@JsonTypeName(PROCESS_LINK_TYPE_FORM_FLOW)
 data class FormFlowProcessLinkUpdateRequestDto(
     override val id: UUID,
-    override val processLinkType: String = PROCESS_LINK_TYPE_FORM_FLOW,
     val formFlowDefinitionId: String,
-) : ProcessLinkUpdateRequestDto
+) : ProcessLinkUpdateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_FORM_FLOW
+}

--- a/form-link/src/main/kotlin/com/ritense/formlink/web/rest/dto/FormProcessLinkCreateRequestDto.kt
+++ b/form-link/src/main/kotlin/com/ritense/formlink/web/rest/dto/FormProcessLinkCreateRequestDto.kt
@@ -16,15 +16,19 @@
 
 package com.ritense.formlink.web.rest.dto
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.ritense.formlink.mapper.FormProcessLinkMapper.Companion.PROCESS_LINK_TYPE_FORM
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
 import java.util.UUID
 
+@JsonTypeName(PROCESS_LINK_TYPE_FORM)
 data class FormProcessLinkCreateRequestDto(
     override val processDefinitionId: String,
     override val activityId: String,
     override val activityType: ActivityTypeWithEventName,
-    override val processLinkType: String = PROCESS_LINK_TYPE_FORM,
     val formDefinitionId: UUID,
-) : ProcessLinkCreateRequestDto
+) : ProcessLinkCreateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_FORM
+}

--- a/form-link/src/main/kotlin/com/ritense/formlink/web/rest/dto/FormProcessLinkUpdateRequestDto.kt
+++ b/form-link/src/main/kotlin/com/ritense/formlink/web/rest/dto/FormProcessLinkUpdateRequestDto.kt
@@ -16,12 +16,16 @@
 
 package com.ritense.formlink.web.rest.dto
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.ritense.formlink.mapper.FormProcessLinkMapper.Companion.PROCESS_LINK_TYPE_FORM
 import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import java.util.UUID
 
+@JsonTypeName(PROCESS_LINK_TYPE_FORM)
 data class FormProcessLinkUpdateRequestDto(
     override val id: UUID,
-    override val processLinkType: String = PROCESS_LINK_TYPE_FORM,
     val formDefinitionId: UUID,
-) : ProcessLinkUpdateRequestDto
+) : ProcessLinkUpdateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_FORM
+}

--- a/plugin/src/main/kotlin/com/ritense/plugin/web/rest/request/PluginProcessLinkCreateDto.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/web/rest/request/PluginProcessLinkCreateDto.kt
@@ -16,18 +16,22 @@
 
 package com.ritense.plugin.web.rest.request
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.ritense.plugin.service.PluginService.Companion.PROCESS_LINK_TYPE_PLUGIN
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
 import java.util.UUID
 
+@JsonTypeName(PROCESS_LINK_TYPE_PLUGIN)
 data class PluginProcessLinkCreateDto(
     override val processDefinitionId: String,
     override val activityId: String,
-    override val processLinkType: String = PROCESS_LINK_TYPE_PLUGIN,
     val pluginConfigurationId: UUID,
     val pluginActionDefinitionKey: String,
     val actionProperties: ObjectNode? = null,
     override val activityType: ActivityTypeWithEventName,
-) : ProcessLinkCreateRequestDto
+) : ProcessLinkCreateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_PLUGIN
+}

--- a/plugin/src/main/kotlin/com/ritense/plugin/web/rest/request/PluginProcessLinkUpdateDto.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/web/rest/request/PluginProcessLinkUpdateDto.kt
@@ -16,15 +16,19 @@
 
 package com.ritense.plugin.web.rest.request
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.ritense.plugin.service.PluginService.Companion.PROCESS_LINK_TYPE_PLUGIN
 import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import java.util.UUID
 
+@JsonTypeName(PROCESS_LINK_TYPE_PLUGIN)
 data class PluginProcessLinkUpdateDto(
     override val id: UUID,
-    override val processLinkType: String = PROCESS_LINK_TYPE_PLUGIN,
     val pluginConfigurationId: UUID,
     val pluginActionDefinitionKey: String,
     val actionProperties: ObjectNode? = null
-) : ProcessLinkUpdateRequestDto
+) : ProcessLinkUpdateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_PLUGIN
+}

--- a/process-link/src/main/kotlin/com/ritense/processlink/service/ProcessLinkService.kt
+++ b/process-link/src/main/kotlin/com/ritense/processlink/service/ProcessLinkService.kt
@@ -26,7 +26,9 @@ import java.util.UUID
 import javax.validation.ValidationException
 import kotlin.jvm.optionals.getOrElse
 import mu.KotlinLogging
+import org.springframework.transaction.annotation.Transactional
 
+@Transactional(readOnly = true)
 open class ProcessLinkService(
     private val processLinkRepository: ProcessLinkRepository,
     private val processLinkMappers: List<ProcessLinkMapper>
@@ -44,6 +46,7 @@ open class ProcessLinkService(
         )
     }
 
+    @Transactional
     fun createProcessLink(createRequest: ProcessLinkCreateRequestDto) {
         if (getProcessLinks(createRequest.processDefinitionId, createRequest.activityId).isNotEmpty()) {
             throw ValidationException("A process-link for process-definition '${createRequest.processDefinitionId}' and activity '${createRequest.activityId}' already exists!")
@@ -53,14 +56,17 @@ open class ProcessLinkService(
         processLinkRepository.save(mapper.toNewProcessLink(createRequest))
     }
 
+    @Transactional
     fun updateProcessLink(updateRequest: ProcessLinkUpdateRequestDto) {
-        val mapper = getProcessLinkMapper(updateRequest.processLinkType)
         val processLinkToUpdate = processLinkRepository.findById(updateRequest.id)
             .getOrElse { throw IllegalStateException("No ProcessLink found with id ${updateRequest.id}") }
+
+        val mapper = getProcessLinkMapper(processLinkToUpdate.processLinkType)
         val processLinkUpdated = mapper.toUpdatedProcessLink(processLinkToUpdate, updateRequest)
         processLinkRepository.save(processLinkUpdated)
     }
 
+    @Transactional
     fun deleteProcessLink(id: UUID) {
         processLinkRepository.deleteById(id)
     }

--- a/process-link/src/main/kotlin/com/ritense/processlink/service/ProcessLinkService.kt
+++ b/process-link/src/main/kotlin/com/ritense/processlink/service/ProcessLinkService.kt
@@ -60,7 +60,9 @@ open class ProcessLinkService(
     fun updateProcessLink(updateRequest: ProcessLinkUpdateRequestDto) {
         val processLinkToUpdate = processLinkRepository.findById(updateRequest.id)
             .getOrElse { throw IllegalStateException("No ProcessLink found with id ${updateRequest.id}") }
-
+        check(updateRequest.processLinkType == processLinkToUpdate.processLinkType) {
+            "The processLinkType of the persisted entity does not match the given type!"
+        }
         val mapper = getProcessLinkMapper(processLinkToUpdate.processLinkType)
         val processLinkUpdated = mapper.toUpdatedProcessLink(processLinkToUpdate, updateRequest)
         processLinkRepository.save(processLinkUpdated)

--- a/process-link/src/main/kotlin/com/ritense/processlink/web/rest/dto/ProcessLinkCreateRequestDto.kt
+++ b/process-link/src/main/kotlin/com/ritense/processlink/web/rest/dto/ProcessLinkCreateRequestDto.kt
@@ -16,10 +16,12 @@
 
 package com.ritense.processlink.web.rest.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "processLinkType")
+@JsonIgnoreProperties(value = ["processLinkType"], allowSetters = true)
 interface ProcessLinkCreateRequestDto {
     val processDefinitionId: String
     val activityId: String

--- a/process-link/src/main/kotlin/com/ritense/processlink/web/rest/dto/ProcessLinkResponseDto.kt
+++ b/process-link/src/main/kotlin/com/ritense/processlink/web/rest/dto/ProcessLinkResponseDto.kt
@@ -16,11 +16,9 @@
 
 package com.ritense.processlink.web.rest.dto
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.ritense.processlink.domain.ActivityTypeWithEventName
 import java.util.UUID
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 interface ProcessLinkResponseDto {
     val id: UUID
     val processDefinitionId: String

--- a/process-link/src/main/kotlin/com/ritense/processlink/web/rest/dto/ProcessLinkUpdateRequestDto.kt
+++ b/process-link/src/main/kotlin/com/ritense/processlink/web/rest/dto/ProcessLinkUpdateRequestDto.kt
@@ -16,10 +16,12 @@
 
 package com.ritense.processlink.web.rest.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.util.UUID
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "processLinkType")
+@JsonIgnoreProperties(value = ["processLinkType"], allowSetters = true)
 interface ProcessLinkUpdateRequestDto {
     val id: UUID
     val processLinkType: String

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkCreateRequestDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkCreateRequestDto.kt
@@ -16,12 +16,16 @@
 
 package com.ritense.processlink.domain
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
 import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
 
+@JsonTypeName(PROCESS_LINK_TYPE_TEST)
 data class CustomProcessLinkCreateRequestDto(
     override val processDefinitionId: String,
     override val activityId: String,
-    override val activityType: ActivityTypeWithEventName,
-    override val processLinkType: String = PROCESS_LINK_TYPE_TEST,
-) : ProcessLinkCreateRequestDto
+    override val activityType: ActivityTypeWithEventName
+) : ProcessLinkCreateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_TEST
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkCreateRequestDtoTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkCreateRequestDtoTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+
+
+class CustomProcessLinkCreateRequestDtoTest {
+
+    private val mapper = jacksonObjectMapper().apply {
+        this.registerSubtypes(CustomProcessLinkCreateRequestDto::class.java, CustomProcessLinkUpdateRequestDto::class.java)
+    }
+
+    @Test
+    fun `should deserialise correctly`() {
+        val value: CustomProcessLinkCreateRequestDto = mapper.readValue("""
+            {
+                "processDefinitionId": "process-definition:1",
+                "activityId": "serviceTask1",
+                "activityType": "${ActivityTypeWithEventName.SERVICE_TASK_START.value}",
+                "processLinkType": "$PROCESS_LINK_TYPE_TEST"
+            }
+        """.trimIndent())
+
+        assertThat(value, instanceOf(CustomProcessLinkCreateRequestDto::class.java))
+        assertThat(value.processLinkType, equalTo(PROCESS_LINK_TYPE_TEST))
+    }
+
+    @Test
+    fun `should serialize correctly`() {
+        val value = CustomProcessLinkCreateRequestDto("process-definition:1","serviceTask1", ActivityTypeWithEventName.SERVICE_TASK_START)
+
+        val json = mapper.writeValueAsString(value)
+
+        JSONAssert.assertEquals("""
+            {
+              "processDefinitionId": "${value.processDefinitionId}",
+              "activityId": "${value.activityId}",
+              "activityType": "${value.activityType.value}",
+              "processLinkType":"$PROCESS_LINK_TYPE_TEST"
+            }
+        """.trimIndent(), json, JSONCompareMode.NON_EXTENSIBLE)
+    }
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkUpdateRequestDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkUpdateRequestDto.kt
@@ -16,11 +16,15 @@
 
 package com.ritense.processlink.domain
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
 import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import java.util.UUID
 
+@JsonTypeName(PROCESS_LINK_TYPE_TEST)
 data class CustomProcessLinkUpdateRequestDto(
-    override val id: UUID,
-    override val processLinkType: String = PROCESS_LINK_TYPE_TEST,
-) : ProcessLinkUpdateRequestDto
+    override val id: UUID
+) : ProcessLinkUpdateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_TEST
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkUpdateRequestDtoTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/CustomProcessLinkUpdateRequestDtoTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
+import java.util.UUID
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+
+
+class CustomProcessLinkUpdateRequestDtoTest {
+
+    private val mapper = jacksonObjectMapper().apply {
+        this.registerSubtypes(CustomProcessLinkCreateRequestDto::class.java, CustomProcessLinkUpdateRequestDto::class.java)
+    }
+
+    @Test
+    fun `should deserialise correctly`() {
+        val value: ProcessLinkUpdateRequestDto = mapper.readValue("""
+            {
+                "id": "${UUID.randomUUID()}",
+                "processLinkType": "$PROCESS_LINK_TYPE_TEST"
+            }
+        """.trimIndent())
+
+        assertThat(value, instanceOf(CustomProcessLinkUpdateRequestDto::class.java))
+        assertThat(value.processLinkType, equalTo(PROCESS_LINK_TYPE_TEST))
+    }
+
+    @Test
+    fun `should serialize correctly`() {
+        val value = CustomProcessLinkUpdateRequestDto(UUID.randomUUID())
+
+        val json = mapper.writeValueAsString(value)
+
+        JSONAssert.assertEquals("""
+            {
+              "processLinkType":"$PROCESS_LINK_TYPE_TEST",
+              "id":"${value.id}"
+            }
+        """.trimIndent(), json, JSONCompareMode.NON_EXTENSIBLE)
+    }
+}


### PR DESCRIPTION
- Service was not transactional
- renamed 'form_flow' type to 'form-flow'
- The DEDUCTION JsonTypeInfo could lead to unexpected behaviour when property names matched, but the given processLinkType value did not. The value of processLinkType is now properly used to determine the type.