### PR TITLE
Fix exception 'created_by'

### DIFF
--- a/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/config/LiquibaseRunner.java
@@ -19,9 +19,15 @@ package com.ritense.valtimo.contract.config;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 import liquibase.Contexts;
 import liquibase.Liquibase;
+import liquibase.Scope;
+import liquibase.command.CommandFactory;
+import liquibase.command.core.AbstractUpdateCommandStep;
+import liquibase.command.core.UpdateCommandStep;
+import liquibase.command.core.UpdateSqlCommandStep;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
@@ -55,6 +61,7 @@ public class LiquibaseRunner {
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(jdbcConnection);
         try {
             for (LiquibaseMasterChangeLogLocation changeLogLocation : liquibaseMasterChangeLogLocations) {
+                disableFastCheckCaching();
                 runChangeLog(database, changeLogLocation.getFilePath());
             }
         } catch (LiquibaseException liquibaseException) {
@@ -75,5 +82,13 @@ public class LiquibaseRunner {
         Liquibase liquibase = new Liquibase(filePath, new ClassLoaderResourceAccessor(), database);
         logger.info("Running liquibase master changelog: {}", liquibase.getChangeLogFile());
         liquibase.update(context);
+    }
+
+    private void disableFastCheckCaching() {
+        CommandFactory commandFactory = Scope.getCurrentScope().getSingleton(CommandFactory.class);
+        Stream.of(UpdateSqlCommandStep.COMMAND_NAME, UpdateCommandStep.COMMAND_NAME)
+            .flatMap(command -> commandFactory.getCommandDefinition(command).getPipeline().stream())
+            .filter(AbstractUpdateCommandStep.class::isInstance)
+            .forEach(it -> ((AbstractUpdateCommandStep) it).setFastCheckEnabled(false));
     }
 }


### PR DESCRIPTION
Disable Liquibase new 'fast check' caching.

The scenario that caused the error:
1. Valtimo boots up with new change set for the `created_by` column
2. First LiquibaseRunner `authorization-master.xml` is ran
3. No changes are detected. This is cached in the 'fast check'-cache
4. Finally LiquibaseRunner `case-master.xml` is ran
5. Will **not** run changesets because the 'fast check'-cache says it has already been updated

<img width="795" alt="Screenshot 2024-06-03 at 20 01 09" src="https://github.com/valtimo-platform/valtimo-backend-libraries/assets/94360980/0e0177b0-4c2f-47dc-9aec-468b1fbdd5df">
