### PR TITLE
fixed NOT_EQUAL_TO and EQUAL_TO operator for PBAC (#979)

### DIFF
--- a/authorization/src/main/kotlin/com/ritense/authorization/permission/condition/PermissionConditionOperator.kt
+++ b/authorization/src/main/kotlin/com/ritense/authorization/permission/condition/PermissionConditionOperator.kt
@@ -50,10 +50,23 @@ enum class PermissionConditionOperator(@JsonValue val asText: String) {
     ): Predicate {
         return when (this) {
             NOT_EQUAL_TO ->
-                criteriaBuilder.notEqual(expression, value)
+                // Hibernate does not handle nulls very well in some configurations. This is a workaround
+                if (value == null) {
+                    expression.isNotNull
+                } else {
+                    criteriaBuilder.or(
+                        expression.isNull,
+                        criteriaBuilder.notEqual(expression, value)
+                    )
+                }
 
             EQUAL_TO ->
-                criteriaBuilder.equal(expression, value)
+                // Hibernate does not handle nulls very well in some configurations. This is a workaround
+                if (value == null) {
+                    expression.isNull
+                } else {
+                    criteriaBuilder.equal(expression, value)
+                }
 
             LESS_THAN -> {
                 criteriaBuilder.lessThan(expression as Expression<T>, value!! as T)

--- a/authorization/src/test/kotlin/com/ritense/authorization/permission/condition/PermissionConditionOperatorIntTest.kt
+++ b/authorization/src/test/kotlin/com/ritense/authorization/permission/condition/PermissionConditionOperatorIntTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization.permission.condition
+
+import com.ritense.authorization.BaseIntegrationTest
+import com.ritense.authorization.permission.condition.PermissionConditionOperator.CONTAINS
+import com.ritense.authorization.permission.condition.PermissionConditionOperator.EQUAL_TO
+import com.ritense.authorization.permission.condition.PermissionConditionOperator.GREATER_THAN
+import com.ritense.authorization.permission.condition.PermissionConditionOperator.GREATER_THAN_OR_EQUAL_TO
+import com.ritense.authorization.permission.condition.PermissionConditionOperator.LESS_THAN
+import com.ritense.authorization.permission.condition.PermissionConditionOperator.LESS_THAN_OR_EQUAL_TO
+import com.ritense.authorization.permission.condition.PermissionConditionOperator.NOT_EQUAL_TO
+import com.ritense.authorization.testimpl.TestEntity
+import com.ritense.authorization.testimpl.TestEntityRepository
+import kotlin.test.Ignore
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class PermissionConditionOperatorIntTest @Autowired constructor(
+    val testEntityRepository: TestEntityRepository
+) : BaseIntegrationTest() {
+
+    lateinit var nullEntity: TestEntity
+    lateinit var fourEntity: TestEntity
+    lateinit var fiveEntity: TestEntity
+    lateinit var sixEntity: TestEntity
+
+    @BeforeEach
+    fun setup() {
+        this.nullEntity = testEntityRepository.save(TestEntity(fruits = mutableListOf(null, "apple"), someNumber = null))
+        this.fourEntity = testEntityRepository.save(TestEntity(fruits = mutableListOf("apple", "banana"), someNumber = 4))
+        this.fiveEntity = testEntityRepository.save(TestEntity(someNumber = 5))
+        this.sixEntity = testEntityRepository.save(TestEntity(someNumber = 6))
+    }
+
+    @Test
+    fun `NOT_EQUAL_TO should evaluate null value`() {
+        val results = findByNumber(NOT_EQUAL_TO, null)
+
+        Assertions.assertThat(results).contains(fourEntity, fiveEntity, sixEntity)
+        Assertions.assertThat(results).doesNotContain(nullEntity)
+    }
+
+    @Test
+    fun `NOT_EQUAL_TO should evaluate number value`() {
+        val results = findByNumber(NOT_EQUAL_TO, 5)
+
+        Assertions.assertThat(results).contains(nullEntity, fourEntity, sixEntity)
+        Assertions.assertThat(results).doesNotContain(fiveEntity)
+    }
+
+    @Test
+    fun `EQUAL_TO should evaluate null value`() {
+        val results = findByNumber(EQUAL_TO, null)
+
+        Assertions.assertThat(results).containsOnly(nullEntity)
+    }
+
+    @Test
+    fun `EQUAL_TO should evaluate number value`() {
+        val results = findByNumber(EQUAL_TO, 5)
+
+        Assertions.assertThat(results).containsOnly(fiveEntity)
+    }
+
+    @Test
+    fun `GREATER_THAN should evaluate number value`() {
+        val results = findByNumber(GREATER_THAN, 5)
+
+        Assertions.assertThat(results).containsOnly(sixEntity)
+    }
+
+    @Test
+    fun `GREATER_THAN_OR_EQUAL_TO should evaluate number value`() {
+        val results = findByNumber(GREATER_THAN_OR_EQUAL_TO, 5)
+
+        Assertions.assertThat(results).contains(fiveEntity, sixEntity)
+        Assertions.assertThat(results).doesNotContain(nullEntity, fourEntity)
+    }
+
+    @Test
+    fun `LESS_THAN should evaluate number value`() {
+        val results = findByNumber(LESS_THAN, 5)
+
+        Assertions.assertThat(results).containsOnly(fourEntity)
+    }
+
+    @Test
+    fun `LESS_THAN_OR_EQUAL_TO should evaluate number value`() {
+        val results = findByNumber(LESS_THAN_OR_EQUAL_TO, 5)
+
+        Assertions.assertThat(results).contains(fourEntity, fiveEntity)
+        Assertions.assertThat(results).doesNotContain(nullEntity, sixEntity)
+    }
+
+    @Test
+    @Ignore("This should match the evaluate() logic, but it does not")
+    fun `CONTAINS should match null item`() {
+        val results = findByFruits(CONTAINS, null)
+
+        //TODO: fix this
+        Assertions.assertThat(results).containsOnly(nullEntity)
+    }
+
+    @Test
+    fun `CONTAINS should match multiple items`() {
+        val results = findByFruits(CONTAINS, "apple")
+
+        Assertions.assertThat(results).containsOnly(nullEntity, fourEntity)
+    }
+
+    @Test
+    fun `CONTAINS should match single item`() {
+        val results = findByFruits(CONTAINS, "banana")
+
+        Assertions.assertThat(results).containsOnly(fourEntity)
+    }
+
+    private fun findByFruits(op: PermissionConditionOperator, fruit: String?): MutableList<TestEntity> =
+        testEntityRepository.findAll { root, _, criteriaBuilder ->
+            op.toPredicate<Int>(
+                criteriaBuilder,
+                root.get<Int>("fruits"),
+                fruit
+            )
+        }
+
+    private fun findByNumber(op: PermissionConditionOperator, number: Int?): MutableList<TestEntity> =
+        testEntityRepository.findAll { root, _, criteriaBuilder ->
+            op.toPredicate<Int>(
+                criteriaBuilder,
+                root.get<Int>("someNumber"),
+                number
+            )
+        }
+}

--- a/authorization/src/test/kotlin/com/ritense/authorization/permission/condition/PermissionConditionOperatorTest.kt
+++ b/authorization/src/test/kotlin/com/ritense/authorization/permission/condition/PermissionConditionOperatorTest.kt
@@ -16,8 +16,8 @@
 
 package com.ritense.authorization.permission.condition
 
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class PermissionConditionOperatorTest {
 
@@ -123,6 +123,8 @@ class PermissionConditionOperatorTest {
         assertEquals(false, op, listOf("a"), null)
         assertEquals(true, op, null, null)
         assertEquals(false, op, null, "a")
+        assertEquals(true, op, "a", "a") // TODO: is this intended behaviour? If so, match the predicate variant.
+        assertEquals(false, op, "b", "a")
     }
 
     private fun assertEquals(expected: Boolean, op: PermissionConditionOperator, left: Any?, right: Any?) {

--- a/authorization/src/test/kotlin/com/ritense/authorization/testimpl/TestEntity.kt
+++ b/authorization/src/test/kotlin/com/ritense/authorization/testimpl/TestEntity.kt
@@ -16,7 +16,6 @@
 
 package com.ritense.authorization.testimpl
 
-import org.hibernate.annotations.Type
 import java.util.UUID
 import javax.persistence.CollectionTable
 import javax.persistence.Column
@@ -25,6 +24,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.Table
+import org.hibernate.annotations.Type
 
 @Entity
 @Table(name = "test_entity")
@@ -43,8 +43,11 @@ data class TestEntity(
         joinColumns = [JoinColumn(name = "test_entity_id", referencedColumnName = "id")]
     )
     @Column(name = "name")
-    val fruits: MutableList<String> = mutableListOf(),
+    val fruits: MutableList<String?> = mutableListOf(),
 
     @Id
     val id: UUID = UUID.randomUUID(),
+
+    @Column(name = "some_number", columnDefinition = "int")
+    val someNumber: Int? = null
 )

--- a/authorization/src/test/resources/config/liquibase/authorization-test-master.xml
+++ b/authorization/src/test/resources/config/liquibase/authorization-test-master.xml
@@ -31,6 +31,9 @@
             <column name="name" type="VARCHAR(100)">
                 <constraints nullable="false"/>
             </column>
+            <column name="some_number" type="int">
+                <constraints nullable="true"/>
+            </column>
         </createTable>
     </changeSet>
 
@@ -40,7 +43,7 @@
                 <constraints nullable="false"/>
             </column>
             <column name="name" type="VARCHAR(100)">
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
             </column>
         </createTable>
     </changeSet>

--- a/contract/src/main/kotlin/com/ritense/valtimo/contract/repository/ExpressionOperator.kt
+++ b/contract/src/main/kotlin/com/ritense/valtimo/contract/repository/ExpressionOperator.kt
@@ -35,15 +35,22 @@ enum class ExpressionOperator(
     fun <T : Comparable<T>> toPredicate(criteriaBuilder: CriteriaBuilder, expression: Expression<T>, value: T?): Predicate {
         return when(this) {
             NOT_EQUAL_TO ->
-                criteriaBuilder.notEqual(
-                    expression,
-                    value
-                )
+                // Hibernate does not handle nulls very well in some configurations. This is a workaround
+                if (value == null) {
+                    expression.isNotNull
+                } else {
+                    criteriaBuilder.or(
+                        expression.isNull,
+                        criteriaBuilder.notEqual(expression, value)
+                    )
+                }
             EQUAL_TO ->
-                criteriaBuilder.equal(
-                    expression,
-                    value
-                )
+                // Hibernate does not handle nulls very well in some configurations. This is a workaround
+                if (value == null) {
+                    expression.isNull
+                } else {
+                    criteriaBuilder.equal(expression, value)
+                }
             LESS_THAN ->
                 criteriaBuilder.lessThan(
                     expression,


### PR DESCRIPTION
* fixed NOT_EQUAL_TO and EQUAL_TO operator for PBAC where null values were not evaluated correctly.