### PR TITLE
#110394 Form flow: spamming next button

### DIFF
--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/handler/FormFlowStepTypeCustomComponentHandler.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/handler/FormFlowStepTypeCustomComponentHandler.kt
@@ -27,7 +27,7 @@ class FormFlowStepTypeCustomComponentHandler(
 
     override fun getTypeProperties(stepInstance: FormFlowStepInstance): CustomComponentTypeProperties {
         val stepDefinitionType = stepInstance.definition.type
-        assert(stepDefinitionType.name == getType())
+        require(stepDefinitionType.name == getType())
         val angularComponentId = (stepDefinitionType.properties as CustomComponentStepTypeProperties).componentId
         return CustomComponentTypeProperties(angularComponentId)
     }

--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/handler/FormFlowStepTypeFormHandler.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/handler/FormFlowStepTypeFormHandler.kt
@@ -45,7 +45,7 @@ class FormFlowStepTypeFormHandler(
 
     private fun getFormDefinition(stepInstance: FormFlowStepInstance): FormIoFormDefinition {
         val stepDefinitionType = stepInstance.definition.type
-        assert(stepDefinitionType.name == getType())
+        require(stepDefinitionType.name == getType())
         val formDefinitionName = (stepDefinitionType.properties as FormStepTypeProperties).definition
         return formIoFormDefinitionService.getFormDefinitionByName(formDefinitionName)
             .orElseThrow { IllegalStateException("No FormDefinition found by name $formDefinitionName") }

--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/result/ListFormFlowDefinitionResponse.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/result/ListFormFlowDefinitionResponse.kt
@@ -26,7 +26,7 @@ data class ListFormFlowDefinitionResponse(
     companion object {
         fun of(formFlowDefinitions: List<FormFlowDefinition>, readOnly: Boolean): ListFormFlowDefinitionResponse {
             val key = formFlowDefinitions.first().id.key
-            assert(formFlowDefinitions.all { it.id.key == key })
+            require(formFlowDefinitions.all { it.id.key == key })
             return ListFormFlowDefinitionResponse(
                 key = key,
                 versions = formFlowDefinitions.map { it.id.version }.sortedDescending(),

--- a/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowInstance.kt
+++ b/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowInstance.kt
@@ -73,7 +73,7 @@ class FormFlowInstance(
         currentFormFlowStepInstanceId: FormFlowStepInstanceId,
         submissionData: JSONObject
     ): FormFlowStepInstance? {
-        assert(this.currentFormFlowStepInstanceId == currentFormFlowStepInstanceId)
+        require(this.currentFormFlowStepInstanceId == currentFormFlowStepInstanceId)
 
         val formFlowStepInstance = getCurrentStep()
 

--- a/form-flow/src/test/kotlin/com/ritense/formflow/domain/FormFlowInstanceTest.kt
+++ b/form-flow/src/test/kotlin/com/ritense/formflow/domain/FormFlowInstanceTest.kt
@@ -125,7 +125,7 @@ internal class FormFlowInstanceTest : BaseTest() {
             formFlowDefinition = definition
         )
 
-        assertThrows<AssertionError> {
+        assertThrows<IllegalArgumentException> {
             instance.complete(FormFlowStepInstanceId.newId(), JSONObject("{\"data\": \"data\"}"))
         }
     }

--- a/form/src/main/kotlin/com/ritense/form/mapper/FormProcessLinkMapper.kt
+++ b/form/src/main/kotlin/com/ritense/form/mapper/FormProcessLinkMapper.kt
@@ -107,7 +107,7 @@ class FormProcessLinkMapper(
         updateRequestDto: ProcessLinkUpdateRequestDto
     ): ProcessLink {
         updateRequestDto as FormProcessLinkUpdateRequestDto
-        assert(processLinkToUpdate.id == updateRequestDto.id)
+        require(processLinkToUpdate.id == updateRequestDto.id)
         if (!formDefinitionService.formDefinitionExistsById(updateRequestDto.formDefinitionId)) {
             throw RuntimeException("Form definition not found with id ${updateRequestDto.formDefinitionId}")
         }

--- a/plugin/src/main/kotlin/com/ritense/plugin/PluginFactory.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/PluginFactory.kt
@@ -114,7 +114,7 @@ abstract class PluginFactory<T : Any>(
         } else if (propertyType.typeParameters.isNotEmpty()) {
             val propertyTypeWithGeneric =
                 getPropertyTypeWithGeneric(instance::class, propertyDefinition.fieldName, mapper)
-            assert(propertyType == propertyTypeWithGeneric.rawClass)
+            require(propertyType == propertyTypeWithGeneric.rawClass)
             mapper.treeToValue(
                 configuredProperty,
                 propertyTypeWithGeneric

--- a/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/service/PluginService.kt
@@ -616,7 +616,7 @@ class PluginService(
             val propertyConfigurationId =
                 PluginConfigurationId.existingId(UUID.fromString(propertyNode?.textValue()))
             val propertyConfiguration = pluginConfigurationRepository.findById(propertyConfigurationId)
-            assert(propertyConfiguration.isPresent) { "Plugin configuration with id ${propertyConfigurationId.id} does not exist!" }
+            require(propertyConfiguration.isPresent) { "Plugin configuration with id ${propertyConfigurationId.id} does not exist!" }
         } else {
             val propertyValue = objectMapper.treeToValue(propertyNode, propertyClass)
             val validationErrors =

--- a/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
+++ b/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/client/ZakenApiClient.kt
@@ -567,7 +567,7 @@ class ZakenApiClient(
     }
 
     fun deleteZaakInformatieObject(authentication: ZakenApiAuthentication, baseUrl: URI, zaakInformatieobjectUrl: URI) {
-        assert(zaakInformatieobjectUrl.toString().startsWith(baseUrl.toString())) {
+        require(zaakInformatieobjectUrl.toString().startsWith(baseUrl.toString())) {
             "zaakInformatieobjectUrl '$zaakInformatieobjectUrl' does not start with baseUrl '$baseUrl'"
         }
         buildWebClient(authentication)


### PR DESCRIPTION
`assert()` by default doesn't work in production without the `-ea` flag. See [link](https://medium.com/kotlin-with-raphael-de-lio/kotlin-tip-28-use-assert-to-assert-conditions-in-development-100-kotlin-1a0b39233bff)