### PR TITLE
Added support for removal operation in prePatch of JsonDocumentContent.build

### DIFF
--- a/document/src/main/java/com/ritense/document/domain/impl/JsonDocumentContent.java
+++ b/document/src/main/java/com/ritense/document/domain/impl/JsonDocumentContent.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.ritense.document.domain.patch.JsonPatchFilterFlag.allowArrayRemovalOperations;
+import static com.ritense.document.domain.patch.JsonPatchFilterFlag.allowRemovalOperations;
 import static com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentNotEmpty;
 import static com.ritense.valtimo.contract.utils.AssertionConcern.assertArgumentNotNull;
 
@@ -57,7 +58,7 @@ public class JsonDocumentContent implements DocumentContent {
     public static JsonDocumentContent build(JsonNode currentContent, JsonNode modifiedContent, JsonPatch prePatch) {
         //Pre patching
         if (prePatch != null && !prePatch.patches().isEmpty()) {
-            JsonPatchService.apply(prePatch, currentContent);
+            JsonPatchService.apply(prePatch, currentContent, allowRemovalOperations());
         }
         return build(currentContent, modifiedContent);
     }

--- a/document/src/test/java/com/ritense/document/domain/impl/JsonDocumentContentTest.java
+++ b/document/src/test/java/com/ritense/document/domain/impl/JsonDocumentContentTest.java
@@ -16,16 +16,32 @@
 
 package com.ritense.document.domain.impl;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.ritense.valtimo.contract.json.patch.JsonPatch;
+import com.ritense.valtimo.contract.json.patch.operation.JsonPatchOperation;
+import com.ritense.valtimo.contract.json.patch.operation.RemoveOperation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonDocumentContentTest {
 
     private ObjectNode source;
+
+    private static final String AGE_KEY = "age";
+    private static final String FAVOURITES_KEY = "favourites";
+    private static final String IDENTITY_KEY = "identity";
+    private static final String NAME_KEY = "name";
+    private static final String SIZE_KEY = "size";
+
+    private static final String AGE_POINTER = "/identity/age";
+    private static final String NAME_POINTER = "/identity/name";
 
     @BeforeEach
     void setUp() {
@@ -33,22 +49,22 @@ class JsonDocumentContentTest {
 
         ArrayNode favorites = JsonNodeFactory.instance.arrayNode();
         ObjectNode identity = JsonNodeFactory.instance.objectNode();
-        identity.put("age", 32);
-        identity.put("name", "Julia");
+        identity.put(AGE_KEY, 32);
+        identity.put(NAME_KEY, "Julia");
 
         ObjectNode bread = JsonNodeFactory.instance.objectNode();
-        bread.put("name", "bread");
-        bread.put("size", "small");
+        bread.put(NAME_KEY, "bread");
+        bread.put(SIZE_KEY, "small");
 
         ObjectNode croissaint = JsonNodeFactory.instance.objectNode();
-        croissaint.put("name", "croissaint");
-        croissaint.put("size", "large");
+        croissaint.put(NAME_KEY, "croissaint");
+        croissaint.put(SIZE_KEY, "large");
 
         favorites.add(bread);
         favorites.add(croissaint);
 
-        source.set("identity", identity);
-        source.set("favorites", favorites);
+        source.set(IDENTITY_KEY, identity);
+        source.set(FAVOURITES_KEY, favorites);
     }
 
     @Test
@@ -57,18 +73,43 @@ class JsonDocumentContentTest {
         ArrayNode newFavorite = JsonNodeFactory.instance.arrayNode();
 
         ObjectNode painAuxChocolat = JsonNodeFactory.instance.objectNode();
-        painAuxChocolat.put("name", "painAuxChocolat");
-        painAuxChocolat.put("size", "normal");
+        painAuxChocolat.put(NAME_KEY, "painAuxChocolat");
+        painAuxChocolat.put(SIZE_KEY, "normal");
 
         newFavorite.add(painAuxChocolat);
-        modifiedContent.set("favorites", newFavorite);
+        modifiedContent.set(FAVOURITES_KEY, newFavorite);
 
         JsonDocumentContent.build(source, modifiedContent);
 
-        assertThat(source.at("/identity/age").intValue()).isEqualTo(32);
-        assertThat(source.at("/identity/name").textValue()).isEqualTo("Julia");
-        assertThat(source.at("/favorites/0/name").textValue()).isEqualTo("painAuxChocolat");
-        assertThat(source.at("/favorites/0/size").textValue()).isEqualTo("normal");
+        assertThat(source.at(AGE_POINTER).intValue()).isEqualTo(32);
+        assertThat(source.at(NAME_POINTER).textValue()).isEqualTo("Julia");
+        assertThat(source.at("/" + FAVOURITES_KEY + "/0/" + NAME_KEY).textValue()).isEqualTo("painAuxChocolat");
+        assertThat(source.at("/" + FAVOURITES_KEY + "/0/" + SIZE_KEY).textValue()).isEqualTo("normal");
+    }
+
+    @Test
+    void shouldRemoveItemViaPrePatchOnlyWithBuild() {
+        // try to remove name from identity the normal way, it should fail
+        ObjectNode modifiedIdentityContent = JsonNodeFactory.instance.objectNode();
+
+        ObjectNode newIdentity = JsonNodeFactory.instance.objectNode();
+        newIdentity.put(AGE_KEY, "32");
+
+        modifiedIdentityContent.set(IDENTITY_KEY, newIdentity);
+
+        JsonDocumentContent.build(source, modifiedIdentityContent);
+
+        assertThat(source.at(NAME_POINTER).isMissingNode()).isFalse();
+
+        // try to remove the name from the identity using pre patch, it should succeed
+        ObjectNode emptyModifiedContent = JsonNodeFactory.instance.objectNode();
+
+        LinkedHashSet<JsonPatchOperation> patches = new LinkedHashSet<>();
+        patches.add(new RemoveOperation(JsonPointer.valueOf(NAME_POINTER)));
+        JsonPatch prePatch = new JsonPatch(patches);
+        JsonDocumentContent.build(source, emptyModifiedContent, prePatch);
+
+        assertThat(source.at(NAME_POINTER).isMissingNode()).isTrue();
     }
 
 }


### PR DESCRIPTION
Sometimes you want to completely remove a path from the json document content which is now supported by specifying the  specific remove operation in the prePatch of the build.