### PR TITLE
73500 Deprecate 'task comments'

### DIFF
--- a/app/gzac/src/main/resources/config/pbac/case-tab.permission.json
+++ b/app/gzac/src/main/resources/config/pbac/case-tab.permission.json
@@ -1,0 +1,10 @@
+{
+    "changesetId": "case-tab-v1",
+    "permissions": [
+        {
+            "resourceType": "com.ritense.case.domain.CaseTab",
+            "action": "view",
+            "roleKey": "ROLE_USER"
+        }
+    ]
+}

--- a/core/src/main/java/com/ritense/valtimo/service/CamundaTaskService.java
+++ b/core/src/main/java/com/ritense/valtimo/service/CamundaTaskService.java
@@ -385,12 +385,15 @@ public class CamundaTaskService {
         return camundaIdentityLinkRepository.findAll(byTaskId(task.getId()));
     }
 
+    @Deprecated(since = "11.1.0", forRemoval = true)
     @Transactional(readOnly = true)
     public List<Comment> getTaskComments(String taskId) {
-        final CamundaTask task = findTaskById(taskId);
+        final CamundaTask task = runWithoutAuthorization(() -> findTaskById(taskId));
+        requirePermission(task, VIEW);
         return taskService.getTaskComments(task.getId());
     }
 
+    @Deprecated(since = "11.1.0", forRemoval = true)
     @Transactional(readOnly = true)
     public List<Comment> getProcessInstanceComments(String processInstanceId) {
         var comments = taskService.getProcessInstanceComments(processInstanceId);
@@ -403,6 +406,7 @@ public class CamundaTaskService {
         return comments;
     }
 
+    @Deprecated(since = "11.1.0", forRemoval = true)
     @Transactional
     public void createComment(@Nullable String taskId, @Nullable String processInstanceId, String message) {
         if (taskId != null) {

--- a/core/src/main/java/com/ritense/valtimo/web/rest/ProcessResource.java
+++ b/core/src/main/java/com/ritense/valtimo/web/rest/ProcessResource.java
@@ -465,6 +465,7 @@ public class ProcessResource extends AbstractProcessResource {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @Deprecated(since = "11.1.0", forRemoval = true)
     @GetMapping("/v1/process/{processInstanceId}/comments")
     public ResponseEntity<List<Comment>> getProcessInstanceComments(@PathVariable String processInstanceId) {
         List<Comment> processInstanceComments = camundaTaskService.getProcessInstanceComments(processInstanceId);
@@ -539,6 +540,7 @@ public class ProcessResource extends AbstractProcessResource {
         return new ResponseEntity<>(BatchDto.fromBatch(migrationBatch), HttpStatus.OK);
     }
 
+    @Deprecated(since = "11.1.0", forRemoval = true)
     @PostMapping("/v1/process/{processInstanceId}/comment")
     public ResponseEntity<Void> createComment(@PathVariable String processInstanceId, @RequestBody CommentDto comment) {
         camundaTaskService.createComment(null, processInstanceId, comment.getText());

--- a/core/src/main/java/com/ritense/valtimo/web/rest/TaskResource.java
+++ b/core/src/main/java/com/ritense/valtimo/web/rest/TaskResource.java
@@ -118,6 +118,7 @@ public class TaskResource extends AbstractTaskResource {
         return ResponseEntity.ok().build();
     }
 
+    @Deprecated(since = "11.1.0", forRemoval = true)
     @GetMapping("/v1/task/{taskId}/comments")
     public ResponseEntity<List<Comment>> getProcessInstanceComments(@PathVariable String taskId) {
         final CamundaTask task = camundaTaskService.findTaskById(taskId);


### PR DESCRIPTION
NOTE:
Unable to properly secure 'createComment' because we dont have support for processInstances permission