### PR TITLE
Logging user email instead of user ID

### DIFF
--- a/contract/src/main/java/com/ritense/valtimo/contract/LoggingConstants.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/LoggingConstants.java
@@ -18,7 +18,7 @@ package com.ritense.valtimo.contract;
 
 public final class LoggingConstants {
 
-    public static final String MDC_USER_ID_KEY = "valtimoUserId";
+    public static final String MDC_USER_EMAIL_KEY = "valtimoUserId";
     public static final String MDC_CORRELATION_ID_KEY = "valtimoCorrelationId";
 
     private LoggingConstants() {

--- a/core/src/main/kotlin/com/ritense/valtimo/logging/UserLoggingFilter.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/logging/UserLoggingFilter.kt
@@ -18,6 +18,7 @@ package com.ritense.valtimo.logging
 
 import com.ritense.valtimo.contract.LoggingConstants
 import com.ritense.valtimo.contract.authentication.UserManagementService
+import com.ritense.valtimo.contract.utils.SecurityUtils
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -35,13 +36,9 @@ class UserLoggingFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        try {
-            val userIdentifier = userManagementService.getCurrentUser()?.getUserIdentifier()
-            if (userIdentifier != null) {
-                MDC.put(LoggingConstants.MDC_USER_ID_KEY, userIdentifier)
-            }
-        } catch (e: Exception) {
-            logger.warn("Failed to add logging context '${LoggingConstants.MDC_USER_ID_KEY}'", e)
+        val userEmail = SecurityUtils.getCurrentUserLogin()
+        if (userEmail != null) {
+            MDC.put(LoggingConstants.MDC_USER_EMAIL_KEY, userEmail)
         }
 
         // We also add a correlation id manually for now.
@@ -50,7 +47,7 @@ class UserLoggingFilter(
         try {
             filterChain.doFilter(request, response)
         } finally {
-            MDC.remove(LoggingConstants.MDC_USER_ID_KEY)
+            MDC.remove(LoggingConstants.MDC_USER_EMAIL_KEY)
             MDC.remove(LoggingConstants.MDC_CORRELATION_ID_KEY)
         }
     }

--- a/core/src/test/kotlin/com/ritense/valtimo/logging/UserLoggingFilterIT.kt
+++ b/core/src/test/kotlin/com/ritense/valtimo/logging/UserLoggingFilterIT.kt
@@ -29,6 +29,7 @@ import org.mockito.kotlin.whenever
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
@@ -60,10 +61,9 @@ class UserLoggingFilterIT : BaseIntegrationTest() {
     }
 
     @Test
+    @WithMockUser("henk@ritense.com")
     fun `should add user to MDC when set`() {
         val user = mock<ManageableUser>()
-        whenever(userManagementService.getCurrentUser()).thenReturn(user)
-        whenever(user.getUserIdentifier()).thenReturn("testUserId")
 
         mockMvc.perform(
             MockMvcRequestBuilders.get("/test")
@@ -83,14 +83,11 @@ class UserLoggingFilterIT : BaseIntegrationTest() {
         UUID.fromString(messageList[0].mdcPropertyMap[LoggingConstants.MDC_CORRELATION_ID_KEY])
 
         // check if the user is set in the MDC
-        assertEquals("testUserId", messageList[0].mdcPropertyMap[LoggingConstants.MDC_USER_ID_KEY])
+        assertEquals("henk@ritense.com", messageList[0].mdcPropertyMap[LoggingConstants.MDC_USER_EMAIL_KEY])
     }
 
     @Test
     fun `should not user to MDC when no user set`() {
-        val user = mock<ManageableUser>()
-        whenever(userManagementService.getCurrentUser()).thenReturn(null)
-
         mockMvc.perform(
             MockMvcRequestBuilders.get("/test")
                 .characterEncoding(StandardCharsets.UTF_8.name())
@@ -109,6 +106,6 @@ class UserLoggingFilterIT : BaseIntegrationTest() {
         UUID.fromString(messageList[0].mdcPropertyMap[LoggingConstants.MDC_CORRELATION_ID_KEY])
 
         // check if the user is set in the MDC
-        assertEquals(null, messageList[0].mdcPropertyMap[LoggingConstants.MDC_USER_ID_KEY])
+        assertEquals(null, messageList[0].mdcPropertyMap[LoggingConstants.MDC_USER_EMAIL_KEY])
     }
 }


### PR DESCRIPTION
- Significantly improves performance: Valtimo no longer needs to do a call to Keycloak for every request to Valtimo
- Logging the user email instead of the userID is better readable for people that use AWS/Grafana when consulting the logs