### PR TITLE
Intermediate save: switched to userManagementService.currentUser.userIdentifier to get the correct user identifier

### DIFF
--- a/form/src/main/kotlin/com/ritense/form/service/IntermediateSubmissionService.kt
+++ b/form/src/main/kotlin/com/ritense/form/service/IntermediateSubmissionService.kt
@@ -38,7 +38,7 @@ class IntermediateSubmissionService(
         authorizationService.requirePermission(
             EntityAuthorizationRequest(CamundaTask::class.java, COMPLETE, task)
         )
-        val currentUser: String = userManagementService.currentUserId
+        val currentUser: String = userManagementService.currentUser.userIdentifier
         val existingIntermediateSubmission = intermediateSubmissionRepository.getByTaskInstanceId(taskInstanceId)
         if (existingIntermediateSubmission != null) {
             return intermediateSubmissionRepository.save(

--- a/form/src/test/kotlin/com/ritense/form/web/rest/IntermediateSubmissionResourceIntTest.kt
+++ b/form/src/test/kotlin/com/ritense/form/web/rest/IntermediateSubmissionResourceIntTest.kt
@@ -58,9 +58,10 @@ class IntermediateSubmissionResourceIntTest : BaseIntegrationTest() {
         whenever(task.id).thenReturn("taskInstanceId")
         whenever(camundaTaskService.findTaskById(any())).thenReturn(task)
 
-        whenever(userManagementService.currentUserId).thenReturn("currentUserId")
         val manageableUser: ManageableUser = mock()
+        whenever(manageableUser.userIdentifier).thenReturn("userIdentifier")
         whenever(manageableUser.fullName).thenReturn("FullName")
+        whenever(userManagementService.currentUser).thenReturn(manageableUser)
         whenever(userManagementService.findByUserIdentifier(any())).thenReturn(manageableUser)
     }
 


### PR DESCRIPTION
Switched to userManagementService.currentUser.userIdentifier to get the correct user identifier

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [X] The contribution only contains changes that are not breaking.

New features or changes that have been introduced have been documented.
- [X] Not applicable

### Tests
Unit tests have been added that cover these changes
- [X] Not applicable

Integration tests have been added that cover these changes
- [X] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [X] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [X] Not applicable

Valtimo access control checks have been implemented
- [X] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [X] Not applicable