### PR TITLE
Codeowners: fixed syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @global-owner1 @valtimo-platform/valtimo-product-backend
+* @valtimo-platform/valtimo-product-backend

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@global-owner1 @valtimo-platform/valtimo-product-backend
+* @global-owner1 @valtimo-platform/valtimo-product-backend


### PR DESCRIPTION
It seems there's a wildcard missing and the first team name is incorrect, following the docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

This fixes the current situation, where only files in the `@global-owner1` directory have a specified codeowner, being team @valtimo-platform/valtimo-product-backend 