### PR TITLE
Dependency upgrade fix: Downgraded to Liquibase 4.24.0

### DIFF
--- a/app/gzac/src/main/resources/config/application.yml
+++ b/app/gzac/src/main/resources/config/application.yml
@@ -54,7 +54,7 @@ spring:
     liquibase:
         enabled: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         show_sql: false
         open-in-view: false
         properties:

--- a/audit/src/test/resources/config/application-postgresql.yml
+++ b/audit/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/authorization/src/test/resources/config/application-postgresql.yml
+++ b/authorization/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/besluit/src/test/resources/config/application-postgresql.yml
+++ b/besluit/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/case/src/test/resources/config/application-postgresql.yml
+++ b/case/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/changelog/src/test/resources/config/application-postgresql.yml
+++ b/changelog/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/connector/src/test/resources/config/application-postgresql.yml
+++ b/connector/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/contactmoment/src/test/resources/config/application-postgresql.yml
+++ b/contactmoment/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/contract/src/test/resources/config/application-postgresql.yml
+++ b/contract/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/contract/src/test/resources/config/application.yml
+++ b/contract/src/test/resources/config/application.yml
@@ -10,7 +10,7 @@ spring:
     liquibase:
         enabled: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
         show_sql: true
         open-in-view: false

--- a/core/src/test/resources/config/application-postgresql.yml
+++ b/core/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/dashboard/src/test/resources/config/application-postgresql.yml
+++ b/dashboard/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/data-provider/src/test/resources/config/application-postgresql.yml
+++ b/data-provider/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/document-generation/smartdocuments/src/test/resources/config/application-postgresql.yml
+++ b/document-generation/smartdocuments/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/document/src/test/resources/config/application-postgresql.yml
+++ b/document/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/form-flow-valtimo/src/test/resources/config/application-postgresql.yml
+++ b/form-flow-valtimo/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/form-flow/src/test/resources/config/application-postgresql.yml
+++ b/form-flow/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/form/src/test/resources/config/application-postgresql.yml
+++ b/form/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ springDependencyManagementVersion=1.1.4
 springCloudStreamVersion=4.1.1
 springRetryVersion=2.0.5
 
-liquibaseVersion=4.27.0
+liquibaseVersion=4.24.0
 liquibaseSlf4jVersion=5.0.0
 
 commonsLangVersion=3.14.0

--- a/haalcentraal/haalcentraal-brp/src/test/resources/config/application-postgresql.yml
+++ b/haalcentraal/haalcentraal-brp/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/klant/src/test/resources/application-postgresql.yml
+++ b/klant/src/test/resources/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/localization/src/test/resources/config/application-postgresql.yml
+++ b/localization/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/mail/flowmailer/src/test/resources/config/application-postgresql.yml
+++ b/mail/flowmailer/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/mail/src/test/resources/config/application-postgresql.yml
+++ b/mail/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/mail/wordpress-mail/src/test/resources/config/application-postgresql.yml
+++ b/mail/wordpress-mail/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/milestones/src/test/resources/config/application-postgresql.yml
+++ b/milestones/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/notes/src/test/resources/config/application-postgresql.yml
+++ b/notes/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/objects-api/src/test/resources/config/application-postgresql.yml
+++ b/objects-api/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/openzaak/src/test/resources/config/application-postgresql.yml
+++ b/openzaak/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/outbox/outbox-rabbitmq/src/test/resources/config/application-postgresql.yml
+++ b/outbox/outbox-rabbitmq/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/outbox/src/test/resources/config/application-postgresql.yml
+++ b/outbox/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/plugin-valtimo/src/test/resources/config/application-postgresql.yml
+++ b/plugin-valtimo/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/plugin/src/test/resources/config/application-postgresql.yml
+++ b/plugin/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/process-document/src/test/resources/config/application-postgresql.yml
+++ b/process-document/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/process-link/src/test/resources/config/application-postgresql.yml
+++ b/process-link/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/resource/temporary-resource-storage/src/test/resources/config/application.yml
+++ b/resource/temporary-resource-storage/src/test/resources/config/application.yml
@@ -10,7 +10,7 @@ spring:
     liquibase:
         enabled: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
         show_sql: true
         open-in-view: false

--- a/search/src/test/resources/config/application-postgresql.yml
+++ b/search/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/zgw/documenten-api/src/test/resources/config/application-postgresql.yml
+++ b/zgw/documenten-api/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/zgw/object-management/src/test/resources/application-postgresql.yml
+++ b/zgw/object-management/src/test/resources/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/zgw/portaaltaak/src/test/resources/config/application-postgresql.yml
+++ b/zgw/portaaltaak/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/zgw/verzoek/src/test/resources/config/application-postgresql.yml
+++ b/zgw/verzoek/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/zgw/zaakdetails/src/test/resources/config/application-postgresql.yml
+++ b/zgw/zaakdetails/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:

--- a/zgw/zaken-api/src/test/resources/config/application-postgresql.yml
+++ b/zgw/zaken-api/src/test/resources/config/application-postgresql.yml
@@ -7,7 +7,7 @@ spring:
         hikari:
             auto-commit: false
     jpa:
-        database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
         database: postgresql
 
 valtimo:


### PR DESCRIPTION
- Changed to `org.hibernate.dialect.PostgreSQLDialect` since `org.hibernate.dialect.PostgreSQL10Dialect` is deprecated
- downgraded to Liquibase 4.24.0 since that is the Spring Boot default