### PR TITLE
Exclude empty `contextResourceType` and `contextConditions` 

### DIFF
--- a/authorization/src/main/kotlin/com/ritense/authorization/deployment/PermissionDto.kt
+++ b/authorization/src/main/kotlin/com/ritense/authorization/deployment/PermissionDto.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.authorization.deployment
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonView
 import com.ritense.authorization.Action
 import com.ritense.authorization.permission.ConditionContainer
@@ -29,12 +30,15 @@ data class PermissionDto(
     val resourceType: Class<*>,
     @field:JsonView(value = [PermissionView.RoleManagement::class, PermissionView.PermissionManagement::class])
     val action: String,
+//    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     @field:JsonView(value = [PermissionView.RoleManagement::class, PermissionView.PermissionManagement::class])
     val conditions: List<PermissionCondition> = emptyList(),
     @field:JsonView(PermissionView.PermissionManagement::class)
     val roleKey: String,
+    @field:JsonInclude(JsonInclude.Include.NON_NULL)
     @field:JsonView(value = [PermissionView.RoleManagement::class, PermissionView.PermissionManagement::class])
     val contextResourceType: Class<*>? = null,
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     @field:JsonView(value = [PermissionView.RoleManagement::class, PermissionView.PermissionManagement::class])
     val contextConditions: List<PermissionCondition> = emptyList(),
 ) {

--- a/authorization/src/test/kotlin/com/ritense/authorization/deployment/PermissionDeployerIntTest.kt
+++ b/authorization/src/test/kotlin/com/ritense/authorization/deployment/PermissionDeployerIntTest.kt
@@ -47,7 +47,7 @@ internal class PermissionDeployerIntTest : BaseIntegrationTest() {
         assertThat(changeset.get().filename).endsWith("/testdocument.permission.json")
         assertThat(changeset.get().dateExecuted).isBetween(Instant.parse("2023-06-13T00:00:00Z"), Instant.now())
         assertThat(changeset.get().orderExecuted).isBetween(0, 1000)
-        assertThat(changeset.get().md5sum).isEqualTo("620892c4c4f31e502c81dd237b807d77")
+        assertThat(changeset.get().md5sum).isEqualTo("ec0f3428909e35d0f9eac83b72cad697")
     }
 
     @Test


### PR DESCRIPTION
Exclude empty `contextResourceType` and `contextConditions` from the permissiondto when serializing