### PR TITLE
To reduce memory usage in RestClient and RestTemplate, most ClientHtt…

### DIFF
--- a/contract/src/main/kotlin/com/ritense/valtimo/contract/client/ApacheRequestFactoryCustomizer.kt
+++ b/contract/src/main/kotlin/com/ritense/valtimo/contract/client/ApacheRequestFactoryCustomizer.kt
@@ -17,6 +17,7 @@
 package com.ritense.valtimo.contract.client
 
 import org.springframework.boot.web.client.RestClientCustomizer
+import org.springframework.http.client.BufferingClientHttpRequestFactory
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.web.client.RestClient
 import java.time.Duration
@@ -33,7 +34,7 @@ class ApacheRequestFactoryCustomizer(
         valtimoHttpRestClientConfigurationProperties.connectionRequestTimeout.let {
             apacheRequestFactory.setConnectionRequestTimeout(Duration.ofSeconds(it))
         }
-        restClientBuilder.requestFactory(apacheRequestFactory)
+        restClientBuilder.requestFactory(BufferingClientHttpRequestFactory(apacheRequestFactory))
     }
 
 }


### PR DESCRIPTION
To reduce memory usage in RestClient and RestTemplate, most ClientHttpRequestFactory implementations no longer buffer request bodies before sending them to the server. As a result, for certain content types such as JSON, the contents size is no longer known, and a Content-Length header is no longer set. If you would like to buffer request bodies like before, simply wrap the ClientHttpRequestFactory you are using in a BufferingClientHttpRequestFactory.