### PR TITLE
fix: OutOfMemoryError

### DIFF
--- a/dashboard/src/main/kotlin/com/ritense/dashboard/datasource/AnnotatedClassResolver.kt
+++ b/dashboard/src/main/kotlin/com/ritense/dashboard/datasource/AnnotatedClassResolver.kt
@@ -25,6 +25,7 @@ abstract class AnnotatedClassResolver {
 
     inline fun <reified T : Annotation> findMethodsWithAnnotation(): List<Method> {
         return ClassGraph()
+            .rejectPaths(*REJECT_PACKAGES)
             .enableClassInfo()
             .enableMethodInfo()
             .enableAnnotationInfo()
@@ -49,5 +50,78 @@ abstract class AnnotatedClassResolver {
 
     companion object {
         val logger = KotlinLogging.logger {}
+        val REJECT_PACKAGES = arrayOf(
+            "org.springframework",
+            "org.apache",
+            "org.hibernate",
+            "org.camunda",
+            "org.eclipse",
+            "org.bouncycastle",
+            "org.gradle",
+            "liquibase",
+            "org.assertj",
+            "camundajar",
+            "org.codehaus",
+            "kotlin",
+            "net.bytebuddy",
+            "io.netty",
+            "org.glassfish",
+            "oracle",
+            "com.google",
+            "groovy",
+            "org.keycloak",
+            "com.fasterxml",
+            "reactor",
+            "org.junit",
+            "javax",
+            "com.sun",
+            "org.h2",
+            "org.jboss",
+            "com.carrotsearch",
+            "com.ctc",
+            "org.aspectj",
+            "kotlinx",
+            "connectjar",
+            "groovyjarjarantlr4",
+            "com.github",
+            "org.mockito",
+            "ch.qos",
+            "org.postgresql",
+            "org.spockframework",
+            "javassist",
+            "com.microsoft",
+            "io.micrometer",
+            "io.vavr",
+            "org.checkerframework",
+            "io.github",
+            "com.datical",
+            "org.joda",
+            "io.smallrye",
+            "io.swagger",
+            "org.yaml",
+            "picocli",
+            "groovyjarjarpicocli",
+            "antlr",
+            "groovyjarjarantlr",
+            "org.springdoc",
+            "com.jayway",
+            "com.esotericsoftware",
+            "org.dom4j",
+            "org.everit",
+            "org.xmlunit",
+            "io.jsonwebtoken",
+            "net.rubygrapefruit",
+            "nonapi",
+            "org.objectweb",
+            "com.vladmihalcea",
+            "org.jvnet",
+            "camundafeel",
+            "groovyjarjarasm",
+            "com.codahale",
+            "org.hamcrest",
+            "net.minidev",
+            "com.thoughtworks",
+            "io.holunda"
+        )
     }
 }

--- a/dashboard/src/main/kotlin/com/ritense/dashboard/datasource/AnnotatedClassResolver.kt
+++ b/dashboard/src/main/kotlin/com/ritense/dashboard/datasource/AnnotatedClassResolver.kt
@@ -25,7 +25,7 @@ abstract class AnnotatedClassResolver {
 
     inline fun <reified T : Annotation> findMethodsWithAnnotation(): List<Method> {
         return ClassGraph()
-            .rejectPaths(*REJECT_PACKAGES)
+            .rejectPackages(*REJECT_PACKAGES)
             .enableClassInfo()
             .enableMethodInfo()
             .enableAnnotationInfo()

--- a/dashboard/src/main/kotlin/com/ritense/dashboard/datasource/dto/DashboardWidgetSingleDto.kt
+++ b/dashboard/src/main/kotlin/com/ritense/dashboard/datasource/dto/DashboardWidgetSingleDto.kt
@@ -17,6 +17,6 @@
 package com.ritense.dashboard.datasource.dto
 
 data class DashboardWidgetSingleDto(
-    val value: String,
+    val value: Long,
     val total: Long,
 )

--- a/dashboard/src/test/kotlin/com/ritense/dashboard/TestDataSource.kt
+++ b/dashboard/src/test/kotlin/com/ritense/dashboard/TestDataSource.kt
@@ -34,7 +34,7 @@ class TestDataSource {
         key = "test-key-single",
         title = "Test title single"
     )
-    fun dashboardWidgetSingleDto() = DashboardWidgetSingleDto("test-value", 0)
+    fun dashboardWidgetSingleDto() = DashboardWidgetSingleDto(1, 0)
 
     fun testNonAnnotatedMethod(): String {
         return "test"

--- a/plugin/src/main/kotlin/com/ritense/plugin/AnnotatedClassResolver.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/AnnotatedClassResolver.kt
@@ -21,8 +21,9 @@ import mu.KotlinLogging
 
 abstract class AnnotatedClassResolver {
 
-    inline fun <reified T: Annotation> findAnnotatedClasses() : Map<Class<*>, T> {
+    inline fun <reified T : Annotation> findAnnotatedClasses(): Map<Class<*>, T> {
         val pluginCategoryClasses = ClassGraph()
+            .rejectPaths(*REJECT_PACKAGES)
             .enableClassInfo()
             .enableAnnotationInfo()
             .scan(1)
@@ -34,7 +35,7 @@ abstract class AnnotatedClassResolver {
                 true
             } catch (e: Exception) {
                 logger.warn { "Unable to load ${T::class.simpleName} ${it.name} class, skipped" }
-                logger.debug(e) {"Unable to load ${T::class.simpleName} ${it.name} because of the following exception"}
+                logger.debug(e) { "Unable to load ${T::class.simpleName} ${it.name} because of the following exception" }
                 false
             }
         }.associate {
@@ -44,5 +45,78 @@ abstract class AnnotatedClassResolver {
 
     companion object {
         val logger = KotlinLogging.logger {}
+        val REJECT_PACKAGES = arrayOf(
+            "org.springframework",
+            "org.apache",
+            "org.hibernate",
+            "org.camunda",
+            "org.eclipse",
+            "org.bouncycastle",
+            "org.gradle",
+            "liquibase",
+            "org.assertj",
+            "camundajar",
+            "org.codehaus",
+            "kotlin",
+            "net.bytebuddy",
+            "io.netty",
+            "org.glassfish",
+            "oracle",
+            "com.google",
+            "groovy",
+            "org.keycloak",
+            "com.fasterxml",
+            "reactor",
+            "org.junit",
+            "javax",
+            "com.sun",
+            "org.h2",
+            "org.jboss",
+            "com.carrotsearch",
+            "com.ctc",
+            "org.aspectj",
+            "kotlinx",
+            "connectjar",
+            "groovyjarjarantlr4",
+            "com.github",
+            "org.mockito",
+            "ch.qos",
+            "org.postgresql",
+            "org.spockframework",
+            "javassist",
+            "com.microsoft",
+            "io.micrometer",
+            "io.vavr",
+            "org.checkerframework",
+            "io.github",
+            "com.datical",
+            "org.joda",
+            "io.smallrye",
+            "io.swagger",
+            "org.yaml",
+            "picocli",
+            "groovyjarjarpicocli",
+            "antlr",
+            "groovyjarjarantlr",
+            "org.springdoc",
+            "com.jayway",
+            "com.esotericsoftware",
+            "org.dom4j",
+            "org.everit",
+            "org.xmlunit",
+            "io.jsonwebtoken",
+            "net.rubygrapefruit",
+            "nonapi",
+            "org.objectweb",
+            "com.vladmihalcea",
+            "org.jvnet",
+            "camundafeel",
+            "groovyjarjarasm",
+            "com.codahale",
+            "org.hamcrest",
+            "net.minidev",
+            "com.thoughtworks",
+            "io.holunda"
+        )
     }
 }

--- a/plugin/src/main/kotlin/com/ritense/plugin/AnnotatedClassResolver.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/AnnotatedClassResolver.kt
@@ -23,7 +23,7 @@ abstract class AnnotatedClassResolver {
 
     inline fun <reified T : Annotation> findAnnotatedClasses(): Map<Class<*>, T> {
         val pluginCategoryClasses = ClassGraph()
-            .rejectPaths(*REJECT_PACKAGES)
+            .rejectPackages(*REJECT_PACKAGES)
             .enableClassInfo()
             .enableAnnotationInfo()
             .scan(1)


### PR DESCRIPTION
Exception:
```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'widgetDataSourceResolver' defined in class path resource [com/ritense/dashboard/autoconfigure/DashboardAutoConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.ritense.dashboard.datasource.WidgetDataSourceResolver]: Factory method 'widgetDataSourceResolver' threw exception; nested exception is io.github.classgraph.ClassGraphException: Uncaught exception during scan
...
Caused by: java.lang.OutOfMemoryError: Java heap space
```


Solution: Don't scan packages with 100+ classes
<img width="430" alt="Screenshot 2023-07-06 at 12 55 14" src="https://github.com/valtimo-platform/valtimo-backend-libraries/assets/94360980/61a2ed2b-8a5c-4791-a287-dd82f23f921a">
