### PR TITLE
Rewrote the loading in of the .env.properties

### DIFF
--- a/app/gzac/build.gradle
+++ b/app/gzac/build.gradle
@@ -31,14 +31,10 @@ bootRun {
     doFirst {
         File f = file(".env.properties")
         if (f.isFile()) {
-            f.readLines().each() {
-                if (!it.isEmpty() && !it.startsWith("#")) {
-                    def (key, value) = it.tokenize('=')
-                    // check if notNullOrBlank for key and value
-                    if (key?.trim() && value?.trim()) {
-                        environment key.trim(), value.trim()
-                    }
-                }
+            def props = new Properties()
+            f.withInputStream { props.load(it) }
+            props.each { key, value ->
+                environment key.toString(), value.toString()
             }
         }
     }


### PR DESCRIPTION
Rewrote the loading in of the `.env.properties` so that it makes use of the `java.util.Properties()` class, instead of manually parsing of the file. This also resolves an issue when there is a `=` sign in the value of the property. (`String.tokenize()` will split on the `=` sign, so if there are multiple `=` signs on one line, everything from the second `=` onward will be ignored.)