### PR TITLE
Fix issue #1218 with LocalDateTime parsing

### DIFF
--- a/core/src/main/java/com/ritense/valtimo/config/JacksonConfiguration.java
+++ b/core/src/main/java/com/ritense/valtimo/config/JacksonConfiguration.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.ritense.valtimo.contract.json.serializer.PageSerializer;
+import com.ritense.valtimo.jackson.CustomLocalDateTimeDeserializer;
+import java.time.LocalDateTime;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -50,7 +52,9 @@ public class JacksonConfiguration {
      */
     @Bean
     public JavaTimeModule javaTimeModule() {
-        return new JavaTimeModule();
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addDeserializer(LocalDateTime.class, new CustomLocalDateTimeDeserializer());
+        return javaTimeModule;
     }
 
     @Bean

--- a/core/src/main/kotlin/com/ritense/valtimo/jackson/CustomLocalDateTimeDeserializer.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/jackson/CustomLocalDateTimeDeserializer.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.jackson
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer
+import java.time.DateTimeException
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+class CustomLocalDateTimeDeserializer : LocalDateTimeDeserializer() {
+    override fun _fromString(p: JsonParser, ctxt: DeserializationContext?, string0: String): LocalDateTime {
+        val stringValue = string0.trim()
+        if (stringValue.isEmpty()) {
+            return _fromEmptyString(p, ctxt, stringValue)
+        }
+        return try {
+            val result = DateTimeFormatter.ISO_DATE_TIME.parseBest(
+                stringValue,
+                ZonedDateTime::from,
+                LocalDateTime::from
+            )
+
+            return when (result) {
+                is LocalDateTime -> result
+                is ZonedDateTime -> result.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime()
+                else -> super._fromString(p, ctxt, string0)
+            }
+        } catch (e: DateTimeException) {
+            _handleDateTimeException(ctxt, e, stringValue)
+        }
+    }
+}

--- a/core/src/test/kotlin/com/ritense/valtimo/jackson/CustomLocalDateTimeDeserializerTest.kt
+++ b/core/src/test/kotlin/com/ritense/valtimo/jackson/CustomLocalDateTimeDeserializerTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.jackson
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class CustomLocalDateTimeDeserializerTest {
+
+
+    @Test
+    fun `should deserialize datetime without zone`() {
+        val dateTimeString = """"$DATETIME_STRING""""
+        val result: LocalDateTime = mapper.readValue(dateTimeString)
+
+        assertThat(result).isEqualTo(LOCAL_DATE_TIME)
+    }
+
+    @Test
+    fun `should deserialize datetime zone`() {
+        val offsetHours = 5
+        val dateTimeString = """"$DATETIME_STRING+0$offsetHours:00""""
+        val result: LocalDateTime = mapper.readValue(dateTimeString)
+        val offset = ZoneId.systemDefault().rules.getOffset(LocalDateTime.now())
+        assertThat(result).isEqualTo(LOCAL_DATE_TIME.minusSeconds((offsetHours * 3600 - offset.totalSeconds).toLong()))
+    }
+
+    @Test
+    fun `should deserialize datetime Z zone`() {
+        val dateTimeString = """"${DATETIME_STRING}Z""""
+        val result: LocalDateTime = mapper.readValue(dateTimeString)
+        val offset = ZoneId.systemDefault().rules.getOffset(LocalDateTime.now())
+        assertThat(result).isEqualTo(LOCAL_DATE_TIME.plusSeconds(offset.totalSeconds.toLong()))
+    }
+
+    companion object {
+        private const val DATETIME_STRING = "2024-02-15T14:39:54.746"
+        private val LOCAL_DATE_TIME = LocalDateTime.of(2024, 2, 15, 14, 39, 54, 746 * 1000000)
+        private val mapper = jacksonMapperBuilder()
+            .addModule(JavaTimeModule().addDeserializer(LocalDateTime::class.java, CustomLocalDateTimeDeserializer()))
+            .build()
+    }
+}

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginIT.kt
@@ -236,7 +236,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
                     "/enkelvoudiginformatieobjecten"
                     -> handleDocumentRequest()
                     "/enkelvoudiginformatieobjecten/$DOCUMENT_ID"
-                    -> handleDocumentRequest()
+                    -> handleDocumentRequest("+02:00")
                     "/enkelvoudiginformatieobjecten/$DOCUMENT_ID/download"
                     -> handleDocumentDownloadRequest()
 
@@ -248,7 +248,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
         server.dispatcher = dispatcher
     }
 
-    private fun handleDocumentRequest(): MockResponse {
+    private fun handleDocumentRequest(zone: String = "Z"): MockResponse {
         val body = """
             {
               "url": "http://example.com",
@@ -262,7 +262,7 @@ internal class DocumentenApiPluginIT @Autowired constructor(
               "formaat": "string",
               "taal": "str",
               "versie": 0,
-              "beginRegistratie": "2019-08-24T14:15:22Z",
+              "beginRegistratie": "2019-08-24T14:15:22$zone",
               "bestandsnaam": "passport.jpg",
               "inhoud": "string",
               "bestandsomvang": 0,


### PR DESCRIPTION
The standard deserialiser provided by JavaTimeModule does not parse datetimes with a zone provided to a LocalDateTime. This PR overrides part of that deserialiser to fix this.

Solves #1218 .