### PR TITLE
feat: match TaakStatus with taak objecttype status

### DIFF
--- a/zgw/portaaltaak/src/main/kotlin/com/ritense/portaaltaak/TaakObject.kt
+++ b/zgw/portaaltaak/src/main/kotlin/com/ritense/portaaltaak/TaakObject.kt
@@ -49,8 +49,8 @@ class TaakForm(
 enum class TaakStatus(@JsonValue val key: String) {
     OPEN("open"),
     INGEDIEND("ingediend"),
-    INGETROKKEN("ingetrokken"),
-    VERWERKT("verwerkt")
+    VERWERKT("verwerkt"),
+    GESLOTEN("gesloten")
 }
 
 enum class TaakFormType(@JsonValue val key: String) {

--- a/zgw/portaaltaak/src/main/kotlin/com/ritense/portaaltaak/TaakObject.kt
+++ b/zgw/portaaltaak/src/main/kotlin/com/ritense/portaaltaak/TaakObject.kt
@@ -49,6 +49,7 @@ class TaakForm(
 enum class TaakStatus(@JsonValue val key: String) {
     OPEN("open"),
     INGEDIEND("ingediend"),
+    INGETROKKEN("ingetrokken"),
     VERWERKT("verwerkt")
 }
 


### PR DESCRIPTION
this PR adds an additional status option to the TaakObject so that implementations can cancel a task by setting it's status to `ZaakStatus.GESLOTEN`