### PR TITLE
fix: plugins configuration export order

### DIFF
--- a/plugin/src/main/kotlin/com/ritense/plugin/web/rest/PluginConfigurationResource.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/web/rest/PluginConfigurationResource.kt
@@ -17,6 +17,7 @@
 package com.ritense.plugin.web.rest
 
 import com.ritense.plugin.domain.ActivityType
+import com.ritense.plugin.domain.PluginConfiguration
 import com.ritense.plugin.domain.PluginConfigurationId
 import com.ritense.plugin.service.PluginConfigurationSearchParameters
 import com.ritense.plugin.service.PluginService
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.util.Comparator.comparingInt
 import java.util.UUID
 
 @RestController
@@ -98,6 +100,11 @@ class PluginConfigurationResource(
     @GetMapping("/v1/plugin/configuration/export")
     fun exportPluginConfiguration(): ResponseEntity<List<PluginConfigurationExportDto>> {
         val pluginConfigurations = pluginService.getPluginConfigurations(PluginConfigurationSearchParameters())
+            .sortedWith(comparingInt<PluginConfiguration> { pluginConfiguration ->
+                pluginConfiguration.properties?.fieldNames()?.asSequence()?.count { it.contains("PluginConfiguration") } ?: 0
+            }
+                .thenBy { it.pluginDefinition.key }
+                .thenBy { it.title })
             .map { PluginConfigurationExportDto(it) }
         return ResponseEntity.ok(pluginConfigurations)
     }


### PR DESCRIPTION
The first plugin in the export file gets created first. If that plugin happens to depend on another plugin, an error is thrown.
