### PR TITLE
Fix error: Illegal base64 character 0x22

### DIFF
--- a/document-generation/smartdocuments/src/main/kotlin/com/ritense/smartdocuments/client/SmartDocumentsClient.kt
+++ b/document-generation/smartdocuments/src/main/kotlin/com/ritense/smartdocuments/client/SmartDocumentsClient.kt
@@ -174,8 +174,8 @@ class SmartDocumentsClient(
             } else if ("data" == fieldName) {
                 jsonParser.nextToken()
                 documentDataStart = jsonParser.currentLocation.byteOffset
-                jsonParser.nextToken()
-                documentDataEnd = jsonParser.currentLocation.byteOffset - 2
+                jsonParser.finishToken()
+                documentDataEnd = jsonParser.currentLocation.byteOffset - 1
             }
 
             if (correctOutputFormat && fileName != null && documentDataStart != -1L) {

--- a/document-generation/smartdocuments/src/main/kotlin/com/ritense/smartdocuments/io/SubInputStream.kt
+++ b/document-generation/smartdocuments/src/main/kotlin/com/ritense/smartdocuments/io/SubInputStream.kt
@@ -22,6 +22,10 @@ import java.io.InputStream
 
 /*
  * A limited input stream. Only reads a section of the given input stream.
+ *
+ * @param inputStream the stream to change.
+ * @param startByteIndex the start index (inclusive).
+ * @param endByteIndex the end index (exclusive).
  */
 class SubInputStream(
     inputStream: InputStream,
@@ -40,7 +44,7 @@ class SubInputStream(
         if (closed) {
             throw IOException("Stream is closed")
         }
-        if (index > endByteIndex) {
+        if (index >= endByteIndex) {
             return -1
         }
         val b = super.read()

--- a/document-generation/smartdocuments/src/test/kotlin/com/ritense/smartdocuments/io/SubInputStreamTest.kt
+++ b/document-generation/smartdocuments/src/test/kotlin/com/ritense/smartdocuments/io/SubInputStreamTest.kt
@@ -18,16 +18,17 @@ package com.ritense.smartdocuments.io
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.text.Charsets.UTF_8
 
 class SubInputStreamTest {
 
     @Test
     fun `should only read part of input stream`() {
-        val inputStream = "0123456789".byteInputStream(Charsets.UTF_8)
+        val inputStream = "0123456789".byteInputStream(UTF_8)
 
         val subIn = SubInputStream(inputStream, 2, 6)
 
         val result = subIn.bufferedReader().use { it.readText() }
-        assertThat(result).isEqualTo("23456")
+        assertThat(result).isEqualTo("2345")
     }
 }


### PR DESCRIPTION
0x22 is a `"` character that was present at the end of the base64-encoded-pdf

I can't reproduce the error locally