### PR TITLE
Fixed bug causing *.zgw-documenten-api-version.json resources not to be detected

### DIFF
--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/service/DocumentenApiVersionService.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/service/DocumentenApiVersionService.kt
@@ -136,7 +136,7 @@ class DocumentenApiVersionService(
     }
 
     companion object {
-        private const val PATH = "classpath*:**/*.zgw-documenten-api-version.json"
+        private const val PATH = "classpath*:config/documenten-api/*.zgw-documenten-api-version.json"
 
         val MINIMUM_VERSION = DocumentenApiVersion("1.0.0")
     }


### PR DESCRIPTION
When the root of a `classpath*:` is a wildcard, the `ResourcePatternResolver` will only find resources in the current jar/module (that is being bootRun'ed) and ignore resources from other modules. (At least on Windows.) Explicitly defining `config/` as the root prevents this issue. (Using `config/documenten-api/` because that is where we expect these files to be anyway.)