### PR TITLE
renamed zaak-object to zaakobjecten for default case tabs

### DIFF
--- a/app/gzac/src/main/resources/config/case-tabs/bezwaar.case-tabs.json
+++ b/app/gzac/src/main/resources/config/case-tabs/bezwaar.case-tabs.json
@@ -36,9 +36,9 @@
                 },
                 {
                     "name": "Zaak objects",
-                    "key": "zaak-object",
+                    "key": "zaakobjecten",
                     "type": "standard",
-                    "contentKey": "zaak-object"
+                    "contentKey": "zaakobjecten"
                 },
                 {
                     "name": "Notes",


### PR DESCRIPTION
Manually moved changes from release/11.1 to development/11.1.0