### PR TITLE
Case list actions speed improvement

### DIFF
--- a/process-document/src/main/java/com/ritense/processdocument/repository/ProcessDocumentDefinitionRepository.java
+++ b/process-document/src/main/java/com/ritense/processdocument/repository/ProcessDocumentDefinitionRepository.java
@@ -34,41 +34,47 @@ import org.springframework.stereotype.Repository;
 public interface ProcessDocumentDefinitionRepository extends
     JpaRepository<CamundaProcessJsonSchemaDocumentDefinition, ProcessDocumentDefinitionId> {
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.documentDefinitionId.version = ( " +
         "   SELECT  MAX(dd.id.version) " +
         "   FROM    JsonSchemaDocumentDefinition dd " +
         "   WHERE   dd.id.name = pdd.id.documentDefinitionId.name " +
-        ")")
+        ")"
+    )
     Page<CamundaProcessJsonSchemaDocumentDefinition> findAllByLatestDocumentDefinitionVersion(Pageable pageable);
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.documentDefinitionId.name = :documentDefinitionName " +
         "AND     pdd.processDocumentDefinitionId.documentDefinitionId.version = ( " +
         "   SELECT  MAX(dd.id.version) " +
         "   FROM    JsonSchemaDocumentDefinition dd " +
-        "   WHERE   dd.id.name = pdd.id.documentDefinitionId.name " +        ") " +
-        "AND (:startableByUser IS NULL OR pdd.startableByUser = :startableByUser)")
+        "   WHERE   dd.id.name = pdd.id.documentDefinitionId.name " +
+        ") " +
+        "AND (:startableByUser IS NULL OR pdd.startableByUser = :startableByUser)" +
+        "AND (:canInitializeDocument IS NULL OR pdd.canInitializeDocument = :canInitializeDocument)"
+    )
     List<CamundaProcessJsonSchemaDocumentDefinition> findAll(
         @Param("documentDefinitionName") String documentDefinitionName,
-        @Nullable @Param("startableByUser") Boolean startableByUser
+        @Nullable @Param("startableByUser") Boolean startableByUser,
+        @Nullable @Param("canInitializeDocument") Boolean canInitializeDocument
     );
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.documentDefinitionId.name = :documentDefinitionName " +
-        "AND     pdd.processDocumentDefinitionId.documentDefinitionId.version = :documentDefinitionVersion")
+        "AND     pdd.processDocumentDefinitionId.documentDefinitionId.version = :documentDefinitionVersion"
+    )
     List<CamundaProcessJsonSchemaDocumentDefinition> findAllByDocumentDefinitionNameAndVersion(
         @Param("documentDefinitionName") String documentDefinitionName,
         @Param("documentDefinitionVersion") long documentDefinitionVersion
     );
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.processDefinitionKey.key = :processDefinitionKey " +
@@ -76,12 +82,13 @@ public interface ProcessDocumentDefinitionRepository extends
         "   SELECT  MAX(dd.id.version) " +
         "   FROM    JsonSchemaDocumentDefinition dd " +
         "   WHERE   dd.id.name = pdd.id.documentDefinitionId.name " +
-        ")")
+        ")"
+    )
     List<CamundaProcessJsonSchemaDocumentDefinition> findAllByProcessDefinitionKeyAndLatestDocumentDefinitionVersion(
         @Param("processDefinitionKey") String processDefinitionKey
     );
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.documentDefinitionId.name = :documentDefinitionName"
@@ -90,7 +97,7 @@ public interface ProcessDocumentDefinitionRepository extends
         @Param("documentDefinitionName") String documentDefinitionName
     );
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.processDefinitionKey = :processDefinitionKey " +
@@ -98,12 +105,13 @@ public interface ProcessDocumentDefinitionRepository extends
         "   SELECT  MAX(dd.id.version) " +
         "   FROM    JsonSchemaDocumentDefinition dd " +
         "   WHERE   dd.id.name = pdd.id.documentDefinitionId.name " +
-        ")")
+        ")"
+    )
     Optional<CamundaProcessJsonSchemaDocumentDefinition> findByProcessDefinitionKeyAndLatestDocumentDefinitionVersion(
         @Param("processDefinitionKey") ProcessDefinitionKey processDefinitionKey
     );
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.processDefinitionKey = :processDefinitionKey " +
@@ -111,26 +119,29 @@ public interface ProcessDocumentDefinitionRepository extends
         "   SELECT MAX(dd.id.version) " +
         "   FROM   JsonSchemaDocumentDefinition dd " +
         "   WHERE  dd.id.name = pdd.id.documentDefinitionId.name " +
-        ")")
+        ")"
+    )
     List<CamundaProcessJsonSchemaDocumentDefinition> findAllByProcessDefinitionKeyAndLatestDocumentDefinitionVersion(
         @Param("processDefinitionKey") ProcessDefinitionKey processDefinitionKey
     );
 
-    @Query("" +
+    @Query(
         "SELECT  pdd " +
         "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
         "WHERE   pdd.processDocumentDefinitionId.processDefinitionKey = :processDefinitionKey " +
-        "AND     pdd.processDocumentDefinitionId.documentDefinitionId.version = :documentDefinitionVersion ")
+        "AND     pdd.processDocumentDefinitionId.documentDefinitionId.version = :documentDefinitionVersion "
+    )
     Optional<CamundaProcessJsonSchemaDocumentDefinition> findByProcessDefinitionKeyAndDocumentDefinitionVersion(
         @Param("processDefinitionKey") ProcessDefinitionKey processDefinitionKey,
         @Param("documentDefinitionVersion") long documentDefinitionVersion
     );
 
     @Modifying
-    @Query("" +
-        "   DELETE " +
-        "   FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
-        "   WHERE   pdd.processDocumentDefinitionId.documentDefinitionId.name = :documentDefinitionName")
+    @Query(
+        "DELETE " +
+        "FROM    CamundaProcessJsonSchemaDocumentDefinition pdd " +
+        "WHERE   pdd.processDocumentDefinitionId.documentDefinitionId.name = :documentDefinitionName"
+    )
     void deleteByDocumentDefinition(@Param("documentDefinitionName") String documentDefinitionName);
 
 }

--- a/process-document/src/main/java/com/ritense/processdocument/service/ProcessDocumentAssociationService.java
+++ b/process-document/src/main/java/com/ritense/processdocument/service/ProcessDocumentAssociationService.java
@@ -48,7 +48,8 @@ public interface ProcessDocumentAssociationService {
 
     List<? extends ProcessDocumentDefinition> findProcessDocumentDefinitions(
         String documentDefinitionName,
-        @Nullable Boolean startableByUser
+        @Nullable Boolean startableByUser,
+        @Nullable Boolean canInitializeDocument
     );
 
     List<? extends ProcessDocumentDefinition> findProcessDocumentDefinitions(String documentDefinitionName, Long documentDefinitionVersion);

--- a/process-document/src/main/java/com/ritense/processdocument/service/ProcessDocumentAssociationService.java
+++ b/process-document/src/main/java/com/ritense/processdocument/service/ProcessDocumentAssociationService.java
@@ -48,6 +48,11 @@ public interface ProcessDocumentAssociationService {
 
     List<? extends ProcessDocumentDefinition> findProcessDocumentDefinitions(
         String documentDefinitionName,
+        @Nullable Boolean startableByUser
+    );
+
+    List<? extends ProcessDocumentDefinition> findProcessDocumentDefinitions(
+        String documentDefinitionName,
         @Nullable Boolean startableByUser,
         @Nullable Boolean canInitializeDocument
     );

--- a/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationService.java
+++ b/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationService.java
@@ -161,16 +161,17 @@ public class CamundaProcessJsonSchemaDocumentAssociationService implements Proce
 
     @Override
     public List<CamundaProcessJsonSchemaDocumentDefinition> findProcessDocumentDefinitions(String documentDefinitionName) {
-        return findProcessDocumentDefinitions(documentDefinitionName, (Boolean) null);
+        return findProcessDocumentDefinitions(documentDefinitionName, null, null);
     }
 
     @Override
     public List<CamundaProcessJsonSchemaDocumentDefinition> findProcessDocumentDefinitions(
         String documentDefinitionName,
-        @Nullable Boolean startableByUser
+        @Nullable Boolean startableByUser,
+        @Nullable Boolean canInitializeDocument
     ) {
         List<CamundaProcessJsonSchemaDocumentDefinition> results = processDocumentDefinitionRepository
-            .findAll(documentDefinitionName, startableByUser);
+            .findAll(documentDefinitionName, startableByUser, canInitializeDocument);
 
         return results.stream().filter(result -> {
             CamundaProcessDefinition processDefinition = AuthorizationContext.runWithoutAuthorization(() ->
@@ -195,8 +196,7 @@ public class CamundaProcessJsonSchemaDocumentAssociationService implements Proce
         String documentDefinitionName,
         Long documentDefinitionVersion
     ) {
-        return processDocumentDefinitionRepository
-            .findAllByDocumentDefinitionNameAndVersion(documentDefinitionName, documentDefinitionVersion);
+        return processDocumentDefinitionRepository.findAllByDocumentDefinitionNameAndVersion(documentDefinitionName, documentDefinitionVersion);
     }
 
     @Override

--- a/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationService.java
+++ b/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationService.java
@@ -167,6 +167,14 @@ public class CamundaProcessJsonSchemaDocumentAssociationService implements Proce
     @Override
     public List<CamundaProcessJsonSchemaDocumentDefinition> findProcessDocumentDefinitions(
         String documentDefinitionName,
+        @Nullable Boolean startableByUser
+    ) {
+        return findProcessDocumentDefinitions(documentDefinitionName, startableByUser, null);
+    }
+
+    @Override
+    public List<CamundaProcessJsonSchemaDocumentDefinition> findProcessDocumentDefinitions(
+        String documentDefinitionName,
         @Nullable Boolean startableByUser,
         @Nullable Boolean canInitializeDocument
     ) {

--- a/process-document/src/main/java/com/ritense/processdocument/web/rest/ProcessDocumentResource.java
+++ b/process-document/src/main/java/com/ritense/processdocument/web/rest/ProcessDocumentResource.java
@@ -100,9 +100,14 @@ public class ProcessDocumentResource {
     @GetMapping("/v1/process-document/definition/document/{document-definition-name}")
     public ResponseEntity<List<? extends ProcessDocumentDefinition>> findProcessDocumentDefinitions(
         @PathVariable(name = "document-definition-name") String documentDefinitionName,
-        @RequestParam(value = "startableByUser", required = false) @Nullable Boolean startableByUser
+        @RequestParam(value = "startableByUser", required = false) @Nullable Boolean startableByUser,
+        @RequestParam(value = "canInitializeDocument", required = false) @Nullable Boolean canInitializeDocument
     ) {
-        return ResponseEntity.ok(processDocumentAssociationService.findProcessDocumentDefinitions(documentDefinitionName, startableByUser));
+        return ResponseEntity.ok(processDocumentAssociationService.findProcessDocumentDefinitions(
+            documentDefinitionName,
+            startableByUser,
+            canInitializeDocument
+        ));
     }
 
     @GetMapping("/v1/process-document/definition/document/{document-definition-name}/version/{document-definition-version}")
@@ -116,10 +121,16 @@ public class ProcessDocumentResource {
     @GetMapping("/management/v1/process-document/definition/document/{document-definition-name}")
     public ResponseEntity<List<? extends ProcessDocumentDefinition>> findManagementProcessDocumentDefinitions(
         @PathVariable(name = "document-definition-name") String documentDefinitionName,
-        @RequestParam(value = "startableByUser", required = false) Boolean startableByUser
+        @RequestParam(value = "startableByUser", required = false) Boolean startableByUser,
+        @RequestParam(value = "canInitializeDocument", required = false) Boolean canInitializeDocument
     ) {
         return ResponseEntity.ok(AuthorizationContext.runWithoutAuthorization(() ->
-            processDocumentAssociationService.findProcessDocumentDefinitions(documentDefinitionName, startableByUser)));
+            processDocumentAssociationService.findProcessDocumentDefinitions(
+                documentDefinitionName,
+                startableByUser,
+                canInitializeDocument
+            ))
+        );
     }
 
     @GetMapping("/v1/process-document/definition/process/{process-definition-key}")

--- a/process-document/src/main/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporter.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/exporter/ProcessDocumentLinkExporter.kt
@@ -36,10 +36,8 @@ class ProcessDocumentLinkExporter(
     override fun supports() = DocumentDefinitionExportRequest::class.java
 
     override fun export(request: DocumentDefinitionExportRequest): ExportResult {
-        val startableByUser: Boolean? = null
         val exportItems = processDocumentAssociationService.findProcessDocumentDefinitions(
-            request.name,
-            startableByUser
+            request.name, null,null
         ).map { definition ->
             ProcessDocumentLinkConfigItem().apply {
                 val processDefinitionKey = definition.processDocumentDefinitionId().processDefinitionKey().toString()
@@ -53,7 +51,7 @@ class ProcessDocumentLinkExporter(
             return ExportResult()
         }
 
-        val relatedRequests = exportItems.map { it.processDefinitionKey }
+        val relatedRequests = exportItems.asSequence().map { it.processDefinitionKey }
             .distinct()
             .map { key -> requireNotNull(camundaRepositoryService.findLatestProcessDefinition(key)) }
             .map { processDefinition ->

--- a/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationServiceIntTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationServiceIntTest.java
@@ -83,33 +83,33 @@ class CamundaProcessJsonSchemaDocumentAssociationServiceIntTest extends BaseInte
     public void setup() {
         runWithoutAuthorization(() -> {
             String oldDocumentDefinitionVersion = """
-                    {
-                        "$id": "some-test.schema",
-                        "$schema": "http://json-schema.org/draft-07/schema#",
-                        "title": "some-test",
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            }
+                {
+                    "$id": "some-test.schema",
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "title": "some-test",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
                         }
                     }
-                """;
+                }
+            """;
             oldDocumentDefinition = documentDefinitionService.deploy(oldDocumentDefinitionVersion).documentDefinition();
 
             String newDocumentDefinitionVersion = """
-                    {
-                        "$id": "some-test.schema",
-                        "$schema": "http://json-schema.org/draft-07/schema#",
-                        "title": "some-test",
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "integer"
-                            }
+                {
+                    "$id": "some-test.schema",
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "title": "some-test",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "integer"
                         }
                     }
-                """;
+                }
+            """;
             newDocumentDefinition = documentDefinitionService.deploy(newDocumentDefinitionVersion).documentDefinition();
 
             return null;
@@ -120,7 +120,7 @@ class CamundaProcessJsonSchemaDocumentAssociationServiceIntTest extends BaseInte
     public void findProcessDocumentDefinition() {
         final var processDocumentDefinitions = AuthorizationContext
             .runWithoutAuthorization(() -> camundaProcessJsonSchemaDocumentAssociationService
-            .findProcessDocumentDefinitions(DOCUMENT_DEFINITION_NAME, true));
+            .findProcessDocumentDefinitions(DOCUMENT_DEFINITION_NAME, null, null));
 
         assertThat(processDocumentDefinitions.size()).isGreaterThanOrEqualTo(1);
         assertThat(processDocumentDefinitions.get(0).processDocumentDefinitionId().processDefinitionKey().toString()).isEqualTo(PROCESS_DEFINITION_KEY);

--- a/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationServiceIntTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentAssociationServiceIntTest.java
@@ -120,7 +120,7 @@ class CamundaProcessJsonSchemaDocumentAssociationServiceIntTest extends BaseInte
     public void findProcessDocumentDefinition() {
         final var processDocumentDefinitions = AuthorizationContext
             .runWithoutAuthorization(() -> camundaProcessJsonSchemaDocumentAssociationService
-            .findProcessDocumentDefinitions(DOCUMENT_DEFINITION_NAME, null, null));
+            .findProcessDocumentDefinitions(DOCUMENT_DEFINITION_NAME));
 
         assertThat(processDocumentDefinitions.size()).isGreaterThanOrEqualTo(1);
         assertThat(processDocumentDefinitions.get(0).processDocumentDefinitionId().processDefinitionKey().toString()).isEqualTo(PROCESS_DEFINITION_KEY);

--- a/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest.java
@@ -40,11 +40,11 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
 
     @Test
     void shouldDeployProcessDocumentLinkFromResourceFolder() {
-        Boolean startableByUser = null;
-        final var processDocumentDefinitions = AuthorizationContext
-            .runWithoutAuthorization(
-                () -> camundaProcessJsonSchemaDocumentAssociationService
-                    .findProcessDocumentDefinitions(DOCUMENT_DEFINITION_NAME, startableByUser));
+        final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
+            camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
+                DOCUMENT_DEFINITION_NAME, null, null
+            )
+        );
 
         assertThat(processDocumentDefinitions.size()).isGreaterThanOrEqualTo(1);
         assertThat(processDocumentDefinitions.get(0).processDocumentDefinitionId().processDefinitionKey()).hasToString(PROCESS_DEFINITION_KEY);
@@ -56,25 +56,53 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
     @Test
     public void findProcessDocumentDefinitionWithStartableByUserTrue() {
         Boolean startableByUser = true;
-        final var processDocumentDefinitions = AuthorizationContext
-            .runWithoutAuthorization(
-                () -> camundaProcessJsonSchemaDocumentAssociationService
-                    .findProcessDocumentDefinitions(DOCUMENT_DEFINITION_NAME, startableByUser));
+        final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
+            camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
+                DOCUMENT_DEFINITION_NAME, startableByUser, null
+            )
+        );
+
+        assertThat(processDocumentDefinitions.size()).isGreaterThanOrEqualTo(1);
+        assertThat(processDocumentDefinitions.get(0).processDocumentDefinitionId().processDefinitionKey().toString()).isEqualTo(PROCESS_DEFINITION_KEY);
+        assertThat(processDocumentDefinitions.get(0).processDocumentDefinitionId().documentDefinitionId().name()).isEqualTo(DOCUMENT_DEFINITION_NAME);
+        assertThat(processDocumentDefinitions.get(0).startableByUser()).isTrue();
+    }
+
+    @Test
+    public void findProcessDocumentDefinitionWithStartableByUserFalse() {
+        Boolean startableByUser = false;
+        final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
+            camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
+                DOCUMENT_DEFINITION_NAME, startableByUser, null
+            )
+        );
+
+        assertThat(processDocumentDefinitions.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void findProcessDocumentDefinitionWithCanInitializeDocumentTrue() {
+        Boolean canInitializeDocument = true;
+        final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
+            camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
+                DOCUMENT_DEFINITION_NAME, null, canInitializeDocument
+            )
+        );
 
         assertThat(processDocumentDefinitions.size()).isGreaterThanOrEqualTo(1);
         assertThat(processDocumentDefinitions.get(0).processDocumentDefinitionId().processDefinitionKey().toString()).isEqualTo(PROCESS_DEFINITION_KEY);
         assertThat(processDocumentDefinitions.get(0).processDocumentDefinitionId().documentDefinitionId().name()).isEqualTo(DOCUMENT_DEFINITION_NAME);
         assertThat(processDocumentDefinitions.get(0).canInitializeDocument()).isTrue();
-        assertThat(processDocumentDefinitions.get(0).startableByUser()).isTrue();
     }
 
     @Test
-    public void findProcessDocumentDefinitionStartableByUserFalse() {
-        Boolean startableByUser = false;
-        final var processDocumentDefinitions = AuthorizationContext
-            .runWithoutAuthorization(
-                () -> camundaProcessJsonSchemaDocumentAssociationService
-                    .findProcessDocumentDefinitions(DOCUMENT_DEFINITION_NAME, startableByUser));
+    public void findProcessDocumentDefinitionWithCanInitializeDocumentFalse() {
+        Boolean canInitializeDocument = false;
+        final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
+            camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
+                DOCUMENT_DEFINITION_NAME, null, canInitializeDocument
+            )
+        );
 
         assertThat(processDocumentDefinitions.size()).isEqualTo(0);
     }
@@ -82,7 +110,7 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
     @Test
     void shouldCopyProcessDocumentLinkToLatestVersino() {
         var result = AuthorizationContext.runWithoutAuthorization(() -> {
-            documentDefinitionService.deploy("" +
+            documentDefinitionService.deploy(
                 "{\n" +
                 "    \"$id\": \"test.schema\",\n" +
                 "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
@@ -95,7 +123,8 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
                 "            \"minimum\": 0\n" +
                 "        }\n" +
                 "    }\n" +
-                "}");
+                "}"
+            );
 
             camundaProcessJsonSchemaDocumentAssociationService.createProcessDocumentDefinition(new ProcessDocumentDefinitionRequest(
                 "deadlock-process",
@@ -103,7 +132,7 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
                 true
             ));
 
-            return documentDefinitionService.deploy("" +
+            return documentDefinitionService.deploy(
                 "{\n" +
                 "    \"$id\": \"test.schema\",\n" +
                 "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
@@ -116,12 +145,15 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
                 "            \"minimum\": 0\n" +
                 "        }\n" +
                 "    }\n" +
-                "}");
+                "}"
+            );
         });
 
         var association = AuthorizationContext.runWithoutAuthorization(() ->
             camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinition(
-                new CamundaProcessDefinitionKey("deadlock-process")).get());
+                new CamundaProcessDefinitionKey("deadlock-process")
+            ).orElseThrow()
+        );
 
         assertThat(result.errors()).isEmpty();
         assertThat(result.documentDefinition().id().version()).isEqualTo(2);

--- a/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest.java
@@ -42,7 +42,7 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
     void shouldDeployProcessDocumentLinkFromResourceFolder() {
         final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
             camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
-                DOCUMENT_DEFINITION_NAME, null, null
+                DOCUMENT_DEFINITION_NAME
             )
         );
 
@@ -58,7 +58,7 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
         Boolean startableByUser = true;
         final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
             camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
-                DOCUMENT_DEFINITION_NAME, startableByUser, null
+                DOCUMENT_DEFINITION_NAME, startableByUser
             )
         );
 
@@ -73,7 +73,7 @@ class CamundaProcessJsonSchemaDocumentDeploymentServiceJavaIntTest extends BaseI
         Boolean startableByUser = false;
         final var processDocumentDefinitions = AuthorizationContext.runWithoutAuthorization(() ->
             camundaProcessJsonSchemaDocumentAssociationService.findProcessDocumentDefinitions(
-                DOCUMENT_DEFINITION_NAME, startableByUser, null
+                DOCUMENT_DEFINITION_NAME, startableByUser
             )
         );
 

--- a/process-document/src/test/java/com/ritense/processdocument/web/rest/ProcessDocumentResourceTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/web/rest/ProcessDocumentResourceTest.java
@@ -155,7 +155,7 @@ class ProcessDocumentResourceTest extends BaseTest {
 
     @Test
     void shouldReturnOkWhenGettingProcessDocumentDefinition() throws Exception {
-        when(processDocumentAssociationService.findProcessDocumentDefinitions(eq(documentDefinitionId.name()), (Boolean) isNull()))
+        when(processDocumentAssociationService.findProcessDocumentDefinitions(eq(documentDefinitionId.name()), isNull(), isNull()))
             .thenReturn(List.of(processDocumentDefinition));
 
         mockMvc.perform(

--- a/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakTypeLinkServiceTest.kt
+++ b/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakTypeLinkServiceTest.kt
@@ -111,7 +111,7 @@ class ZaakTypeLinkServiceTest {
 
     @Test
     fun `should get empty zaakTypeLinks`() {
-        whenever(processDocumentAssociationService.findProcessDocumentDefinitions("documentDefinitionName", true))
+        whenever(processDocumentAssociationService.findProcessDocumentDefinitions("documentDefinitionName", null, null))
             .thenReturn(emptyList())
 
         val result = zaakTypeLinkService.getByProcess("processDefinitionKey")
@@ -121,7 +121,6 @@ class ZaakTypeLinkServiceTest {
 
     @Test
     fun `should get zaakTypeLinks`() {
-
         whenever(processDocumentAssociationService.findAllProcessDocumentDefinitions(CamundaProcessDefinitionKey("processDefinitionKey")))
             .thenReturn(listOf(
                 CamundaProcessJsonSchemaDocumentDefinition(

--- a/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakTypeLinkServiceTest.kt
+++ b/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/service/ZaakTypeLinkServiceTest.kt
@@ -111,9 +111,6 @@ class ZaakTypeLinkServiceTest {
 
     @Test
     fun `should get empty zaakTypeLinks`() {
-        whenever(processDocumentAssociationService.findProcessDocumentDefinitions("documentDefinitionName", null, null))
-            .thenReturn(emptyList())
-
         val result = zaakTypeLinkService.getByProcess("processDefinitionKey")
 
         assertThat(result).isEmpty()


### PR DESCRIPTION
Add query param canInitializeDocument to ProcessDocumentResource#findProcessDocumentDefinitions to be able to filter on it

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [X] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [x] Not applicable

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [X] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [X] Yes

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [X] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [X] Not applicable

Valtimo access control checks have been implemented
- [X] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [X] Not applicable