### PR TITLE
Removed the quoting from the JSON path

### DIFF
--- a/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
@@ -357,7 +357,7 @@ class CaseTaskListSearchService(
         documentRoot: Root<JsonSchemaDocument>,
         searchCriteria: AdvancedSearchRequest.OtherFilter
     ): Expression<Comparable<Any>> {
-        val jsonPath = "$." + quoteJsonPath(searchCriteria.path.substring(DOC_PREFIX.length))
+        val jsonPath = "$." + searchCriteria.path.substring(DOC_PREFIX.length)
         return queryDialectHelper.getJsonValueExpression(
             cb,
             documentRoot.get<Any>("content")
@@ -514,8 +514,7 @@ class CaseTaskListSearchService(
                 val property = order.property
                 when {
                     property.startsWith(DOC_PREFIX) -> {
-                        val quotedPath = quoteJsonPath(property.substring(DOC_PREFIX.length))
-                        val jsonPath = "$.${quotedPath}"
+                        val jsonPath = "$." + property.substring(DOC_PREFIX.length)
                         expression = queryDialectHelper.getJsonValueExpression(
                             cb,
                             documentRoot.get<JsonDocumentContent>(CONTENT)
@@ -643,9 +642,6 @@ class CaseTaskListSearchService(
         }
         return result as Path<T>
     }
-
-    private fun quoteJsonPath(property: String): String =
-        property.split(".").joinToString(".") { "\"${it}\"" }
 
     companion object {
         val defaultColumns: List<TaskListColumn> = listOf(


### PR DESCRIPTION
Removed the quoting from the JSON path so that the path with slashes works again. This will break dot notation when there is a dash or space in the path name, but at least this is consistent with the other JSON path implementations within Valtimo.