### PR TITLE
Fix Hibernate `javax.persistence.lock.timeout` deprecation log

### DIFF
--- a/outbox/src/main/kotlin/com/ritense/outbox/OutboxMessageRepository.kt
+++ b/outbox/src/main/kotlin/com/ritense/outbox/OutboxMessageRepository.kt
@@ -18,7 +18,7 @@ package com.ritense.outbox
 
 import jakarta.persistence.LockModeType.PESSIMISTIC_WRITE
 import jakarta.persistence.QueryHint
-import org.hibernate.cfg.AvailableSettings.JPA_LOCK_TIMEOUT
+import org.hibernate.cfg.AvailableSettings.JAKARTA_LOCK_TIMEOUT
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.QueryHints
@@ -29,7 +29,7 @@ interface OutboxMessageRepository : JpaRepository<OutboxMessage, UUID> {
     /**
      * Use 'FOR UPDATE SKIP LOCKED' in sql query. But only if it's supported by the 'spring.jpa.database-platform'.
      */
-    @QueryHints(value = [QueryHint(name = JPA_LOCK_TIMEOUT, value = SKIP_LOCKED)])
+    @QueryHints(value = [QueryHint(name = JAKARTA_LOCK_TIMEOUT, value = SKIP_LOCKED)])
     @Lock(PESSIMISTIC_WRITE)
     fun findTopByOrderByCreatedOnAsc(): OutboxMessage?
 


### PR DESCRIPTION
Finally found the culprit of the `HHH90000021: Encountered deprecated setting [javax.persistence.lock.timeout], use [jakarta.persistence.lock.timeout] instead` log