### PR TITLE
Fixed composite-id equals() and hashCode() warnings

### DIFF
--- a/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldId.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/searchfield/SearchFieldId.java
@@ -19,6 +19,7 @@ package com.ritense.document.domain.impl.searchfield;
 import com.ritense.valtimo.contract.domain.AbstractId;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import java.util.Objects;
 import java.util.UUID;
 
 @Embeddable
@@ -48,5 +49,21 @@ public class SearchFieldId extends AbstractId<SearchFieldId> {
 
     public UUID getId() {
         return this.id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SearchFieldId that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id) && Objects.equals(documentDefinitionName, that.documentDefinitionName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, documentDefinitionName);
     }
 }

--- a/plugin/src/main/kotlin/com/ritense/plugin/domain/PluginPropertyId.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/domain/PluginPropertyId.kt
@@ -22,7 +22,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class PluginPropertyId(
+data class PluginPropertyId(
     @Column(name = "plugin_property_key")
     val key: String,
     @JsonIgnore

--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/NotificatiesApiConfigurationId.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/domain/NotificatiesApiConfigurationId.kt
@@ -23,7 +23,7 @@ import jakarta.persistence.Embeddable
 import java.util.UUID
 
 @Embeddable
-class NotificatiesApiConfigurationId(
+data class NotificatiesApiConfigurationId(
     @Column(name = "notificaties_api_configuration_id")
     @JsonValue
     val id: UUID

--- a/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/domain/ZaakInstanceLinkId.kt
+++ b/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/domain/ZaakInstanceLinkId.kt
@@ -25,7 +25,7 @@ import jakarta.persistence.Embeddable
 import java.util.UUID
 
 @Embeddable
-class ZaakInstanceLinkId(
+data class ZaakInstanceLinkId(
 
     @Column(name = "zaak_instance_link_id")
     @JsonValue


### PR DESCRIPTION
Fixed HHH000038 and HHH000039 warnings: `Composite-id class does not override equals()/hashCode()`