### PR TITLE
Bugfix/search field

### DIFF
--- a/document/src/main/java/com/ritense/document/repository/SearchFieldRepository.java
+++ b/document/src/main/java/com/ritense/document/repository/SearchFieldRepository.java
@@ -30,4 +30,6 @@ public interface SearchFieldRepository extends JpaRepository<SearchField, Search
     Optional<SearchField> findByIdDocumentDefinitionNameAndKey(String documentDefinitionName, String key);
 
     boolean existsByIdDocumentDefinitionName(String documentDefinitionName);
+
+    void deleteAllByIdDocumentDefinitionName(String documentDefinitionName);
 }

--- a/document/src/main/java/com/ritense/document/service/SearchConfigurationDeploymentService.java
+++ b/document/src/main/java/com/ritense/document/service/SearchConfigurationDeploymentService.java
@@ -75,12 +75,8 @@ public class SearchConfigurationDeploymentService {
         var searchConfiguration = objectMapper.readValue(searchConfigurationJson, SearchConfigurationDto.class);
 
         try {
-            List<SearchField> databaseSearchFields =  searchFieldService.getSearchFields(documentDefinitionName);
-            List<SearchField> searchConfigurationFields  = searchConfiguration.toEntity(documentDefinitionName);
-            databaseSearchFields.forEach(databaseSearchField ->
-                searchConfigurationFields
-                        .removeIf(
-                                searchConfigurationField -> databaseSearchField.getKey().equals(searchConfigurationField.getKey())));
+            searchFieldService.deleteSearchFields(documentDefinitionName);
+            List<SearchField> searchConfigurationFields = searchConfiguration.toEntity(documentDefinitionName);
             searchFieldService.createSearchConfiguration(searchConfigurationFields);
             logger.info("Deployed search configuration for document - {}", documentDefinitionName);
         } catch (Exception e) {

--- a/document/src/main/java/com/ritense/document/service/SearchFieldService.java
+++ b/document/src/main/java/com/ritense/document/service/SearchFieldService.java
@@ -63,6 +63,10 @@ public class SearchFieldService {
         return searchFieldRepository.findAllByIdDocumentDefinitionNameOrderByOrder(documentDefinitionName);
     }
 
+    public void deleteSearchFields(String documentDefinitionName) {
+        searchFieldRepository.deleteAllByIdDocumentDefinitionName(documentDefinitionName);
+    }
+
     public void updateSearchFields(String documentDefinitionName, List<SearchFieldDto> searchFieldDtos) {
         searchFieldDtos.forEach(this::validateSearchField);
         searchFieldDtos.forEach(searchFieldDto ->

--- a/document/src/main/resources/config/search/schema/search.schema.json
+++ b/document/src/main/resources/config/search/schema/search.schema.json
@@ -36,7 +36,9 @@
                         "enum": [
                             "single",
                             "multiple",
-                            "range"
+                            "range",
+                            "multi-select-dropdown",
+                            "single-select-dropdown"
                         ],
                         "description": "The field type of the form field"
                     },

--- a/form-link/src/main/java/com/ritense/formlink/autoconfigure/FormLinkAutoConfiguration.java
+++ b/form-link/src/main/java/com/ritense/formlink/autoconfigure/FormLinkAutoConfiguration.java
@@ -196,7 +196,7 @@ public class FormLinkAutoConfiguration {
     @Bean
     @ConditionalOnBean(FormLinkNewProcessFormFlowProvider.class)
     @ConditionalOnMissingBean(FormLinkFormFlowResource.class)
-    public FormLinkFormFlowResource processLinkFormFlowResource(
+    public FormLinkFormFlowResource formLinkFormFlowResource(
         FormLinkNewProcessFormFlowProvider formLinkNewProcessFormFlowProvider
     ) {
         return new FormLinkFormFlowResource(formLinkNewProcessFormFlowProvider);

--- a/form-link/src/main/kotlin/com/ritense/formlink/web/rest/FormLinkFormFlowResource.kt
+++ b/form-link/src/main/kotlin/com/ritense/formlink/web/rest/FormLinkFormFlowResource.kt
@@ -25,10 +25,8 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 
 @Deprecated("Since 10.6.0")
-@RestController
 @RequestMapping(value = ["/api"], produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
 internal class FormLinkFormFlowResource internal constructor(
     private val formLinkNewProcessFormFlowProvider: FormLinkNewProcessFormFlowProvider


### PR DESCRIPTION
- Fix: implementations teams expect that the search fields in the configuration file override all existing search fields
- Fix: add missing search-field-types: single-select-dropdown, multi-select-dropdown
- Fix exception: 
```Parameter 0 of constructor in com.ritense.formlink.web.rest.FormLinkFormFlowResource required a bean of type 'com.ritense.formlink.service.FormLinkNewProcessFormFlowProvider' that could not be found.```