### PR TITLE
Changed the SearchFieldV2's to have sub-types

### DIFF
--- a/process-document/src/main/kotlin/com/ritense/processdocument/autoconfigure/ProcessDocumentsAutoConfiguration.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/autoconfigure/ProcessDocumentsAutoConfiguration.kt
@@ -38,6 +38,7 @@ import com.ritense.processdocument.service.ProcessDocumentService
 import com.ritense.processdocument.service.ProcessDocumentsService
 import com.ritense.processdocument.service.ValueResolverDelegateService
 import com.ritense.processdocument.service.impl.CamundaProcessJsonSchemaDocumentService
+import com.ritense.processdocument.tasksearch.TaskListSearchFieldV2Mapper
 import com.ritense.processdocument.web.TaskListResource
 import com.ritense.search.service.SearchFieldV2Service
 import com.ritense.valtimo.camunda.service.CamundaRepositoryService
@@ -230,5 +231,13 @@ class ProcessDocumentsAutoConfiguration {
             caseTaskListSearchService,
             camundaTaskService
         )
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(TaskListSearchFieldV2Mapper::class)
+    fun taskListSearchFieldV2Mapper(
+        objectMapper: ObjectMapper
+    ): TaskListSearchFieldV2Mapper {
+        return TaskListSearchFieldV2Mapper(objectMapper)
     }
 }

--- a/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Dto.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Dto.kt
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ *  Licensed under EUPL, Version 1.2 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.ritense.processdocument.tasksearch
 
 import com.fasterxml.jackson.annotation.JsonTypeName

--- a/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Dto.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Dto.kt
@@ -8,7 +8,6 @@ import com.ritense.search.domain.SearchFieldMatchType
 import com.ritense.search.web.rest.dto.SearchFieldV2Dto
 import java.util.UUID
 
-@Suppress("unused")
 @JsonTypeName(SEARCH_FIELD_OWNER_TYPE)
 data class TaskListSearchFieldV2Dto(
     override val id: UUID = UUID.randomUUID(),

--- a/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Dto.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Dto.kt
@@ -1,0 +1,27 @@
+package com.ritense.processdocument.tasksearch
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.ritense.processdocument.service.SEARCH_FIELD_OWNER_TYPE
+import com.ritense.search.domain.DataType
+import com.ritense.search.domain.FieldType
+import com.ritense.search.domain.SearchFieldMatchType
+import com.ritense.search.web.rest.dto.SearchFieldV2Dto
+import java.util.UUID
+
+@Suppress("unused")
+@JsonTypeName(SEARCH_FIELD_OWNER_TYPE)
+data class TaskListSearchFieldV2Dto(
+    override val id: UUID = UUID.randomUUID(),
+    override val ownerId: String,
+    override val key: String,
+    override val title: String?,
+    override val path: String,
+    override val order: Int,
+    override val dataType: DataType,
+    override val fieldType: FieldType,
+    override val matchType: SearchFieldMatchType? = null,
+    override val dropdownDataProvider: String? = null
+): SearchFieldV2Dto {
+    override val ownerType: String
+        get() = SEARCH_FIELD_OWNER_TYPE
+}

--- a/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Mapper.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Mapper.kt
@@ -18,8 +18,8 @@ class TaskListSearchFieldV2Mapper(
 
     override fun supportsOwnerType(ownerType: String) = ownerType == SEARCH_FIELD_OWNER_TYPE
 
-    override fun toNewSearchFieldV2(searchFieldV2Dto: SearchFieldV2Dto): SearchFieldV2 {
-        return SearchFieldV2(
+    override fun toNewSearchFieldV2(searchFieldV2Dto: SearchFieldV2Dto): SearchFieldV2 =
+        SearchFieldV2(
             id = searchFieldV2Dto.id,
             ownerId = searchFieldV2Dto.ownerId,
             ownerType = SEARCH_FIELD_OWNER_TYPE,
@@ -32,6 +32,4 @@ class TaskListSearchFieldV2Mapper(
             matchType = searchFieldV2Dto.matchType,
             dropdownDataProvider = searchFieldV2Dto.dropdownDataProvider
         )
-    }
-
 }

--- a/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Mapper.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Mapper.kt
@@ -1,0 +1,37 @@
+package com.ritense.processdocument.tasksearch
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ritense.processdocument.service.SEARCH_FIELD_OWNER_TYPE
+import com.ritense.search.domain.SearchFieldV2
+import com.ritense.search.mapper.SearchFieldV2Mapper
+import com.ritense.search.web.rest.dto.SearchFieldV2Dto
+
+class TaskListSearchFieldV2Mapper(
+    objectMapper: ObjectMapper
+): SearchFieldV2Mapper {
+
+    init{
+        objectMapper.registerSubtypes(
+            TaskListSearchFieldV2Dto::class.java
+        )
+    }
+
+    override fun supportsOwnerType(ownerType: String) = ownerType == SEARCH_FIELD_OWNER_TYPE
+
+    override fun toNewSearchFieldV2(searchFieldV2Dto: SearchFieldV2Dto): SearchFieldV2 {
+        return SearchFieldV2(
+            id = searchFieldV2Dto.id,
+            ownerId = searchFieldV2Dto.ownerId,
+            ownerType = SEARCH_FIELD_OWNER_TYPE,
+            key = searchFieldV2Dto.key,
+            title = searchFieldV2Dto.title,
+            path = searchFieldV2Dto.path,
+            order = searchFieldV2Dto.order,
+            dataType = searchFieldV2Dto.dataType,
+            fieldType = searchFieldV2Dto.fieldType,
+            matchType = searchFieldV2Dto.matchType,
+            dropdownDataProvider = searchFieldV2Dto.dropdownDataProvider
+        )
+    }
+
+}

--- a/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Mapper.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/tasksearch/TaskListSearchFieldV2Mapper.kt
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ *  Licensed under EUPL, Version 1.2 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.ritense.processdocument.tasksearch
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
+++ b/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
@@ -28,14 +28,13 @@ import com.ritense.processdocument.BaseIntegrationTest
 import com.ritense.processdocument.domain.CaseTask
 import com.ritense.processdocument.domain.impl.request.StartProcessForDocumentRequest
 import com.ritense.processdocument.tasksearch.SearchWithConfigRequest
+import com.ritense.processdocument.tasksearch.TaskListSearchFieldV2Dto
 import com.ritense.search.domain.DataType
 import com.ritense.search.domain.FieldType
 import com.ritense.search.domain.SearchFieldMatchType
-import com.ritense.search.domain.SearchFieldV2
 import com.ritense.search.service.SearchFieldV2Service
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
-import org.camunda.bpm.engine.TaskService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -89,10 +88,9 @@ class CaseTaskListSearchServiceIntTest: BaseIntegrationTest() {
             result
         }
 
-        searchFieldV2Service.create(SearchFieldV2(
+        searchFieldV2Service.create(TaskListSearchFieldV2Dto(
             id = UUID.randomUUID(),
             ownerId = definition!!.id!!.name(),
-            ownerType = SEARCH_FIELD_OWNER_TYPE,
             key = "street",
             title = "Street",
             path = "doc:street",
@@ -103,10 +101,9 @@ class CaseTaskListSearchServiceIntTest: BaseIntegrationTest() {
             dropdownDataProvider = null)
         )
 
-        searchFieldV2Service.create(SearchFieldV2(
+        searchFieldV2Service.create(TaskListSearchFieldV2Dto(
             id = UUID.randomUUID(),
             ownerId = definition!!.id!!.name(),
-            ownerType = SEARCH_FIELD_OWNER_TYPE,
             key = "number",
             title = "House number",
             path = "doc:houseNumber",

--- a/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/TemporaryResourceStorageDeletionServiceIntegrationTest.kt
+++ b/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/TemporaryResourceStorageDeletionServiceIntegrationTest.kt
@@ -18,6 +18,7 @@ package com.ritense.resource.service
 
 import com.ritense.resource.BaseIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
@@ -34,6 +35,7 @@ class TemporaryResourceStorageDeletionServiceIntegrationTest @Autowired construc
     private val temporaryResourceStorageDeletionService: TemporaryResourceStorageDeletionService
 ) : BaseIntegrationTest() {
 
+    @Disabled("https://github.com/gradle/gradle/issues/27871")
     @Test
     fun `should delete files older that 60 minutes`() {
         val resourceId = temporaryResourceStorageService.store("My file data".byteInputStream())

--- a/search/src/main/kotlin/com/ritense/search/autoconfigure/SearchAutoConfiguration.kt
+++ b/search/src/main/kotlin/com/ritense/search/autoconfigure/SearchAutoConfiguration.kt
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.jsontype.NamedType
 import com.ritense.search.ObjectMapperConfigurer
 import com.ritense.search.domain.DateFormatDisplayTypeParameter
 import com.ritense.search.domain.EnumDisplayTypeParameter
+import com.ritense.search.mapper.LegacySearchFieldV2Mapper
+import com.ritense.search.mapper.SearchFieldV2Mapper
 import com.ritense.search.repository.SearchFieldV2Repository
 import com.ritense.search.repository.SearchListColumnRepository
 import com.ritense.search.security.config.SearchHttpSecurityConfigurer
@@ -63,10 +65,12 @@ class SearchAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(SearchFieldV2Service::class)
     fun searchFieldV2Service(
-        searchFieldV2Repository: SearchFieldV2Repository
+        searchFieldV2Repository: SearchFieldV2Repository,
+        searchFieldMappers: List<SearchFieldV2Mapper>
     ): SearchFieldV2Service {
         return SearchFieldV2Service(
-            searchFieldV2Repository
+            searchFieldV2Repository,
+            searchFieldMappers
         )
     }
 
@@ -103,6 +107,14 @@ class SearchAutoConfiguration {
         displayTypeParameterTypes: Collection<NamedType>
     ): ObjectMapperConfigurer {
         return ObjectMapperConfigurer(objectMapper, displayTypeParameterTypes)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(LegacySearchFieldV2Mapper::class)
+    fun legacySearchFieldV2Mapper(
+        objectMapper: ObjectMapper
+    ): LegacySearchFieldV2Mapper {
+        return LegacySearchFieldV2Mapper(objectMapper)
     }
 
 }

--- a/search/src/main/kotlin/com/ritense/search/domain/SearchFieldV2.kt
+++ b/search/src/main/kotlin/com/ritense/search/domain/SearchFieldV2.kt
@@ -24,6 +24,8 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.util.UUID
 
+const val LEGACY_OWNER_TYPE = "Legacy"
+
 @Entity
 @Table(name = "search_field_v2")
 data class SearchFieldV2(
@@ -35,7 +37,7 @@ data class SearchFieldV2(
     val ownerId: String,
 
     @Column(name = "owner_type")
-    val ownerType: String?,
+    val ownerType: String,
 
     @Column(name = "column_key")
     val key: String,
@@ -83,7 +85,7 @@ data class SearchFieldV2(
         order = order,
         dataType = dataType,
         fieldType = fieldType,
-        ownerType = null,
+        ownerType = LEGACY_OWNER_TYPE,
         matchType = null,
         dropdownDataProvider = null
     )

--- a/search/src/main/kotlin/com/ritense/search/mapper/LegacySearchFieldV2Mapper.kt
+++ b/search/src/main/kotlin/com/ritense/search/mapper/LegacySearchFieldV2Mapper.kt
@@ -1,0 +1,38 @@
+package com.ritense.search.mapper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ritense.search.domain.LEGACY_OWNER_TYPE
+import com.ritense.search.domain.SearchFieldV2
+import com.ritense.search.web.rest.dto.LegacySearchFieldV2Dto
+import com.ritense.search.web.rest.dto.SearchFieldV2Dto
+
+
+class LegacySearchFieldV2Mapper(
+    objectMapper: ObjectMapper
+): SearchFieldV2Mapper {
+
+    init{
+        objectMapper.registerSubtypes(
+            LegacySearchFieldV2Dto::class.java
+        )
+    }
+
+    override fun supportsOwnerType(ownerType: String) = ownerType == LEGACY_OWNER_TYPE
+
+    override fun toNewSearchFieldV2(searchFieldV2Dto: SearchFieldV2Dto): SearchFieldV2 {
+        return SearchFieldV2(
+            id = searchFieldV2Dto.id,
+            ownerId = searchFieldV2Dto.ownerId,
+            ownerType = LEGACY_OWNER_TYPE,
+            key = searchFieldV2Dto.key,
+            title = searchFieldV2Dto.title,
+            path = searchFieldV2Dto.path,
+            order = searchFieldV2Dto.order,
+            dataType = searchFieldV2Dto.dataType,
+            fieldType = searchFieldV2Dto.fieldType,
+            matchType = searchFieldV2Dto.matchType,
+            dropdownDataProvider = searchFieldV2Dto.dropdownDataProvider
+        )
+    }
+
+}

--- a/search/src/main/kotlin/com/ritense/search/mapper/LegacySearchFieldV2Mapper.kt
+++ b/search/src/main/kotlin/com/ritense/search/mapper/LegacySearchFieldV2Mapper.kt
@@ -19,8 +19,8 @@ class LegacySearchFieldV2Mapper(
 
     override fun supportsOwnerType(ownerType: String) = ownerType == LEGACY_OWNER_TYPE
 
-    override fun toNewSearchFieldV2(searchFieldV2Dto: SearchFieldV2Dto): SearchFieldV2 {
-        return SearchFieldV2(
+    override fun toNewSearchFieldV2(searchFieldV2Dto: SearchFieldV2Dto): SearchFieldV2 =
+        SearchFieldV2(
             id = searchFieldV2Dto.id,
             ownerId = searchFieldV2Dto.ownerId,
             ownerType = LEGACY_OWNER_TYPE,
@@ -33,6 +33,4 @@ class LegacySearchFieldV2Mapper(
             matchType = searchFieldV2Dto.matchType,
             dropdownDataProvider = searchFieldV2Dto.dropdownDataProvider
         )
-    }
-
 }

--- a/search/src/main/kotlin/com/ritense/search/mapper/LegacySearchFieldV2Mapper.kt
+++ b/search/src/main/kotlin/com/ritense/search/mapper/LegacySearchFieldV2Mapper.kt
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ *  Licensed under EUPL, Version 1.2 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.ritense.search.mapper
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/search/src/main/kotlin/com/ritense/search/mapper/SearchFieldV2Mapper.kt
+++ b/search/src/main/kotlin/com/ritense/search/mapper/SearchFieldV2Mapper.kt
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ *  Licensed under EUPL, Version 1.2 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" basis,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package com.ritense.search.mapper
 
 import com.ritense.search.domain.SearchFieldV2

--- a/search/src/main/kotlin/com/ritense/search/mapper/SearchFieldV2Mapper.kt
+++ b/search/src/main/kotlin/com/ritense/search/mapper/SearchFieldV2Mapper.kt
@@ -1,0 +1,10 @@
+package com.ritense.search.mapper
+
+import com.ritense.search.domain.SearchFieldV2
+import com.ritense.search.web.rest.dto.SearchFieldV2Dto
+
+
+interface SearchFieldV2Mapper {
+    fun supportsOwnerType(ownerType: String): Boolean
+    fun toNewSearchFieldV2(searchFieldV2Dto: SearchFieldV2Dto): SearchFieldV2
+}

--- a/search/src/main/kotlin/com/ritense/search/repository/SearchFieldV2Repository.kt
+++ b/search/src/main/kotlin/com/ritense/search/repository/SearchFieldV2Repository.kt
@@ -24,6 +24,8 @@ interface SearchFieldV2Repository : JpaRepository<SearchFieldV2, UUID> {
 
     fun findByOwnerIdAndKeyOrderByOrder(ownerId: String, key: String): SearchFieldV2?
 
+    fun findByOwnerTypeAndOwnerIdAndKeyOrderByOrder(ownerType: String, ownerId: String, key: String): SearchFieldV2?
+
     fun findAllByOwnerTypeOrderByOrder(ownerType: String?): List<SearchFieldV2>
 
     fun findAllByOwnerIdOrderByOrder(ownerId: String): List<SearchFieldV2>

--- a/search/src/main/kotlin/com/ritense/search/web/rest/SearchFieldV2Resource.kt
+++ b/search/src/main/kotlin/com/ritense/search/web/rest/SearchFieldV2Resource.kt
@@ -16,8 +16,8 @@
 
 package com.ritense.search.web.rest
 
-import com.ritense.search.domain.SearchFieldV2
 import com.ritense.search.service.SearchFieldV2Service
+import com.ritense.search.web.rest.dto.SearchFieldV2Dto
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.domain.ValtimoMediaType.APPLICATION_JSON_UTF8_VALUE
 import jakarta.validation.Valid
@@ -41,28 +41,32 @@ class SearchFieldV2Resource(
     @PostMapping("/{ownerId}")
     fun create(
         @PathVariable ownerId: String,
-        @Valid @RequestBody searchFieldV2: SearchFieldV2
+        @Valid @RequestBody searchFieldV2Dto: SearchFieldV2Dto
     ) =
-        ResponseEntity.ok(searchFieldV2Service.create(searchFieldV2))
+        ResponseEntity.ok(searchFieldV2Service.create(searchFieldV2Dto))
 
     @PutMapping("/{ownerId}/{key}")
     fun update(
         @PathVariable ownerId: String,
         @PathVariable key: String,
-        @Valid @RequestBody searchFieldV2: SearchFieldV2
+        @Valid @RequestBody searchFieldV2Dto: SearchFieldV2Dto
     ) =
-        ResponseEntity.ok(searchFieldV2Service.update(ownerId, key, searchFieldV2))
+        ResponseEntity.ok(searchFieldV2Service.update(ownerId, key, searchFieldV2Dto))
 
     @PutMapping("/{ownerId}/fields")
     fun updateList(
         @PathVariable ownerId: String,
-        @Valid @RequestBody searchFieldV2: List<SearchFieldV2>
+        @Valid @RequestBody searchFieldV2Dtos: List<SearchFieldV2Dto>
     ) =
-        ResponseEntity.ok(searchFieldV2Service.updateList(ownerId, searchFieldV2))
+        ResponseEntity.ok(searchFieldV2Service.updateList(ownerId, searchFieldV2Dtos))
 
     @GetMapping("/{ownerId}")
     fun getAllByOwnerId(@PathVariable ownerId: String) =
         ResponseEntity.ok(searchFieldV2Service.findAllByOwnerId(ownerId))
+
+    @GetMapping("/{ownerType}/{ownerId}")
+    fun getAllByOwnerTypeAndOwnerId(@PathVariable ownerType: String, @PathVariable ownerId: String) =
+        ResponseEntity.ok(searchFieldV2Service.findAllByOwnerTypeAndOwnerId(ownerType, ownerId))
 
     @DeleteMapping("/{ownerId}/{key}")
     fun delete(
@@ -70,6 +74,16 @@ class SearchFieldV2Resource(
         @PathVariable key: String
     ): ResponseEntity<Any> {
         searchFieldV2Service.delete(ownerId, key)
+        return ResponseEntity.noContent().build()
+    }
+
+    @DeleteMapping("/{ownerType}/{ownerId}/{key}")
+    fun delete(
+        @PathVariable ownerType: String,
+        @PathVariable ownerId: String,
+        @PathVariable key: String
+    ): ResponseEntity<Any> {
+        searchFieldV2Service.delete(ownerType, ownerId, key)
         return ResponseEntity.noContent().build()
     }
 }

--- a/search/src/main/kotlin/com/ritense/search/web/rest/dto/LegacySearchFieldV2Dto.kt
+++ b/search/src/main/kotlin/com/ritense/search/web/rest/dto/LegacySearchFieldV2Dto.kt
@@ -23,7 +23,7 @@ import com.ritense.search.domain.LEGACY_OWNER_TYPE
 import com.ritense.search.domain.SearchFieldMatchType
 import java.util.UUID
 
-@JsonTypeName("")
+@JsonTypeName
 data class LegacySearchFieldV2Dto(
     override val id: UUID = UUID.randomUUID(),
     override val ownerId: String,

--- a/search/src/main/kotlin/com/ritense/search/web/rest/dto/LegacySearchFieldV2Dto.kt
+++ b/search/src/main/kotlin/com/ritense/search/web/rest/dto/LegacySearchFieldV2Dto.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.search.web.rest.dto
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.ritense.search.domain.DataType
+import com.ritense.search.domain.FieldType
+import com.ritense.search.domain.LEGACY_OWNER_TYPE
+import com.ritense.search.domain.SearchFieldMatchType
+import java.util.UUID
+
+@JsonTypeName("")
+data class LegacySearchFieldV2Dto(
+    override val id: UUID = UUID.randomUUID(),
+    override val ownerId: String,
+    override val key: String,
+    override val title: String?,
+    override val path: String,
+    override val order: Int,
+    override val dataType: DataType,
+    override val fieldType: FieldType,
+    override val matchType: SearchFieldMatchType? = null,
+    override val dropdownDataProvider: String? = null
+) : SearchFieldV2Dto {
+    override val ownerType: String
+        get() = LEGACY_OWNER_TYPE
+
+}

--- a/search/src/main/kotlin/com/ritense/search/web/rest/dto/SearchFieldV2Dto.kt
+++ b/search/src/main/kotlin/com/ritense/search/web/rest/dto/SearchFieldV2Dto.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.search.web.rest.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.ritense.search.domain.DataType
+import com.ritense.search.domain.FieldType
+import com.ritense.search.domain.SearchFieldMatchType
+import java.util.UUID
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, defaultImpl = LegacySearchFieldV2Dto::class, include = JsonTypeInfo.As.PROPERTY, property = "ownerType")
+@JsonIgnoreProperties("ownerType", allowGetters = true)
+interface SearchFieldV2Dto {
+    val id: UUID
+    val ownerId: String
+    val ownerType: String
+    val key: String
+    val title: String?
+    val path: String
+    val order: Int
+    val dataType: DataType
+    val fieldType: FieldType
+    val matchType: SearchFieldMatchType?
+    val dropdownDataProvider: String?
+}

--- a/search/src/main/resources/config/liquibase/changelog/20240620-replace-uq-constraint-remove-null.xml
+++ b/search/src/main/resources/config/liquibase/changelog/20240620-replace-uq-constraint-remove-null.xml
@@ -1,0 +1,45 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2015-2024 Ritense BV, the Netherlands.
+  ~
+  ~ Licensed under EUPL, Version 1.2 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" basis,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+    <property name="booleanFalseValue" value="0" dbms="mysql"/>
+    <property name="booleanFalseValue" value="false" dbms="postgresql"/>
+    <property name="uuidType" value="BINARY(16)" dbms="mysql"/>
+    <property name="uuidType" value="uuid" dbms="h2,postgresql"/>
+
+    <changeSet id="add-owner_type-not-null-constraint" author="Ritense">
+        <addNotNullConstraint columnDataType="varchar(255)"
+                              columnName="owner_type"
+                              constraintName="search_field_v2_owner_type_nn"
+                              defaultNullValue="Legacy"
+                              tableName="search_field_v2"/>
+    </changeSet>
+
+    <changeSet id="remove-unique-contstraint" author="Ritense">
+        <dropUniqueConstraint  constraintName="unique-owner_id-column_key-constraint"
+                               tableName="search_field_v2"/>
+    </changeSet>
+
+    <changeSet id="add-unique-contstraint" author="Ritense">
+        <addUniqueConstraint constraintName="unique-owner_id-owner_type-column_key-constraint"
+                             columnNames="owner_type, owner_id, column_key"
+                             tableName="search_field_v2"/>
+    </changeSet>
+</databaseChangeLog>

--- a/search/src/main/resources/config/liquibase/search-master.xml
+++ b/search/src/main/resources/config/liquibase/search-master.xml
@@ -27,5 +27,6 @@
     <include file="changelog/20230131-add-search-field-table.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20230426-migrate-path.xml" relativeToChangelogFile="true"/>
     <include file="changelog/20240523-add-ownertype-matchtype-dropdown.xml" relativeToChangelogFile="true"/>
+    <include file="changelog/20240620-replace-uq-constraint-remove-null.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/search/src/test/kotlin/com/ritense/search/service/SearchFieldV2IntTest.kt
+++ b/search/src/test/kotlin/com/ritense/search/service/SearchFieldV2IntTest.kt
@@ -20,6 +20,8 @@ import com.ritense.search.BaseIntegrationTest
 import com.ritense.search.domain.DataType
 import com.ritense.search.domain.FieldType
 import com.ritense.search.domain.SearchFieldV2
+import com.ritense.search.web.rest.dto.LegacySearchFieldV2Dto
+import com.ritense.search.web.rest.dto.SearchFieldV2Dto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -37,10 +39,22 @@ internal class SearchFieldV2IntTest : BaseIntegrationTest() {
         assertThat(searchField).isNotNull
 
         val updatedSearchField = searchField.copy(title = "New Title")
+        val updatedSearchFieldDto = LegacySearchFieldV2Dto(
+            id = updatedSearchField.id,
+            ownerId = updatedSearchField.ownerId,
+            key = updatedSearchField.key,
+            title = updatedSearchField.title,
+            path = updatedSearchField.path,
+            order = updatedSearchField.order,
+            dataType = updatedSearchField.dataType,
+            fieldType = updatedSearchField.fieldType,
+            matchType = updatedSearchField.matchType,
+            dropdownDataProvider = updatedSearchField.dropdownDataProvider
+        )
         val dbUpdatedSearchField = searchFieldV2Service.update(
             updatedSearchField.ownerId,
             updatedSearchField.key,
-            updatedSearchField
+            updatedSearchFieldDto
         )
 
         assertThat(dbUpdatedSearchField?.title).isEqualTo(updatedSearchField.title)
@@ -59,7 +73,7 @@ internal class SearchFieldV2IntTest : BaseIntegrationTest() {
 
     private fun createSearchField(ownerId: String? = null): SearchFieldV2 =
         searchFieldV2Service.create(
-            SearchFieldV2(
+            LegacySearchFieldV2Dto(
                 ownerId = ownerId ?: "I own this",
                 key = "the magic key",
                 title = "Title",
@@ -67,7 +81,6 @@ internal class SearchFieldV2IntTest : BaseIntegrationTest() {
                 order = 1,
                 dataType = DataType.TEXT,
                 fieldType = FieldType.RANGE,
-                ownerType = null,
                 matchType = null,
                 dropdownDataProvider = null
             )

--- a/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceIntTest.kt
+++ b/zgw/object-management/src/test/kotlin/com/ritense/objectmanagement/service/ObjectManagementServiceIntTest.kt
@@ -35,6 +35,7 @@ import com.ritense.search.domain.SearchFieldV2
 import com.ritense.search.domain.SearchListColumn
 import com.ritense.search.service.SearchFieldV2Service
 import com.ritense.search.service.SearchListColumnService
+import com.ritense.search.web.rest.dto.LegacySearchFieldV2Dto
 import jakarta.transaction.Transactional
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -177,7 +178,7 @@ internal class ObjectManagementServiceIntTest : BaseIntegrationTest() {
         )
 
         searchFieldV2Service.create(
-            SearchFieldV2(
+            LegacySearchFieldV2Dto(
                 ownerId = objectManagement.id.toString(),
                 key = "property1",
                 title = "property1",


### PR DESCRIPTION
Changed the SearchFieldV2's so that the `ownerType` is now determined by subclass of the DTO to reduce the chance of issues by using wrong values for this field.