### PR TITLE
Removed escaping of formio default value

### DIFF
--- a/form/src/main/java/com/ritense/form/domain/FormIoFormDefinition.java
+++ b/form/src/main/java/com/ritense/form/domain/FormIoFormDefinition.java
@@ -182,7 +182,7 @@ public class FormIoFormDefinition extends AbstractAggregateRoot<FormIoFormDefini
                     Object value = valueMap.get(fieldKey);
                     if(value != null) {
                         JsonNode valueNode = Mapper.INSTANCE.get().valueToTree(value);
-                        fieldNode.set(DEFAULT_VALUE_FIELD, htmlEscape(valueNode));
+                        fieldNode.set(DEFAULT_VALUE_FIELD, valueNode);
                     }
                 });
     }
@@ -356,7 +356,7 @@ public class FormIoFormDefinition extends AbstractAggregateRoot<FormIoFormDefini
                 .flatMap(
                     contentItem -> getValueBy(content, contentItem.getJsonPointer())
                 ).ifPresent(
-                    valueNode -> field.set(DEFAULT_VALUE_FIELD, htmlEscape(valueNode))
+                    valueNode -> field.set(DEFAULT_VALUE_FIELD, valueNode)
                 );
         }
     }
@@ -370,14 +370,6 @@ public class FormIoFormDefinition extends AbstractAggregateRoot<FormIoFormDefini
             return getExternalFormField(node);
         }
         return Optional.empty();
-    }
-
-    private JsonNode htmlEscape(JsonNode input) {
-        if (input.isTextual()) {
-            String escapedContent = HtmlUtils.htmlEscape(input.textValue(), StandardCharsets.UTF_8.name());
-            return new TextNode(escapedContent);
-        }
-        return input;
     }
 
     private Optional<JsonPointer> buildJsonPointer(String jsonPointerExpression) {

--- a/form/src/test/java/com/ritense/form/domain/FormIoFormDefinitionTest.java
+++ b/form/src/test/java/com/ritense/form/domain/FormIoFormDefinitionTest.java
@@ -117,14 +117,14 @@ public class FormIoFormDefinitionTest extends BaseTest {
     }
 
     @Test
-    public void shouldEscapeHtmlAtPreFill() throws IOException {
+    public void shouldNotEscapeHtmlAtPreFill() throws IOException {
         final var formDefinition = formDefinitionOf("process-variables-form-example");
 
         var content = content(Map.of("pv", Map.of("firstName", "</b>")));
 
         final var formDefinitionPreFilled = formDefinition.preFill(content);
 
-        assertThat(formDefinitionPreFilled.getFormDefinition().get("components").get(0).get("defaultValue").asText()).isEqualTo("&lt;/b&gt;");
+        assertThat(formDefinitionPreFilled.getFormDefinition().get("components").get(0).get("defaultValue").asText()).isEqualTo("</b>");
     }
 
     @Test


### PR DESCRIPTION
Removed escaping of formio default value output because formio escapes the input. The HTML component was fixed to also escape html variables.