### PR TITLE
Increase HTTP socket timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,8 @@ namedVolumeNameTest=valtimo-test-fixtures
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2048m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=false
+https.socketTimeout=60000
+https.connectionTimeout=60000
 # override liquibase to fix bug see :
 # https://forum.liquibase.org/t/liquibaseexception-java-lang-classcastexception-class-java-time-localdatetime-cannot-be-cast-to-class-java-lang-string/5059/3
 


### PR DESCRIPTION
Set https socket timeout options, allowing Nexus more time to generate a response.