### PR TITLE
Dependency upgrades

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -128,8 +128,6 @@ dependencies {
 
     implementation "org.liquibase:liquibase-core:${liquibaseVersion}"
 
-    implementation "io.dropwizard.metrics:metrics-core"
-    implementation "io.dropwizard.metrics:metrics-annotation"
     implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     implementation "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
     implementation "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ dokkaPluginVersion=1.9.20
 versionsPluginVersion=0.51.0
 sonarqubePluginVersion=4.4.1.3373
 dockerComposePluginVersion=0.17.7
-dependencyLicenseReportVersion=2.7
+dependencyLicenseReportVersion=2.8
 
 groovyVersion=4.0.22
 amqpCLientVersion=5.21.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,9 +28,9 @@ https.connectionTimeout=60000
 
 # dependency versions
 kotlinVersion=1.9.23
-kotlinCoroutinesVersion=1.8.0
+kotlinCoroutinesVersion=1.8.1
 kotlinLoggingVersion=3.0.5
-mockitoKotlinVersion=5.2.1
+mockitoKotlinVersion=5.4.0
 mockitoInlineVersion=5.2.0
 
 camundaVersion=7.21.0
@@ -40,33 +40,33 @@ camundaBpmAssertVersion=15.0.0
 camundaBpmMockitoVersion=5.16.0
 mybatisSpringBootStarterVersion=3.0.3
 
-springBootVersion=3.2.5
-springBootAdminStarterClientVersion=3.2.3
-springDependencyManagementVersion=1.1.4
-springCloudStreamVersion=4.1.1
+springBootVersion=3.3.2
+springBootAdminStarterClientVersion=3.3.3
+springDependencyManagementVersion=1.1.6
+springCloudStreamVersion=4.1.3
 springRetryVersion=2.0.5
 
-liquibaseVersion=4.24.0
+liquibaseVersion=4.29.0
 liquibaseSlf4jVersion=5.0.0
 
-commonsLangVersion=3.14.0
+commonsLangVersion=3.15.0
 commonsIoVersion=2.16.1
-commonsCodecVersion=1.17.0
-commonsValidatorVersion=1.8.0
+commonsCodecVersion=1.17.1
+commonsValidatorVersion=1.9.0
 commonsText=1.12.0
 
 dokkaPluginVersion=1.9.20
 versionsPluginVersion=0.51.0
 sonarqubePluginVersion=4.4.1.3373
-dockerComposePluginVersion=0.17.6
+dockerComposePluginVersion=0.17.7
 dependencyLicenseReportVersion=2.7
 
-groovyVersion=4.0.21
+groovyVersion=4.0.22
 amqpCLientVersion=5.21.0
 jaxbApiVersion=4.0.2
-jjwtVersion=0.12.5
-graalvmJsVersion=23.0.4
-hypersistenceUtilsVersion=3.7.4
+jjwtVersion=0.12.6
+graalvmJsVersion=23.0.5
+hypersistenceUtilsVersion=3.8.2
 problemSpringWebVersion=0.29.1
 jacksonDatatypeProblemVersion=0.27.1
 jakartaInjectVersion=2.0.1
@@ -76,27 +76,27 @@ jaywayJsonpathVersion=2.9.0
 everitJsonSchemaVersion=1.14.4
 orgJsonJsonVersion=20240303
 bucket4jVersion=8.7.0
-keycloakClientVersion=24.0.3
+keycloakClientVersion=24.0.5
 apacheTikaVersion=2.9.2
 mandrillLutungClientVersion=0.0.8
-classgraphVersion=4.8.172
-guavaVersion=33.1.0-jre
-springDocVersion=2.3.0
-awssdkVersion=2.23.8
-jacksonVersion=2.17.0
-junitVersion=5.10.2
+classgraphVersion=4.8.174
+guavaVersion=33.2.1-jre
+springDocVersion=2.6.0
+awssdkVersion=2.26.25
+jacksonVersion=2.17.2
+junitVersion=5.10.3
 postgresqlDriverVersion=42.7.3
-mysqlDriverVersion=8.3.0
-hibernateCoreVersion=6.2.24.Final
+mysqlDriverVersion=8.4.0
+hibernateCoreVersion=6.5.2.Final
 mapstructVersion=1.5.5.Final
-kotestVersion=5.8.1
-shedlockVersion=5.13.0
-jsonassertVersion=1.5.1
+kotestVersion=5.9.1
+shedlockVersion=5.14.0
+jsonassertVersion=1.5.3
 cloudEventsCoreVersion=3.0.0
 
 # version overrides
 
-nettyCodecVersionOverride=4.1.106.Final
+nettyCodecVersionOverride=4.1.112.Final
 snakeYamlVersionOverride=2.2
 
 # project version

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ camundaBpmAssertVersion=15.0.0
 camundaBpmMockitoVersion=5.16.0
 mybatisSpringBootStarterVersion=3.0.3
 
-springBootVersion=3.3.2
+springBootVersion=3.2.5
 springBootAdminStarterClientVersion=3.3.3
 springDependencyManagementVersion=1.1.6
 springCloudStreamVersion=4.1.3

--- a/milestones/build.gradle
+++ b/milestones/build.gradle
@@ -80,9 +80,6 @@ dependencies {
     implementation "org.hibernate.orm:hibernate-core:${hibernateCoreVersion}"
     implementation "org.hibernate.orm:hibernate-envers:${hibernateCoreVersion}"
 
-    implementation "io.dropwizard.metrics:metrics-core"
-    implementation "io.dropwizard.metrics:metrics-annotation"
-
     testImplementation "org.springframework.security:spring-security-test"
 }
 


### PR DESCRIPTION
Also removed dropwizard metrics libraries as they weren't used.

**Not all dependencies are now 100% up to date. The list that isn't up to date (because it is a major upgrade, unspecified version, or a non-stable release):**
 - com.mysql:mysql-connector-j [8.4.0 -> 9.0.0]
     http://dev.mysql.com/doc/connector-j/en/
 - com.squareup.okhttp3:mockwebserver [4.12.0 -> 5.0.0-alpha.14]
     https://square.github.io/okhttp/
 - com.squareup.okhttp3:okhttp [4.12.0 -> 5.0.0-alpha.14]
     https://square.github.io/okhttp/
 - io.cloudevents:cloudevents-core [3.0.0 -> 4.0.1]
     https://cloudevents.github.io/sdk-java/
 - io.cloudevents:cloudevents-json-jackson [3.0.0 -> 4.0.1]
     https://cloudevents.github.io/sdk-java/
 - io.github.microutils:kotlin-logging [3.0.5 -> 4.0.0-beta-2]
     https://github.com/MicroUtils/kotlin-logging
 - io.netty:netty-resolver-dns-native-macos [4.1.105.Final -> 4.2.0.Alpha2]
     https://netty.io/
 - org.apache.groovy:groovy-all [4.0.22 -> 5.0.0-alpha-9]
     https://groovy-lang.org
 - org.apache.httpcomponents.client5:httpclient5 [5.3.1 -> 5.4-beta1]
     https://hc.apache.org/httpcomponents-client-5.4.x/${project.version}/
 - org.apache.tika:tika-core [2.9.2 -> 3.0.0-BETA2]
     https://tika.apache.org/
 - org.apache.tika:tika-parser-microsoft-module [2.9.2 -> 3.0.0-BETA2]
     https://tika.apache.org/
 - org.assertj:assertj-core [3.25.3 -> 3.26.3]
     https://assertj.github.io/doc/#assertj-core
 - org.camunda.bpm:camunda-engine [7.21.0 -> 7.22.0-alpha3]
     http://www.camunda.org
 - org.camunda.bpm:camunda-engine-plugin-connect [7.21.0 -> 7.22.0-alpha3]
     http://www.camunda.org
 - org.camunda.bpm:camunda-engine-plugin-spin [7.21.0 -> 7.22.0-alpha3]
     http://www.camunda.org
 - org.camunda.bpm.springboot:camunda-bpm-spring-boot-starter-rest [7.21.0 -> 7.22.0-alpha3]
     http://www.camunda.org
 - org.camunda.bpm.springboot:camunda-bpm-spring-boot-starter-webapp [7.21.0 -> 7.22.0-alpha3]
     http://www.camunda.org
 - org.graalvm.js:js-scriptengine [23.0.5 -> 24.0.2]
     http://www.graalvm.org/
 - org.hibernate.orm:hibernate-core [6.5.2.Final -> 7.0.0.Alpha3]
     https://hibernate.org/orm
 - org.hibernate.orm:hibernate-envers [6.5.2.Final -> 7.0.0.Alpha3]
     https://hibernate.org/orm
 - org.jetbrains.kotlin:kotlin-allopen-compiler-plugin-embeddable [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-noarg-compiler-plugin-embeddable [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-reflect [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8 [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-test [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.plugin.allopen:org.jetbrains.kotlin.plugin.allopen.gradle.plugin [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.plugin.jpa:org.jetbrains.kotlin.plugin.jpa.gradle.plugin [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.plugin.spring:org.jetbrains.kotlin.plugin.spring.gradle.plugin [1.9.23 -> 2.0.20-Beta2]
     https://kotlinlang.org/
 - org.jetbrains.kotlinx:kotlinx-coroutines-core [1.8.1 -> 1.9.0-RC]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-reactor [1.8.1 -> 1.9.0-RC]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-test [1.8.1 -> 1.9.0-RC]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.junit:junit-bom [5.10.3 -> 5.11.0-M2]
     https://junit.org/junit5/
 - org.junit.jupiter:junit-jupiter [5.10.3 -> 5.11.0-M2]
     https://junit.org/junit5/
 - org.junit.jupiter:junit-jupiter-engine [5.10.3 -> 5.11.0-M2]
     https://junit.org/junit5/
 - org.keycloak:keycloak-admin-client [24.0.5 -> 25.0.2]
     http://keycloak.org
 - org.mapstruct:mapstruct [1.5.5.Final -> 1.6.0.RC1]
     https://mapstruct.org/mapstruct/
 - org.mapstruct:mapstruct-processor [1.5.5.Final -> 1.6.0.RC1]
     https://mapstruct.org/mapstruct-processor/
 - org.mockito:mockito-core [5.11.0 -> 5.12.0]
     https://github.com/mockito/mockito
 - org.owasp.dependencycheck:org.owasp.dependencycheck.gradle.plugin [8.4.0 -> 10.0.3]
 - org.skyscreamer:jsonassert [1.5.3 -> 2.0-rc1]
     https://github.com/skyscreamer/JSONassert
 - org.sonarqube:org.sonarqube.gradle.plugin [4.4.1.3373 -> 5.1.0.4882]
 - org.springframework.retry:spring-retry [2.0.5 -> 2.0.7]
     https://www.springsource.org