### PR TITLE
make Informatieobjecttype serializable

### DIFF
--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/domain/Informatieobjecttype.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/domain/Informatieobjecttype.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.catalogiapi.domain
 
+import java.io.Serializable
 import java.net.URI
 import java.time.LocalDate
 
@@ -27,4 +28,4 @@ class Informatieobjecttype(
     val beginGeldigheid: LocalDate,
     val eindeGeldigheid: LocalDate?,
     val concept: Boolean
-)
+) : Serializable


### PR DESCRIPTION
bugfix:make Informatieobjecttype serializable used in the SearchConfigurationDeploymentService for deploying all search configurations.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable