### PR TITLE
Fix case status color migration

### DIFF
--- a/document/src/main/resources/config/liquibase/changelog/20240214-add-column-color-to-internal-case-status-table.xml
+++ b/document/src/main/resources/config/liquibase/changelog/20240214-add-column-color-to-internal-case-status-table.xml
@@ -21,7 +21,7 @@
 
     <changeSet author="Ritense" id="1">
         <addColumn tableName="internal_case_status">
-            <column name="internal_case_status_color" type="varchar(50)">
+            <column name="internal_case_status_color" type="varchar(50)" defaultValue="BLUE">
                 <constraints nullable="false"/>
             </column>
         </addColumn>


### PR DESCRIPTION
Fix error: 
`MigrationFailedException: Migration failed for changeset config/liquibase/changelog/20240214-add-column-color-to-internal-case-status-table.xml`