### PR TITLE
add 'bestandsomvang' for Document API requests

### DIFF
--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/domain/MetadataType.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/domain/MetadataType.kt
@@ -21,5 +21,6 @@ enum class MetadataType(val key: String) {
     DOCUMENT_ID("documentId"),
     FILE_NAME("filename"),
     FILE_PATH("filePath"),
+    FILE_SIZE("fileSize"),
     USER("user"),
 }

--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
@@ -34,6 +34,7 @@ import kotlin.io.path.notExists
 import kotlin.io.path.pathString
 import kotlin.io.path.readText
 import org.apache.tika.Tika
+import kotlin.io.path.*
 
 class TemporaryResourceStorageService(
     private val random: SecureRandom = SecureRandom(),
@@ -62,7 +63,8 @@ class TemporaryResourceStorageService(
         }
 
         val metaDataContent = metadata + mapOf(
-            MetadataType.FILE_PATH.key to dataFile.absolutePathString()
+            MetadataType.FILE_PATH.key to dataFile.absolutePathString(),
+            MetadataType.FILE_SIZE.key to dataFile.fileSize().toString()
         )
         val metaDataFile = Files.createTempFile(tempDir, "${random.nextLong().toULong()}-", ".json")
         metaDataFile.toFile().writeText(Mapper.INSTANCE.get().writeValueAsString(metaDataContent))

--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
@@ -26,13 +26,6 @@ import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.SecureRandom
-import kotlin.io.path.Path
-import kotlin.io.path.absolutePathString
-import kotlin.io.path.inputStream
-import kotlin.io.path.nameWithoutExtension
-import kotlin.io.path.notExists
-import kotlin.io.path.pathString
-import kotlin.io.path.readText
 import org.apache.tika.Tika
 import kotlin.io.path.*
 

--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
@@ -27,7 +27,14 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.security.SecureRandom
 import org.apache.tika.Tika
-import kotlin.io.path.*
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.fileSize
+import kotlin.io.path.inputStream
+import kotlin.io.path.nameWithoutExtension
+import kotlin.io.path.notExists
+import kotlin.io.path.pathString
+import kotlin.io.path.readText
 
 class TemporaryResourceStorageService(
     private val random: SecureRandom = SecureRandom(),

--- a/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/TemporaryResourceStorageServiceIntegrationTest.kt
+++ b/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/TemporaryResourceStorageServiceIntegrationTest.kt
@@ -77,6 +77,8 @@ class TemporaryResourceStorageServiceIntegrationTest : BaseIntegrationTest() {
         val metadata = temporaryResourceStorageService.getResourceMetadata(resourceId)
         assertThat(metadata[MetadataType.FILE_NAME.key]).isEqualTo(fileName)
         assertThat(metadata).doesNotContainKey(MetadataType.FILE_PATH.key)
+        assertThat(metadata[MetadataType.FILE_SIZE.key]).isNotNull
+        assertThat(metadata[MetadataType.FILE_SIZE.key]).isEqualTo(fileData.length.toString())
     }
 
     @Test

--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -33,7 +33,6 @@ import com.ritense.resource.domain.MetadataType
 import com.ritense.resource.service.TemporaryResourceStorageService
 import com.ritense.valtimo.contract.validation.Url
 import com.ritense.zgw.domain.Vertrouwelijkheid
-import org.apache.commons.io.IOUtils
 import org.camunda.bpm.engine.delegate.DelegateExecution
 import org.hibernate.validator.constraints.Length
 import org.springframework.context.ApplicationEventPublisher
@@ -189,13 +188,6 @@ class DocumentenApiPlugin(
         informationObjectType: String,
         storedDocumentUrl: String
     ) {
-        //determine size of InputStream if not null
-        val contentInBytes = contentAsInputStream.readAllBytes()
-        IOUtils.closeQuietly(contentAsInputStream)
-        val bestandsOmvang = contentInBytes.size.toLong()
-        val copyInputStream = contentInBytes.inputStream()
-
-
         val request = CreateDocumentRequest(
             bronorganisatie = bronorganisatie,
             creatiedatum = getLocalDateFromMetaData(metadata, "creationDate", LocalDate.now())!!,
@@ -205,15 +197,13 @@ class DocumentenApiPlugin(
             status = status,
             taal = language ?: DEFAULT_LANGUAGE,
             bestandsnaam = filename,
-            bestandsomvang = bestandsOmvang,
-            inhoud = copyInputStream,
+            bestandsomvang = (metadata[MetadataType.FILE_SIZE.key] as String?)?.toLong(),
+            inhoud = contentAsInputStream,
             beschrijving = description,
             ontvangstdatum = getLocalDateFromMetaData(metadata, "receiptDate"),
             verzenddatum = getLocalDateFromMetaData(metadata, "sendDate"),
             informatieobjecttype = informationObjectType,
         )
-
-
 
         val documentCreateResult = client.storeDocument(authenticationPluginConfiguration, url, request)
 

--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentRequest.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentRequest.kt
@@ -44,6 +44,4 @@ class CreateDocumentRequest(
     val verzenddatum: LocalDate? = null,
     val indicatieGebruiksrecht: Boolean? = false,
     val informatieobjecttype: String,
-) {
-
-}
+)

--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentRequest.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentRequest.kt
@@ -17,11 +17,13 @@
 package com.ritense.documentenapi.client
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.ritense.zgw.domain.Vertrouwelijkheid
 import java.io.InputStream
 import java.time.LocalDate
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class CreateDocumentRequest(
     val bronorganisatie: String,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
@@ -32,6 +34,7 @@ class CreateDocumentRequest(
     val status: DocumentStatusType? = null,
     val taal: String,
     val bestandsnaam: String? = null,
+    val bestandsomvang: Long? = null,
     @JsonSerialize(using = Base64StreamSerializer::class)
     val inhoud: InputStream,
     val beschrijving: String? = null,
@@ -41,4 +44,6 @@ class CreateDocumentRequest(
     val verzenddatum: LocalDate? = null,
     val indicatieGebruiksrecht: Boolean? = false,
     val informatieobjecttype: String,
-)
+) {
+
+}

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
@@ -122,7 +122,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
             }
         """.trimIndent())
         val documentId = temporaryResourceStorageService.store(
-            "test".byteInputStream()
+            "test".byteInputStream(), mutableMapOf(MetadataType.FILE_SIZE.key to 4L)
         )
 
         val newDocumentRequest = NewDocumentRequest(DOCUMENT_DEFINITION_KEY, Mapper.INSTANCE.get().createObjectNode())

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
@@ -149,6 +149,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
         assertEquals("description", parsedOutput["beschrijving"])
         assertEquals("GZAC", parsedOutput["auteur"])
         assertEquals("test.ext", parsedOutput["bestandsnaam"])
+        assertEquals(4, parsedOutput["bestandsomvang"])
         assertEquals("nld", parsedOutput["taal"])
         assertEquals("dGVzdA==", parsedOutput["inhoud"])
         assertEquals("testtype", parsedOutput["informatieobjecttype"])

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -26,6 +26,7 @@ import com.ritense.documentenapi.client.DocumentenApiClient
 import com.ritense.documentenapi.event.DocumentCreated
 import com.ritense.resource.service.TemporaryResourceStorageService
 import com.ritense.zgw.domain.Vertrouwelijkheid
+import org.apache.commons.io.IOUtils
 import org.camunda.bpm.engine.delegate.DelegateExecution
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -34,6 +35,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
+import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.net.URI
 import java.time.LocalDate
@@ -41,6 +43,7 @@ import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class DocumentenApiPluginTest {
 
@@ -51,7 +54,8 @@ internal class DocumentenApiPluginTest {
         val applicationEventPublisher: ApplicationEventPublisher= mock()
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val executionMock = mock<DelegateExecution>()
-        val fileStream = mock<InputStream>()
+        val content = "contentForRequest"
+        val inputStream = ByteArrayInputStream(content.toByteArray())
         val result = CreateDocumentResult(
             "returnedUrl",
             "returnedAuthor",
@@ -63,7 +67,7 @@ internal class DocumentenApiPluginTest {
         whenever(executionMock.getVariable("localDocumentVariableName"))
             .thenReturn("localDocumentLocation")
         whenever(storageService.getResourceContentAsInputStream("localDocumentLocation"))
-            .thenReturn(fileStream)
+            .thenReturn(inputStream)
         whenever(client.storeDocument(any(), any(), any())).thenReturn(result)
 
         val plugin = DocumentenApiPlugin(client, storageService, applicationEventPublisher, jacksonObjectMapper())
@@ -98,7 +102,7 @@ internal class DocumentenApiPluginTest {
         assertEquals("test.ext", request.bestandsnaam)
         assertEquals(Vertrouwelijkheid.ZAAKVERTROUWELIJK, request.vertrouwelijkheidaanduiding)
         assertEquals("taal", request.taal)
-        assertEquals(fileStream, request.inhoud)
+        assertEquals(content, IOUtils.toString(request.inhoud, Charsets.UTF_8))
         assertEquals("type", request.informatieobjecttype)
         assertEquals(DocumentStatusType.IN_BEWERKING, request.status)
         assertEquals(false, request.indicatieGebruiksrecht)
@@ -118,7 +122,8 @@ internal class DocumentenApiPluginTest {
         val applicationEventPublisher: ApplicationEventPublisher= mock()
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val executionMock = mock<DelegateExecution>()
-        val fileStream = mock<InputStream>()
+        val content = "contentForRequest"
+        val inputStream = ByteArrayInputStream(content.toByteArray())
         val result = CreateDocumentResult(
             "returnedUrl",
             "returnedAuthor",
@@ -130,7 +135,7 @@ internal class DocumentenApiPluginTest {
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR))
             .thenReturn("localDocumentLocation")
         whenever(storageService.getResourceContentAsInputStream("localDocumentLocation"))
-            .thenReturn(fileStream)
+            .thenReturn(inputStream)
         whenever(storageService.getResourceMetadata("localDocumentLocation"))
             .thenReturn(mapOf("title" to "title",
                 "confidentialityLevel" to "zaakvertrouwelijk",
@@ -166,7 +171,7 @@ internal class DocumentenApiPluginTest {
         assertEquals("description", request.beschrijving)
         assertEquals("test.ext", request.bestandsnaam)
         assertEquals("taal", request.taal)
-        assertEquals(fileStream, request.inhoud)
+        assertEquals(content, IOUtils.toString(request.inhoud, Charsets.UTF_8))
         assertEquals("type", request.informatieobjecttype)
         assertEquals(DocumentStatusType.IN_BEWERKING, request.status)
         assertEquals(false, request.indicatieGebruiksrecht)
@@ -180,7 +185,8 @@ internal class DocumentenApiPluginTest {
         val applicationEventPublisher: ApplicationEventPublisher= mock()
         val authenticationMock = mock<DocumentenApiAuthentication>()
         val executionMock = mock<DelegateExecution>()
-        val fileStream = mock<InputStream>()
+        val content = "contentForRequest"
+        val inputStream = ByteArrayInputStream(content.toByteArray())
         val result = CreateDocumentResult(
             "returnedUrl",
             "returnedAuthor",
@@ -192,7 +198,7 @@ internal class DocumentenApiPluginTest {
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR))
             .thenReturn("localDocumentLocation")
         whenever(storageService.getResourceContentAsInputStream("localDocumentLocation"))
-            .thenReturn(fileStream)
+            .thenReturn(inputStream)
         whenever(storageService.getResourceMetadata("localDocumentLocation"))
             .thenReturn(mapOf("title" to "title",
                 "status" to "in_bewerking",
@@ -222,7 +228,7 @@ internal class DocumentenApiPluginTest {
         assertEquals("GZAC", request.auteur)
         assertEquals("test.ext", request.bestandsnaam)
         assertEquals("taal", request.taal)
-        assertEquals(fileStream, request.inhoud)
+        assertEquals(content, IOUtils.toString(request.inhoud, Charsets.UTF_8))
         assertEquals("type", request.informatieobjecttype)
         assertEquals(DocumentStatusType.IN_BEWERKING, request.status)
         assertEquals(false, request.indicatieGebruiksrecht)

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -36,7 +36,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import java.io.ByteArrayInputStream
-import java.io.InputStream
 import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime


### PR DESCRIPTION
closes #1203
Adds an extra field to request to be compatible with Alfresco DRC at Amsterdam Erfpacht. 