### PR TITLE
story: use repositories for authorization entity mappers

### DIFF
--- a/document/src/main/kotlin/com/ritense/document/DocumentDocumentDefinitionMapper.kt
+++ b/document/src/main/kotlin/com/ritense/document/DocumentDocumentDefinitionMapper.kt
@@ -22,17 +22,17 @@ import com.ritense.authorization.AuthorizationEntityMapperResult
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.domain.impl.JsonSchemaDocumentDefinition
 import com.ritense.document.domain.impl.JsonSchemaDocumentDefinitionId
-import com.ritense.document.service.DocumentDefinitionService
+import com.ritense.document.repository.DocumentDefinitionRepository
 import jakarta.persistence.criteria.AbstractQuery
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.Root
 
 class DocumentDocumentDefinitionMapper(
-    private val documentDefinitionService: DocumentDefinitionService
+    private val documentDefinitionRepository: DocumentDefinitionRepository<JsonSchemaDocumentDefinition>
 ) : AuthorizationEntityMapper<JsonSchemaDocument, JsonSchemaDocumentDefinition> {
     override fun mapRelated(entity: JsonSchemaDocument): List<JsonSchemaDocumentDefinition> {
         return runWithoutAuthorization {
-            listOf(documentDefinitionService.findBy(entity.definitionId()).get() as JsonSchemaDocumentDefinition)
+            listOf(documentDefinitionRepository.findById(entity.definitionId()).get())
         }
     }
 

--- a/document/src/main/kotlin/com/ritense/document/autoconfiguration/DocumentAuthorizationAutoConfiguration.kt
+++ b/document/src/main/kotlin/com/ritense/document/autoconfiguration/DocumentAuthorizationAutoConfiguration.kt
@@ -21,6 +21,8 @@ import com.ritense.document.JsonSchemaDocumentDefinitionSpecificationFactory
 import com.ritense.document.JsonSchemaDocumentSnapshotSpecificationFactory
 import com.ritense.document.JsonSchemaDocumentSpecificationFactory
 import com.ritense.document.SearchFieldSpecificationFactory
+import com.ritense.document.domain.impl.JsonSchemaDocumentDefinition
+import com.ritense.document.repository.DocumentDefinitionRepository
 import com.ritense.document.service.impl.JsonSchemaDocumentDefinitionService
 import com.ritense.document.service.impl.JsonSchemaDocumentService
 import com.ritense.valtimo.contract.database.QueryDialectHelper
@@ -59,6 +61,6 @@ class DocumentAuthorizationAutoConfiguration {
 
     @Bean
     fun documentDocumentDefinitionMapper(
-        @Lazy documentDefinitionService: JsonSchemaDocumentDefinitionService
-    ) = DocumentDocumentDefinitionMapper(documentDefinitionService)
+        documentDefinitionRepository: DocumentDefinitionRepository<JsonSchemaDocumentDefinition>
+    ) = DocumentDocumentDefinitionMapper(documentDefinitionRepository)
 }

--- a/notes/src/main/kotlin/com/ritense/note/autoconfigure/NoteAutoConfiguration.kt
+++ b/notes/src/main/kotlin/com/ritense/note/autoconfigure/NoteAutoConfiguration.kt
@@ -18,6 +18,7 @@ package com.ritense.note.autoconfigure
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.authorization.AuthorizationService
+import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
 import com.ritense.document.service.DocumentService
 import com.ritense.note.repository.NoteDocumentMapper
 import com.ritense.note.repository.NoteRepository
@@ -83,9 +84,9 @@ class NoteAutoConfiguration {
 
     @Bean
     fun noteDocumentMapper(
-        @Lazy documentService: DocumentService,
+        documentRepository: JsonSchemaDocumentRepository
     ): NoteDocumentMapper {
-        return NoteDocumentMapper(documentService)
+        return NoteDocumentMapper(documentRepository)
     }
 
     @Bean

--- a/notes/src/main/kotlin/com/ritense/note/repository/NoteDocumentMapper.kt
+++ b/notes/src/main/kotlin/com/ritense/note/repository/NoteDocumentMapper.kt
@@ -21,7 +21,7 @@ import com.ritense.authorization.AuthorizationEntityMapper
 import com.ritense.authorization.AuthorizationEntityMapperResult
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.domain.impl.JsonSchemaDocumentId
-import com.ritense.document.service.DocumentService
+import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
 import com.ritense.note.domain.Note
 import jakarta.persistence.criteria.AbstractQuery
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -29,10 +29,10 @@ import jakarta.persistence.criteria.Root
 import java.util.UUID
 
 class NoteDocumentMapper(
-    private val documentService: DocumentService
+    private val documentRepository: JsonSchemaDocumentRepository
 ) : AuthorizationEntityMapper<Note, JsonSchemaDocument> {
     override fun mapRelated(entity: Note): List<JsonSchemaDocument> {
-        return runWithoutAuthorization { listOf(documentService.get(entity.documentId.toString()) as JsonSchemaDocument) }
+        return runWithoutAuthorization { listOf(documentRepository.findById(JsonSchemaDocumentId.existingId(entity.documentId)).get()) }
     }
 
     override fun mapQuery(root: Root<Note>, query: AbstractQuery<*>, criteriaBuilder: CriteriaBuilder): AuthorizationEntityMapperResult<JsonSchemaDocument> {

--- a/process-document/src/main/kotlin/com/ritense/processdocument/autoconfigure/ProcessDocumentsAutoConfiguration.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/autoconfigure/ProcessDocumentsAutoConfiguration.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.authorization.AuthorizationService
 import com.ritense.case.repository.TaskListColumnRepository
 import com.ritense.case.service.CaseDefinitionService
+import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
 import com.ritense.document.service.DocumentService
 import com.ritense.document.service.impl.JsonSchemaDocumentService
 import com.ritense.processdocument.camunda.authorization.CamundaTaskDocumentMapper
@@ -28,6 +29,7 @@ import com.ritense.processdocument.exporter.ProcessDocumentLinkExporter
 import com.ritense.processdocument.importer.ProcessDocumentLinkImporter
 import com.ritense.processdocument.listener.CaseAssigneeListener
 import com.ritense.processdocument.listener.CaseAssigneeTaskCreatedListener
+import com.ritense.processdocument.repository.ProcessDocumentInstanceRepository
 import com.ritense.processdocument.service.CaseTaskListSearchService
 import com.ritense.processdocument.service.CorrelationService
 import com.ritense.processdocument.service.CorrelationServiceImpl
@@ -37,7 +39,6 @@ import com.ritense.processdocument.service.ProcessDocumentDeploymentService
 import com.ritense.processdocument.service.ProcessDocumentService
 import com.ritense.processdocument.service.ProcessDocumentsService
 import com.ritense.processdocument.service.ValueResolverDelegateService
-import com.ritense.processdocument.service.impl.CamundaProcessJsonSchemaDocumentService
 import com.ritense.processdocument.tasksearch.TaskListSearchFieldV2Mapper
 import com.ritense.processdocument.tasksearch.TaskSearchFieldDeployer
 import com.ritense.processdocument.tasksearch.TaskSearchFieldExporter
@@ -63,7 +64,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Lazy
 
 @AutoConfiguration
 class ProcessDocumentsAutoConfiguration {
@@ -112,6 +112,7 @@ class ProcessDocumentsAutoConfiguration {
             objectMapper,
         )
     }
+
     @ProcessBean
     @Bean
     @ConditionalOnMissingBean(CorrelationService::class)
@@ -176,10 +177,11 @@ class ProcessDocumentsAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(CamundaTaskDocumentMapper::class)
     fun camundaTaskDocumentMapper(
-        @Lazy processDocumentService: CamundaProcessJsonSchemaDocumentService,
+        processDocumentInstanceRepository: ProcessDocumentInstanceRepository,
+        documentRepository: JsonSchemaDocumentRepository,
         queryDialectHelper: QueryDialectHelper
     ): CamundaTaskDocumentMapper {
-        return CamundaTaskDocumentMapper(processDocumentService, queryDialectHelper)
+        return CamundaTaskDocumentMapper(processDocumentInstanceRepository, documentRepository, queryDialectHelper)
     }
 
     @Bean

--- a/process-document/src/main/kotlin/com/ritense/processdocument/camunda/authorization/CamundaTaskDocumentMapper.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/camunda/authorization/CamundaTaskDocumentMapper.kt
@@ -20,8 +20,9 @@ import com.ritense.authorization.AuthorizationEntityMapper
 import com.ritense.authorization.AuthorizationEntityMapperResult
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.domain.impl.JsonSchemaDocumentId
+import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
 import com.ritense.processdocument.domain.impl.CamundaProcessInstanceId
-import com.ritense.processdocument.service.impl.CamundaProcessJsonSchemaDocumentService
+import com.ritense.processdocument.repository.ProcessDocumentInstanceRepository
 import com.ritense.valtimo.camunda.domain.CamundaExecution
 import com.ritense.valtimo.camunda.domain.CamundaTask
 import com.ritense.valtimo.camunda.repository.CamundaHistoricProcessInstanceSpecificationHelper.Companion.BUSINESS_KEY
@@ -33,13 +34,15 @@ import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.Root
 
 class CamundaTaskDocumentMapper(
-    private val processDocumentService: CamundaProcessJsonSchemaDocumentService,
+    private val processDocumentInstanceRepository: ProcessDocumentInstanceRepository,
+    private val documentRepository: JsonSchemaDocumentRepository,
     private val queryDialectHelper: QueryDialectHelper
 ) : AuthorizationEntityMapper<CamundaTask, JsonSchemaDocument> {
 
     override fun mapRelated(entity: CamundaTask): List<JsonSchemaDocument> {
         val processInstanceId = CamundaProcessInstanceId(entity.getProcessInstanceId())
-        val document = processDocumentService.getDocument(processInstanceId, entity)
+        val processDocumentInstance = processDocumentInstanceRepository.findByProcessInstanceId(processInstanceId).get()
+        val document = documentRepository.findById(processDocumentInstance.processDocumentInstanceId().documentId()).get()
         return listOf(document)
     }
 


### PR DESCRIPTION
closes https://ritense.tpondemand.com/entity/93218-be-use-repositories-for-authorizationentitymapper