### PR TITLE
87074 Add configuration property to disable outbox

### DIFF
--- a/app/gzac/src/main/resources/config/application.yml
+++ b/app/gzac/src/main/resources/config/application.yml
@@ -219,6 +219,7 @@ valtimo:
         case-tabs:
             clear-tables: true
     outbox:
+        enabled: false
         publisher:
             cloudevent-source: "com.ritense.gzac"
             rabbitmq:

--- a/core/src/main/java/com/ritense/valtimo/service/CamundaTaskService.java
+++ b/core/src/main/java/com/ritense/valtimo/service/CamundaTaskService.java
@@ -227,7 +227,7 @@ public class CamundaTaskService {
         requirePermission(task, COMPLETE);
         taskService.complete(taskId);
         entityManager.detach(task);
-        outboxService.send(new TaskCompleted(taskId));
+        outboxService.send(() -> new TaskCompleted(taskId));
     }
 
     @Transactional

--- a/core/src/test/java/com/ritense/valtimo/service/CamundaTaskServiceIntTest.java
+++ b/core/src/test/java/com/ritense/valtimo/service/CamundaTaskServiceIntTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static com.ritense.valtimo.contract.authentication.AuthoritiesConstants.ADMIN;
 import static com.ritense.valtimo.contract.authentication.AuthoritiesConstants.USER;
@@ -293,9 +294,9 @@ class CamundaTaskServiceIntTest extends BaseIntegrationTest {
 
         camundaTaskService.complete(task.getId());
 
-        var eventCapture = ArgumentCaptor.forClass(BaseEvent.class);
+        ArgumentCaptor<Supplier<BaseEvent>> eventCapture = ArgumentCaptor.forClass(Supplier.class);
         verify(outboxService, times(1)).send(eventCapture.capture());
-        var event = eventCapture.getValue();
+        var event = eventCapture.getValue().get();
         assertThat(event.getType()).isEqualTo("com.ritense.valtimo.task.completed");
         assertThat(event.getResultType()).isEqualTo("com.ritense.valtimo.camunda.domain.CamundaTask");
         assertThat(event.getResultId()).isEqualTo(task.getId());

--- a/document/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentService.java
+++ b/document/src/main/java/com/ritense/document/service/impl/JsonSchemaDocumentService.java
@@ -229,7 +229,7 @@ public class JsonSchemaDocumentService implements DocumentService {
 
                 documentRepository.save(jsonSchemaDocument);
 
-                outboxService.send(
+                outboxService.send(() ->
                     new DocumentCreated(
                         jsonSchemaDocument.id().toString(),
                         Mapper.INSTANCE.get().valueToTree(jsonSchemaDocument)
@@ -298,7 +298,7 @@ public class JsonSchemaDocumentService implements DocumentService {
 
         result.resultingDocument().ifPresent(modifiedDocument -> {
             documentRepository.save(modifiedDocument);
-            outboxService.send(
+            outboxService.send(() ->
                 new DocumentUpdated(
                     modifiedDocument.id().toString(),
                     Mapper.INSTANCE.get().valueToTree(modifiedDocument)

--- a/document/src/main/java/com/ritense/document/web/rest/impl/JsonSchemaDocumentResource.java
+++ b/document/src/main/java/com/ritense/document/web/rest/impl/JsonSchemaDocumentResource.java
@@ -75,7 +75,7 @@ public class JsonSchemaDocumentResource implements DocumentResource {
     public ResponseEntity<? extends Document> getDocument(@PathVariable(name = "id") UUID id) {
         var document = documentService.findBy(JsonSchemaDocumentId.existingId(id)).orElse(null);
         if (document != null) {
-            outboxService.send(
+            outboxService.send(() ->
                 new DocumentViewed(
                     document.id().toString(),
                     Mapper.INSTANCE.get().valueToTree(document)

--- a/document/src/test/java/com/ritense/document/web/rest/JsonSchemaDocumentResourceIntegrationTest.java
+++ b/document/src/test/java/com/ritense/document/web/rest/JsonSchemaDocumentResourceIntegrationTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static com.ritense.valtimo.contract.utils.TestUtil.convertObjectToJsonBytes;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -257,9 +258,9 @@ class JsonSchemaDocumentResourceIntegrationTest extends BaseIntegrationTest {
             .andDo(print())
             .andExpect(status().isOk());
 
-        var eventCapture = ArgumentCaptor.forClass(BaseEvent.class);
+        ArgumentCaptor<Supplier<BaseEvent>> eventCapture = ArgumentCaptor.forClass(Supplier.class);
         verify(outboxService, times(1)).send(eventCapture.capture());
-        var event = eventCapture.getValue();
+        var event = eventCapture.getValue().get();
         assertEquals("com.ritense.valtimo.document.viewed", event.getType());
         assertEquals("com.ritense.document.domain.impl.JsonSchemaDocument", event.getResultType());
         assertEquals(document.id().toString(), event.getResultId());

--- a/document/src/test/kotlin/com/ritense/document/service/impl/JsonSchemaDocumentServiceIntTest.kt
+++ b/document/src/test/kotlin/com/ritense/document/service/impl/JsonSchemaDocumentServiceIntTest.kt
@@ -32,6 +32,9 @@ import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.ADMIN
 import com.ritense.valtimo.contract.authentication.AuthoritiesConstants.USER
 import com.ritense.valtimo.contract.authentication.NamedUser
 import com.ritense.valtimo.contract.json.Mapper
+import java.util.UUID
+import java.util.function.Supplier
+import javax.transaction.Transactional
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
@@ -44,8 +47,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.security.test.context.support.WithMockUser
-import java.util.UUID
-import javax.transaction.Transactional
 
 @Tag("integration")
 @Transactional
@@ -132,9 +133,9 @@ internal class JsonSchemaDocumentServiceIntTest : BaseIntegrationTest() {
 
         val document = createDocument("""{"street": "Admin street"}""")
 
-        val eventCapture = argumentCaptor<BaseEvent>()
+        val eventCapture = argumentCaptor<Supplier<BaseEvent>>()
         verify(outboxService, times(1)).send(eventCapture.capture())
-        val event = eventCapture.firstValue
+        val event = eventCapture.firstValue.get()
         assertThat(event.type).isEqualTo("com.ritense.valtimo.document.created")
         assertThat(event.resultType).isEqualTo("com.ritense.document.domain.impl.JsonSchemaDocument")
         assertThat(event.resultId).isEqualTo(document.id().toString())
@@ -151,9 +152,9 @@ internal class JsonSchemaDocumentServiceIntTest : BaseIntegrationTest() {
 
         val modifiedDocument = documentService.modifyDocument(documentRequest).resultingDocument().orElseThrow()
 
-        val eventCapture = argumentCaptor<BaseEvent>()
+        val eventCapture = argumentCaptor<Supplier<BaseEvent>>()
         verify(outboxService, times(1)).send(eventCapture.capture())
-        val event = eventCapture.firstValue
+        val event = eventCapture.firstValue.get()
         assertThat(event.type).isEqualTo("com.ritense.valtimo.document.updated")
         assertThat(event.resultType).isEqualTo("com.ritense.document.domain.impl.JsonSchemaDocument")
         assertThat(event.resultId).isEqualTo(document.id().toString())

--- a/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/config/RabbitOutboxAutoconfiguration.kt
+++ b/outbox/outbox-rabbitmq/src/main/kotlin/com/ritense/outbox/rabbitmq/config/RabbitOutboxAutoconfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.outbox.rabbitmq.config
 
+import com.ritense.outbox.config.condition.ConditionalOnOutboxEnabled
 import com.ritense.outbox.publisher.MessagePublisher
 import com.ritense.outbox.rabbitmq.RabbitMessagePublisher
 import org.springframework.amqp.rabbit.core.RabbitTemplate
@@ -26,6 +27,7 @@ import org.springframework.context.annotation.Configuration
 
 
 @Configuration
+@ConditionalOnOutboxEnabled
 @EnableConfigurationProperties(RabbitOutboxConfigurationProperties::class)
 class RabbitOutboxAutoconfiguration {
 

--- a/outbox/src/main/kotlin/com/ritense/outbox/DefaultOutboxService.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/DefaultOutboxService.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ritense.outbox.domain.BaseEvent
+import com.ritense.outbox.domain.CloudEventData
+import io.cloudevents.core.builder.CloudEventBuilder
+import io.cloudevents.core.provider.EventFormatProvider
+import io.cloudevents.jackson.JsonFormat
+import java.net.URI
+import java.time.ZonedDateTime
+import java.util.UUID
+import java.util.function.Supplier
+import kotlin.text.Charsets.UTF_8
+import mu.KotlinLogging
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+
+open class DefaultOutboxService(
+    private val outboxMessageRepository: OutboxMessageRepository,
+    private val objectMapper: ObjectMapper,
+    private val userProvider: UserProvider,
+    private val cloudEventSource: String,
+) : OutboxService {
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    override fun send(eventSupplier: Supplier<BaseEvent>) {
+        val baseEvent = eventSupplier.get()
+
+        val userId = baseEvent.userId ?: userProvider.getCurrentUserLogin() ?: "System"
+        val roles = baseEvent.roles ?: userProvider.getCurrentUserRoles().joinToString(",")
+        val cloudEventData = CloudEventData(userId, roles, baseEvent.resultType, baseEvent.resultId, baseEvent.result)
+        val cloudEvent = CloudEventBuilder.v1()
+            .withId(baseEvent.id.toString())
+            .withSource(URI(cloudEventSource))
+            .withTime(baseEvent.date.atOffset(ZonedDateTime.now().offset))
+            .withType(baseEvent.type)
+            .withDataContentType("application/json")
+            .withData(objectMapper.writeValueAsBytes(cloudEventData))
+            .build()
+        val serializedCloudEvent = EventFormatProvider
+            .getInstance()
+            .resolveFormat(JsonFormat.CONTENT_TYPE)!!
+            .serialize(cloudEvent)
+        val serializedCloudEventString = String(serializedCloudEvent, UTF_8)
+
+        send(serializedCloudEventString)
+    }
+
+    /**
+     * Guarantee that the message is published using the transactional outbox pattern.
+     * See: https://microservices.io/patterns/data/transactional-outbox.html
+     *
+     * Typical workflow:
+     * @Transactional
+     * fun saveOrders() {
+     *      orderRepo.save(order)
+     *      order.events.forEach { outboxService.send(it) }
+     *      order.events.clear()
+     * }
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun send(message: String) {
+        val outboxMessage = OutboxMessage(
+            message = message
+        )
+        logger.debug { "Saving OutboxMessage '${outboxMessage.id}'" }
+        outboxMessageRepository.save(outboxMessage)
+    }
+
+    open fun getOldestMessage() = outboxMessageRepository.findTopByOrderByCreatedOnAsc()
+
+    open fun deleteMessage(id: UUID) = outboxMessageRepository.deleteById(id)
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/outbox/src/main/kotlin/com/ritense/outbox/NoopOutboxService.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/NoopOutboxService.kt
@@ -21,7 +21,7 @@ import com.ritense.outbox.domain.BaseEvent
 import java.util.function.Supplier
 
 class NoopOutboxService : OutboxService {
-    override fun send(baseEventSupplier: Supplier<BaseEvent>) {
+    override fun send(eventSupplier: Supplier<BaseEvent>) {
         // Nothing to do
     }
 }

--- a/outbox/src/main/kotlin/com/ritense/outbox/NoopOutboxService.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/NoopOutboxService.kt
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package com.ritense.outbox.config.condition
-
-import org.springframework.context.annotation.Conditional
+package com.ritense.outbox
 
 
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
-@MustBeDocumented
-@Conditional(
-    OnOutboxEnabledCondition::class
-)
-annotation class ConditionalOnOutboxEnabled(val value: Boolean = true)
+import com.ritense.outbox.domain.BaseEvent
+import java.util.function.Supplier
+
+class NoopOutboxService : OutboxService {
+    override fun send(baseEventSupplier: Supplier<BaseEvent>) {
+        // Nothing to do
+    }
+}

--- a/outbox/src/main/kotlin/com/ritense/outbox/OutboxService.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/OutboxService.kt
@@ -21,5 +21,5 @@ import com.ritense.outbox.domain.BaseEvent
 import java.util.function.Supplier
 
 interface OutboxService {
-    fun send(baseEventSupplier: Supplier<BaseEvent>)
+    fun send(eventSupplier: Supplier<BaseEvent>)
 }

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/DisabledOutboxAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/DisabledOutboxAutoConfiguration.kt
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-package com.ritense.outbox.config.condition
+package com.ritense.outbox.config
 
-import org.springframework.context.annotation.Conditional
+import com.ritense.outbox.NoopOutboxService
+import com.ritense.outbox.OutboxService
+import com.ritense.outbox.config.condition.ConditionalOnOutboxEnabled
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
 
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
-@MustBeDocumented
-@Conditional(
-    OnOutboxEnabledCondition::class
-)
-annotation class ConditionalOnOutboxEnabled(val value: Boolean = true)
+@Configuration
+@ConditionalOnOutboxEnabled(false)
+class DisabledOutboxAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean(OutboxService::class)
+    fun noopOutboxService() = NoopOutboxService()
+}

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/LoggingOutboxMessagePublisherAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/LoggingOutboxMessagePublisherAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.outbox.config
 
+import com.ritense.outbox.config.condition.ConditionalOnOutboxEnabled
 import com.ritense.outbox.publisher.LoggingMessagePublisher
 import com.ritense.outbox.publisher.MessagePublisher
 import org.springframework.boot.autoconfigure.AutoConfigureOrder
@@ -25,6 +26,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
 
 @Configuration
+@ConditionalOnOutboxEnabled
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 class LoggingOutboxMessagePublisherAutoConfiguration {
     @Bean

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/LoggingOutboxMessagePublisherAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/LoggingOutboxMessagePublisherAutoConfiguration.kt
@@ -14,28 +14,22 @@
  * limitations under the License.
  */
 
-package com.ritense.outbox.rabbitmq.config
+package com.ritense.outbox.config
 
+import com.ritense.outbox.publisher.LoggingMessagePublisher
 import com.ritense.outbox.publisher.MessagePublisher
-import com.ritense.outbox.rabbitmq.RabbitMessagePublisher
-import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.boot.autoconfigure.AutoConfigureOrder
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-
+import org.springframework.core.Ordered
 
 @Configuration
-@EnableConfigurationProperties(RabbitOutboxConfigurationProperties::class)
-class RabbitOutboxAutoconfiguration {
-
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
+class LoggingOutboxMessagePublisherAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(MessagePublisher::class)
-    fun outboxPublisher(rabbitTemplate: RabbitTemplate, configurationProperties: RabbitOutboxConfigurationProperties): MessagePublisher {
-        return RabbitMessagePublisher(
-            rabbitTemplate,
-            configurationProperties.routingKey,
-            configurationProperties.deliveryTimeout
-        )
+    fun loggingMessagePublisher(): MessagePublisher {
+        return LoggingMessagePublisher()
     }
 }

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-package com.ritense.outbox
+package com.ritense.outbox.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ritense.outbox.publisher.LoggingMessagePublisher
+import com.ritense.outbox.OutboxLiquibaseRunner
+import com.ritense.outbox.OutboxMessageRepository
+import com.ritense.outbox.OutboxService
+import com.ritense.outbox.UserProvider
 import com.ritense.outbox.publisher.MessagePublisher
 import com.ritense.outbox.publisher.PollingPublisherJob
 import com.ritense.outbox.publisher.PollingPublisherService
@@ -99,11 +102,4 @@ class OutboxAutoConfiguration {
     ): PollingPublisherJob {
         return PollingPublisherJob(pollingPublisherService)
     }
-
-    @Bean
-    @ConditionalOnMissingBean(MessagePublisher::class)
-    fun loggingMessagePublisher(): MessagePublisher {
-        return LoggingMessagePublisher()
-    }
-
 }

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
@@ -21,6 +21,7 @@ import com.ritense.outbox.OutboxLiquibaseRunner
 import com.ritense.outbox.OutboxMessageRepository
 import com.ritense.outbox.OutboxService
 import com.ritense.outbox.UserProvider
+import com.ritense.outbox.config.condition.ConditionalOnOutboxEnabled
 import com.ritense.outbox.publisher.MessagePublisher
 import com.ritense.outbox.publisher.PollingPublisherJob
 import com.ritense.outbox.publisher.PollingPublisherService
@@ -39,6 +40,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.transaction.PlatformTransactionManager
 
 @Configuration
+@ConditionalOnOutboxEnabled
 @EnableJpaRepositories(
     basePackageClasses = [
         OutboxMessageRepository::class

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/OutboxAutoConfiguration.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.outbox.OutboxLiquibaseRunner
 import com.ritense.outbox.OutboxMessageRepository
 import com.ritense.outbox.OutboxService
+import com.ritense.outbox.DefaultOutboxService
 import com.ritense.outbox.UserProvider
 import com.ritense.outbox.config.condition.ConditionalOnOutboxEnabled
 import com.ritense.outbox.publisher.MessagePublisher
@@ -69,13 +70,13 @@ class OutboxAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(OutboxService::class)
-    fun outboxService(
+    fun defaultOutboxService(
         outboxMessageRepository: OutboxMessageRepository,
         objectMapper: ObjectMapper,
         userProvider: UserProvider,
         @Value("\${valtimo.outbox.publisher.cloudevent-source:\${spring.application.name:application}}") cloudEventSource: String,
-        ): OutboxService {
-        return OutboxService(
+    ): OutboxService {
+        return DefaultOutboxService(
             outboxMessageRepository,
             objectMapper,
             userProvider,
@@ -86,7 +87,7 @@ class OutboxAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(PollingPublisherService::class)
     fun pollingPublisherService(
-        outboxService: OutboxService,
+        outboxService: DefaultOutboxService,
         messagePublisher: MessagePublisher,
         platformTransactionManager: PlatformTransactionManager
     ): PollingPublisherService {

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/condition/ConditionalOnOutboxEnabled.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/condition/ConditionalOnOutboxEnabled.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox.config.condition
+
+import org.springframework.context.annotation.Conditional
+
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Conditional(
+    OnOutboxEnabledCondition::class
+)
+annotation class ConditionalOnOutboxEnabled

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledCondition.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledCondition.kt
@@ -21,10 +21,13 @@ import org.springframework.context.annotation.ConditionContext
 import org.springframework.core.type.AnnotatedTypeMetadata
 
 class OnOutboxEnabledCondition : Condition {
-    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata) =
-        context.environment.getProperty(PROPERTY_NAME, "true").toBoolean()
+    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata): Boolean {
+        val annotationName = ConditionalOnOutboxEnabled::class.java.name
+        val value = (metadata.getAnnotationAttributes(annotationName)?.get("value") as? Boolean) ?: true
+        return context.environment.getProperty(PROPERTY_NAME, "true").toBoolean() == value
+    }
 
     companion object {
-        const val PROPERTY_NAME = "valtimo.outbox.enabled"
+        internal const val PROPERTY_NAME = "valtimo.outbox.enabled"
     }
 }

--- a/outbox/src/main/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledCondition.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledCondition.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.outbox.config.condition
+
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.core.type.AnnotatedTypeMetadata
+
+class OnOutboxEnabledCondition : Condition {
+    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata) =
+        context.environment.getProperty(PROPERTY_NAME, "true").toBoolean()
+
+    companion object {
+        const val PROPERTY_NAME = "valtimo.outbox.enabled"
+    }
+}

--- a/outbox/src/main/kotlin/com/ritense/outbox/publisher/LoggingMessagePublisher.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/publisher/LoggingMessagePublisher.kt
@@ -23,7 +23,7 @@ import mu.KotlinLogging
 open class LoggingMessagePublisher : MessagePublisher {
 
     override fun publish(message: OutboxMessage) {
-        logger.info { "OutboxMessage id: '${message.id}', content: ${message.message}" }
+        logger.info { "OutboxMessage id: '${message.id}'" }
     }
 
     companion object {

--- a/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
@@ -17,10 +17,10 @@
 package com.ritense.outbox.publisher
 
 import com.ritense.outbox.OutboxService
+import java.util.concurrent.atomic.AtomicBoolean
 import mu.KotlinLogging
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
-import java.util.concurrent.atomic.AtomicBoolean
 
 open class PollingPublisherService(
     private val outboxService: OutboxService,
@@ -28,6 +28,10 @@ open class PollingPublisherService(
     private val platformTransactionManager: PlatformTransactionManager
 ) {
     private val polling = AtomicBoolean(false)
+
+    init {
+        logger.info { "Using ${messagePublisher::class.qualifiedName} as outbox message publisher." }
+    }
 
     /**
      * Poll messages from the outbox table and publishes them in the correct order.

--- a/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/publisher/PollingPublisherService.kt
@@ -16,14 +16,14 @@
 
 package com.ritense.outbox.publisher
 
-import com.ritense.outbox.OutboxService
+import com.ritense.outbox.DefaultOutboxService
 import java.util.concurrent.atomic.AtomicBoolean
 import mu.KotlinLogging
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
 
 open class PollingPublisherService(
-    private val outboxService: OutboxService,
+    private val outboxService: DefaultOutboxService,
     private val messagePublisher: MessagePublisher,
     private val platformTransactionManager: PlatformTransactionManager
 ) {

--- a/outbox/src/main/resources/META-INF/spring.factories
+++ b/outbox/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.ritense.outbox.OutboxAutoConfiguration
+  com.ritense.outbox.config.OutboxAutoConfiguration, \
+  com.ritense.outbox.config.LoggingOutboxMessagePublisherAutoConfiguration

--- a/outbox/src/main/resources/META-INF/spring.factories
+++ b/outbox/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.ritense.outbox.config.OutboxAutoConfiguration, \
-  com.ritense.outbox.config.LoggingOutboxMessagePublisherAutoConfiguration
+  com.ritense.outbox.config.DisabledOutboxAutoConfiguration, \
+  com.ritense.outbox.config.LoggingOutboxMessagePublisherAutoConfiguration, \
+  com.ritense.outbox.config.OutboxAutoConfiguration

--- a/outbox/src/test/kotlin/com/ritense/outbox/OutboxServiceImplIntTest.kt
+++ b/outbox/src/test/kotlin/com/ritense/outbox/OutboxServiceImplIntTest.kt
@@ -27,10 +27,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.transaction.annotation.Transactional
 
-class OutboxServiceIntTest : BaseIntegrationTest() {
+class OutboxServiceImplIntTest : BaseIntegrationTest() {
 
     @Autowired
-    lateinit var outboxService: OutboxService
+    lateinit var outboxService: DefaultOutboxService
 
     @Test
     @Transactional
@@ -59,7 +59,7 @@ class OutboxServiceIntTest : BaseIntegrationTest() {
     @Test
     @Transactional
     fun `should save a cloud event if a base event is submitted`() {
-        outboxService.send(TestEvent())
+        outboxService.send { TestEvent() }
 
         val messages = outboxMessageRepository.findAll()
         assertThat(messages.size).isEqualTo(1)
@@ -70,7 +70,7 @@ class OutboxServiceIntTest : BaseIntegrationTest() {
     @Test
     @Transactional
     fun `should set source to 'application' when no application name or system user id is provided`() {
-        outboxService.send(TestEvent())
+        outboxService.send { TestEvent() }
 
         val messages = outboxMessageRepository.findAll()
         assertThat(messages.size).isEqualTo(1)
@@ -81,7 +81,7 @@ class OutboxServiceIntTest : BaseIntegrationTest() {
     @Test
     @Transactional
     fun `should set user id to "System" if no user is available`() {
-        outboxService.send(TestEvent())
+        outboxService.send { TestEvent() }
 
         val messages = outboxMessageRepository.findAll()
         assertThat(messages.size).isEqualTo(1)
@@ -93,7 +93,7 @@ class OutboxServiceIntTest : BaseIntegrationTest() {
     @WithMockUser(username = "user@ritense.com", authorities = ["ADMIN", "USER"])
     @Transactional
     fun `should correctly set user id and roles for a cloud event`() {
-        outboxService.send(TestEvent())
+        outboxService.send { TestEvent() }
 
         val messages = outboxMessageRepository.findAll()
         assertThat(messages.size).isEqualTo(1)

--- a/outbox/src/test/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledConditionIntTest.kt
+++ b/outbox/src/test/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledConditionIntTest.kt
@@ -1,13 +1,28 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.outbox.config.condition
 
-import com.ritense.outbox.OutboxService
+import com.ritense.outbox.DefaultOutboxService
+import com.ritense.outbox.NoopOutboxService
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
@@ -23,8 +38,8 @@ class OnOutboxEnabledConditionIntTest {
         private val context: ApplicationContext
     ) {
         @Test
-        fun `Should create an OutboxService bean`() {
-            val bean = context.getBean(OutboxService::class.java)
+        fun `Should create an DefaultOutboxService bean`() {
+            val bean = context.getBean(DefaultOutboxService::class.java)
             Assertions.assertThat(bean).isNotNull
         }
     }
@@ -35,10 +50,9 @@ class OnOutboxEnabledConditionIntTest {
         private val context: ApplicationContext
     ) {
         @Test
-        fun `Should not create an OutboxService bean`() {
-            assertThrows<NoSuchBeanDefinitionException> {
-                context.getBean(OutboxService::class.java)
-            }
+        fun `Should create NoopOutboxService bean`() {
+            val bean = context.getBean(NoopOutboxService::class.java)
+            Assertions.assertThat(bean).isNotNull
         }
     }
 }

--- a/outbox/src/test/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledConditionIntTest.kt
+++ b/outbox/src/test/kotlin/com/ritense/outbox/config/condition/OnOutboxEnabledConditionIntTest.kt
@@ -1,0 +1,44 @@
+package com.ritense.outbox.config.condition
+
+import com.ritense.outbox.OutboxService
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@Tag("integration")
+class OnOutboxEnabledConditionIntTest {
+
+    @Nested
+    @SpringBootTest(properties = ["${OnOutboxEnabledCondition.PROPERTY_NAME}=true"])
+    inner class Enabled @Autowired constructor(
+        private val context: ApplicationContext
+    ) {
+        @Test
+        fun `Should create an OutboxService bean`() {
+            val bean = context.getBean(OutboxService::class.java)
+            Assertions.assertThat(bean).isNotNull
+        }
+    }
+
+    @Nested
+    @SpringBootTest(properties = ["${OnOutboxEnabledCondition.PROPERTY_NAME}=false"])
+    inner class Disabled @Autowired constructor(
+        private val context: ApplicationContext
+    ) {
+        @Test
+        fun `Should not create an OutboxService bean`() {
+            assertThrows<NoSuchBeanDefinitionException> {
+                context.getBean(OutboxService::class.java)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added `@ConditionalOnOutboxEnabled` annotation that checks the `valtimo.outbox.enabled` property and can be used by custom message publishers as well
- Moved `LoggingMessagePublisher` to its own configuration so that the priority can be set to lowest. This makes it easier/less error prone for custom implementations to override the `LoggingMessagePublisher`.