### PR TITLE
Downgrade liquibase

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,14 +37,14 @@ camundaBpmAssertVersion=15.0.0
 mybatisVersion=3.5.13
 mybatisSpringBootStarterVersion=2.3.0
 
-springBootVersion=2.7.10
+springBootVersion=2.7.11
 springBootAdminStarterClientVersion=2.7.10
 springDependencyManagementVersion=1.1.0
 springCloudStarterStreamRabbitVersion=3.2.7
 springRetryVersion=1.3.4
 
-liquibaseVersion=4.21.1
-liquibaseSlf4jVersion=5.0.0
+liquibaseVersion=4.9.1
+liquibaseSlf4jVersion=4.1.0
 
 commonsLangVersion=3.12.0
 commonsIoVersion=2.11.0


### PR DESCRIPTION
Because [Spring boot BOM](https://github.com/spring-projects/spring-boot/blob/v2.7.11/spring-boot-project/spring-boot-dependencies/build.gradle#L1163-L1173) overrides Liquibase version and sets it to 4.9.1