### PR TITLE
Logging publisher has lowest priority

### DIFF
--- a/outbox/src/main/kotlin/com/ritense/outbox/config/LoggingOutboxMessagePublisherAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/LoggingOutboxMessagePublisherAutoConfiguration.kt
@@ -14,28 +14,22 @@
  * limitations under the License.
  */
 
-package com.ritense.outbox.rabbitmq.config
+package com.ritense.outbox.config
 
+import com.ritense.outbox.publisher.LoggingMessagePublisher
 import com.ritense.outbox.publisher.MessagePublisher
-import com.ritense.outbox.rabbitmq.RabbitMessagePublisher
-import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.boot.autoconfigure.AutoConfigureOrder
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-
+import org.springframework.core.Ordered
 
 @Configuration
-@EnableConfigurationProperties(RabbitOutboxConfigurationProperties::class)
-class RabbitOutboxAutoconfiguration {
-
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
+class LoggingOutboxMessagePublisherAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(MessagePublisher::class)
-    fun outboxPublisher(rabbitTemplate: RabbitTemplate, configurationProperties: RabbitOutboxConfigurationProperties): MessagePublisher {
-        return RabbitMessagePublisher(
-            rabbitTemplate,
-            configurationProperties.routingKey,
-            configurationProperties.deliveryTimeout
-        )
+    fun loggingMessagePublisher(): MessagePublisher {
+        return LoggingMessagePublisher()
     }
 }

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-package com.ritense.outbox
+package com.ritense.outbox.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ritense.outbox.publisher.LoggingMessagePublisher
+import com.ritense.outbox.OutboxLiquibaseRunner
+import com.ritense.outbox.OutboxMessageRepository
+import com.ritense.outbox.OutboxService
+import com.ritense.outbox.UserProvider
 import com.ritense.outbox.publisher.MessagePublisher
 import com.ritense.outbox.publisher.PollingPublisherJob
 import com.ritense.outbox.publisher.PollingPublisherService
@@ -99,11 +102,4 @@ class OutboxAutoConfiguration {
     ): PollingPublisherJob {
         return PollingPublisherJob(pollingPublisherService)
     }
-
-    @Bean
-    @ConditionalOnMissingBean(MessagePublisher::class)
-    fun loggingMessagePublisher(): MessagePublisher {
-        return LoggingMessagePublisher()
-    }
-
 }

--- a/outbox/src/main/kotlin/com/ritense/outbox/publisher/LoggingMessagePublisher.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/publisher/LoggingMessagePublisher.kt
@@ -23,7 +23,7 @@ import mu.KotlinLogging
 open class LoggingMessagePublisher : MessagePublisher {
 
     override fun publish(message: OutboxMessage) {
-        logger.info { "OutboxMessage id: '${message.id}', content: ${message.message}" }
+        logger.info { "OutboxMessage id: '${message.id}'" }
     }
 
     companion object {

--- a/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
@@ -17,10 +17,10 @@
 package com.ritense.outbox.publisher
 
 import com.ritense.outbox.OutboxService
+import java.util.concurrent.atomic.AtomicBoolean
 import mu.KotlinLogging
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
-import java.util.concurrent.atomic.AtomicBoolean
 
 open class PollingPublisherService(
     private val outboxService: OutboxService,
@@ -28,6 +28,10 @@ open class PollingPublisherService(
     private val platformTransactionManager: PlatformTransactionManager
 ) {
     private val polling = AtomicBoolean(false)
+
+    init {
+        logger.info { "Using ${messagePublisher::class.qualifiedName} as outbox message publisher." }
+    }
 
     /**
      * Poll messages from the outbox table and publishes them in the correct order.

--- a/outbox/src/main/resources/META-INF/spring.factories
+++ b/outbox/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.ritense.outbox.OutboxAutoConfiguration
+  com.ritense.outbox.config.OutboxAutoConfiguration, \
+  com.ritense.outbox.config.LoggingOutboxMessagePublisherAutoConfiguration


### PR DESCRIPTION
LoggingMessagePublisher now has lowest priority, making it easier to provide a custom publisher.