### PR TITLE
Validate plugin properties after resolving the placeholders.

### DIFF
--- a/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
@@ -119,12 +119,13 @@ class PluginService(
         ) {
             deletePluginConfiguration(PluginConfigurationId.existingId(deploymentDto.id))
         }
+        resolveProperties(deploymentDto.properties)
         validateProperties(deploymentDto.properties!!, pluginDefinition)
         val pluginId = pluginConfigurationRepository.saveAndFlush(
             PluginConfiguration(
                 deploymentDto.id?.let { PluginConfigurationId.existingId(it) } ?: PluginConfigurationId.newId(),
                 deploymentDto.title,
-                resolveProperties(deploymentDto.properties),
+                deploymentDto.properties,
                 pluginDefinition
             )
         ).id

--- a/plugin/src/test/kotlin/com/ritense/plugin/autodeployment/AutoDeploymentTestPlugin.kt
+++ b/plugin/src/test/kotlin/com/ritense/plugin/autodeployment/AutoDeploymentTestPlugin.kt
@@ -18,12 +18,9 @@ package com.ritense.plugin.autodeployment
 
 import com.ritense.plugin.annotation.Plugin
 import com.ritense.plugin.annotation.PluginAction
-import com.ritense.plugin.annotation.PluginActionProperty
-import com.ritense.plugin.annotation.PluginEvent
 import com.ritense.plugin.annotation.PluginProperty
 import com.ritense.plugin.domain.ActivityType
-import com.ritense.plugin.domain.ActivityType.SERVICE_TASK_START
-import com.ritense.plugin.domain.EventType
+import com.ritense.valtimo.contract.validation.Url
 import java.net.URI
 
 @Plugin(
@@ -33,8 +30,9 @@ import java.net.URI
 )
 class AutoDeploymentTestPlugin(
 )  {
+    @Url
     @PluginProperty(key = "property1", secret = false)
-    lateinit var property1: String
+    lateinit var property1: URI
 
     @PluginProperty(key = "property2", required = false, secret = false)
     var property2: Boolean? = null

--- a/plugin/src/test/kotlin/com/ritense/plugin/autodeployment/PluginAutoDeploymentEventListenerIntTest.kt
+++ b/plugin/src/test/kotlin/com/ritense/plugin/autodeployment/PluginAutoDeploymentEventListenerIntTest.kt
@@ -18,13 +18,10 @@
 package com.ritense.plugin.autodeployment
 
 import com.ritense.plugin.BaseIntegrationTest
-import com.ritense.plugin.repository.PluginDefinitionRepository
 import com.ritense.plugin.service.PluginConfigurationSearchParameters
 import com.ritense.plugin.service.PluginService
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -39,7 +36,7 @@ class PluginAutoDeploymentEventListenerIntTest: BaseIntegrationTest() {
             PluginConfigurationSearchParameters(pluginDefinitionKey = "auto-deployment-test-plugin")
         )
         assertTrue { result.size == 1 }
-        assertEquals("property one", result[0].properties?.get("property1")?.textValue())
+        assertEquals("https://www.google.com", result[0].properties?.get("property1")?.textValue())
         assertTrue (result[0].properties?.get("property2")?.booleanValue()!!)
         assertEquals(3, result[0].properties?.get("property3")?.intValue())
     }

--- a/plugin/src/test/resources/config/plugin-configurations/config.pluginconfig.json
+++ b/plugin/src/test/resources/config/plugin-configurations/config.pluginconfig.json
@@ -3,7 +3,7 @@
         "title": "auto deployment test plugin",
         "pluginDefinitionKey": "auto-deployment-test-plugin",
         "properties": {
-            "property1": "property one",
+            "property1": "https://www.google.com",
             "property2": true,
             "property3": 3
         }


### PR DESCRIPTION
Fixed TP #70486: 
As a person implementing the plugin auto configuration
I did use placeholders for values that differ per environment
and expected this to be accepted and the placeholder value be replaced with the environment variable
but experienced an error telling me that it failed parsing the value (in my case as a URI)