### PR TITLE
feature/93310-besluiten-api-create-besluit

### DIFF
--- a/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/Besluit.kt
+++ b/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/Besluit.kt
@@ -17,6 +17,7 @@
 package com.ritense.besluitenapi.client
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import java.net.URI
 import java.time.LocalDate
 
@@ -34,6 +35,7 @@ class Besluit(
     val ingangsdatum: LocalDate,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     val vervaldatum: LocalDate?,
+    @JsonDeserialize(using = EmptyStringToVervalredenDeserializer::class)
     val vervalreden: Vervalreden?,
     val vervalredenWeergave: String?,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/EmptyStringToVervalredenDeserializer.kt
+++ b/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/EmptyStringToVervalredenDeserializer.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2023 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ritense.besluitenapi.client
 
 import com.fasterxml.jackson.core.JsonParser

--- a/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/EmptyStringToVervalredenDeserializer.kt
+++ b/zgw/besluiten-api/src/main/kotlin/com/ritense/besluitenapi/client/EmptyStringToVervalredenDeserializer.kt
@@ -1,0 +1,21 @@
+package com.ritense.besluitenapi.client
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import java.io.IOException
+
+
+class EmptyStringToVervalredenDeserializer :  JsonDeserializer<Vervalreden?>() {
+    @Throws(IOException::class, JsonProcessingException::class)
+
+    override fun deserialize(jsonParser: JsonParser, context: DeserializationContext?): Vervalreden? {
+        val node: JsonNode = jsonParser.readValueAsTree()
+        if (node.asText().isEmpty()) {
+            return null
+        }
+        return Vervalreden.valueOf(node.asText().uppercase())
+    }
+}

--- a/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/client/BesluitenApiClientTest.kt
+++ b/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/client/BesluitenApiClientTest.kt
@@ -136,6 +136,88 @@ class BesluitenApiClientTest {
 
     }
 
+    @Test
+    fun `should send create besluit request and parse response when vervalreden is null`() {
+        val webclientBuilder = WebClient.builder()
+        val client = BesluitenApiClient(webclientBuilder)
+
+        val responseBody = """
+            {
+                "url": "http://besluit.api/besluit",
+                "identificatie": "identificatie",
+                "verantwoordelijkeOrganisatie": "633182801",
+                "besluittype": "http://catalogus.api/besluittype",
+                "zaak": "http://zaken.api/zaak",
+                "datum": "2023-04-20",
+                "toelichting": "toelichting",
+                "bestuursorgaan": "680572442",
+                "ingangsdatum": "2023-04-21",
+                "vervaldatum": "2023-04-22",
+                "vervalreden": null,
+                "vervalredenWeergave": "reden",
+                "publicatiedatum": "2023-04-23",
+                "verzenddatum": "2023-04-24",
+                "uiterlijkeReactiedatum": "2023-04-25"
+            }
+        """.trimIndent()
+
+        mockApi.enqueue(mockResponse(responseBody))
+
+        val besluit = client.createBesluit(
+            TestAuthentication(),
+            URI(mockApi.url("/").toString()),
+            CreateBesluitRequest(
+                zaak = URI("http://zaken.api/zaak"),
+                besluittype = URI("http://catalogus.api/besluittype"),
+                verantwoordelijkeOrganisatie = "633182801",
+                datum = LocalDate.of(2024, 4, 20),
+                ingangsdatum = LocalDate.of(2024, 4, 21),
+                toelichting = "toelichting",
+                bestuursorgaan = "680572442",
+                vervaldatum = LocalDate.of(2024, 4, 22),
+                vervalreden = null,
+                publicatiedatum = LocalDate.of(2024, 4, 23),
+                verzenddatum = LocalDate.of(2024, 4, 24),
+                uiterlijkeReactiedatum = LocalDate.of(2024, 4, 25)
+            )
+        )
+
+        val recordedRequest = mockApi.takeRequest()
+        val body = recordedRequest.body.readUtf8()
+
+        //validate request
+       assertThat(body, jsonPathMissingOrNull("$.identificatie"))
+       assertThat(body, hasJsonPath("$.verantwoordelijkeOrganisatie", equalTo("633182801")))
+       assertThat(body, hasJsonPath("$.besluittype", equalTo("http://catalogus.api/besluittype")))
+       assertThat(body, hasJsonPath("$.zaak", equalTo("http://zaken.api/zaak")))
+       assertThat(body, hasJsonPath("$.datum", equalTo("2024-04-20")))
+       assertThat(body, hasJsonPath("$.toelichting", equalTo("toelichting")))
+       assertThat(body, hasJsonPath("$.bestuursorgaan", equalTo("680572442")))
+       assertThat(body, hasJsonPath("$.ingangsdatum", equalTo("2024-04-21")))
+       assertThat(body, hasJsonPath("$.vervaldatum", equalTo("2024-04-22")))
+       assertThat(body, jsonPathMissingOrNull("$.vervalreden"))
+       assertThat(body, hasJsonPath("$.publicatiedatum", equalTo("2024-04-23")))
+       assertThat(body, hasJsonPath("$.verzenddatum", equalTo("2024-04-24")))
+       assertThat(body, hasJsonPath("$.uiterlijkeReactiedatum", equalTo("2024-04-25")))
+
+        //validate response
+        assertEquals(URI("http://besluit.api/besluit"), besluit.url)
+        assertEquals("identificatie", besluit.identificatie)
+        assertEquals("633182801", besluit.verantwoordelijkeOrganisatie)
+        assertEquals(URI("http://catalogus.api/besluittype"), besluit.besluittype)
+        assertEquals(URI("http://zaken.api/zaak"), besluit.zaak)
+        assertEquals(LocalDate.of(2023, 4, 20), besluit.datum)
+        assertEquals("toelichting", besluit.toelichting)
+        assertEquals("680572442", besluit.bestuursorgaan)
+        assertEquals(LocalDate.of(2023, 4, 21), besluit.ingangsdatum)
+        assertEquals(LocalDate.of(2023, 4, 22), besluit.vervaldatum)
+        assertEquals(null, besluit.vervalreden)
+        assertEquals("reden", besluit.vervalredenWeergave)
+        assertEquals(LocalDate.of(2023, 4, 23), besluit.publicatiedatum)
+        assertEquals(LocalDate.of(2023, 4, 24), besluit.verzenddatum)
+        assertEquals(LocalDate.of(2023, 4, 25), besluit.uiterlijkeReactiedatum)
+    }
+
     private fun mockResponse(body: String): MockResponse {
         return MockResponse()
             .addHeader("Content-Type", "application/json")

--- a/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/client/BesluitenApiClientTest.kt
+++ b/zgw/besluiten-api/src/test/kotlin/com/ritense/besluitenapi/client/BesluitenApiClientTest.kt
@@ -153,7 +153,7 @@ class BesluitenApiClientTest {
                 "bestuursorgaan": "680572442",
                 "ingangsdatum": "2023-04-21",
                 "vervaldatum": "2023-04-22",
-                "vervalreden": null,
+                "vervalreden": "",
                 "vervalredenWeergave": "reden",
                 "publicatiedatum": "2023-04-23",
                 "verzenddatum": "2023-04-24",


### PR DESCRIPTION
Bug fix: failing creation of Zaakbesluit when 'reason for expiry' (vervalreden) is null.
Error message: Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot coerce empty String ("") to `com.ritense.besluitenapi.client.Vervalreden` value (but could if coercion was enabled using `CoercionConfig`)