### PR TITLE
#69531 Fix: plugin deployment problems

### DIFF
--- a/app/gzac/src/main/resources/config/objectmanagement/bomen.json
+++ b/app/gzac/src/main/resources/config/objectmanagement/bomen.json
@@ -2,9 +2,9 @@
     "id": "d8257077-ec44-44d3-9d2e-e8c87fa6fd09",
     "title": "Bomen",
     "objecttypenApiPluginConfigurationId": "4021bb75-18c8-4ca5-8658-b9f9c728bba0",
-    "objecttypeId": "feeaa795-d212-4fa2-bb38-2c34996e570",
+    "objecttypeId": "feeaa795-d212-4fa2-bb38-2c34996e5702",
     "objectenApiPluginConfigurationId": "b6d83348-97e7-4660-bd35-2e5fcc9629b4",
-    "showInDataMenu":false,
-    "formDefinitionView": null,
-    "formDefinitionEdit": null
+    "showInDataMenu": true,
+    "formDefinitionView": "boom.summary",
+    "formDefinitionEdit": "boom.editform"
 }

--- a/plugin/src/main/kotlin/com/ritense/plugin/autodeployment/PluginAutoDeploymentEventListener.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/autodeployment/PluginAutoDeploymentEventListener.kt
@@ -52,11 +52,11 @@ class PluginAutoDeploymentEventListener(
                 try {
                     createPluginConfigurations(resource)
                 } catch (e: Exception) {
-                    logger.error(e) { "Error while deploying plugin" }
+                    logger.error(e) { "Error while deploying plugin configuration" }
                 }
             }
         } catch (e: Exception) {
-            logger.error(e) { "Error while deploying plugins" }
+            logger.error(e) { "Error while deploying plugin configurations" }
         }
     }
 

--- a/plugin/src/main/kotlin/com/ritense/plugin/autodeployment/PluginAutoDeploymentEventListener.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/autodeployment/PluginAutoDeploymentEventListener.kt
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.treeToValue
-import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.plugin.service.PluginService
 import mu.KLogger
 import mu.KotlinLogging
@@ -34,7 +33,6 @@ import org.springframework.core.io.ResourceLoader
 import org.springframework.core.io.support.ResourcePatternUtils
 import org.springframework.transaction.annotation.Transactional
 import java.io.IOException
-import java.lang.Exception
 
 @Transactional
 class PluginAutoDeploymentEventListener(
@@ -51,7 +49,11 @@ class PluginAutoDeploymentEventListener(
         try {
             val resources = loadResources()
             for (resource in resources) {
-                createPluginConfigurations(resource)
+                try {
+                    createPluginConfigurations(resource)
+                } catch (e: Exception) {
+                    logger.error(e) { "Error while deploying plugin" }
+                }
             }
         } catch (e: Exception) {
             logger.error(e) { "Error while deploying plugins" }

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/Kanaal.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/Kanaal.kt
@@ -16,6 +16,9 @@
 
 package com.ritense.notificatiesapi.domain
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class Kanaal(
     val url: String? = null,
     val naam: String,


### PR DESCRIPTION
Solves:
- Error: ```"invalidParams":[{"name":"documentatieLink","code":"null","reason":"Dit veld mag niet leeg zijn."}]```
- Error when running plugin events for a plugin that already exist.
- Error when decrypting plugin secret that hasn't been encrypted yet due to it being in a Transaction.