### PR TITLE
feature/filter-zaakinformatieobjecttypen

### DIFF
--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiPlugin.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiPlugin.kt
@@ -48,6 +48,7 @@ import com.ritense.zgw.Page
 import mu.KotlinLogging
 import org.camunda.bpm.engine.delegate.DelegateExecution
 import java.net.URI
+import java.time.LocalDate
 
 @Plugin(
     key = "catalogiapi",
@@ -149,15 +150,28 @@ class CatalogiApiPlugin(
                     page = currentPage++
                 )
             )
-            currentResults.results.map {
+
+            val filteredTypes =  currentResults.results.mapNotNull {
                 logger.trace { "Getting Informatieobjecttype ${it.informatieobjecttype}" }
+
                 val informatieobjecttype = client.getInformatieobjecttype(
                     authenticationPluginConfiguration,
                     url,
                     it.informatieobjecttype
                 )
-                results.add(informatieobjecttype)
+
+                // Filter the types based on the geldigheid dates for all non-concept types
+                if (!informatieobjecttype.concept &&
+                    informatieobjecttype.beginGeldigheid.isBefore(LocalDate.now()) &&
+                    (informatieobjecttype.eindeGeldigheid == null ||
+                        informatieobjecttype.eindeGeldigheid.isAfter(LocalDate.now()))) {
+                    informatieobjecttype
+                } else {
+                    null
+                }
             }
+
+            results.addAll(filteredTypes)
         } while (currentResults?.next != null)
 
         return results

--- a/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginTest.kt
+++ b/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/CatalogiApiPluginTest.kt
@@ -41,7 +41,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.net.URI
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 import kotlin.test.assertEquals
 
 internal class CatalogiApiPluginTest : BaseTest() {
@@ -82,10 +82,16 @@ internal class CatalogiApiPluginTest : BaseTest() {
         )
 
         val mockInformatieobjecttype1 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype1.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype1.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype1.eindeGeldigheid).thenReturn(null)
         val mockInformatieobjecttypeUrl1 = URI("https://example.com/informatieobjecttype/1")
         whenever(mockZaaktypeInformatieobjecttype1.informatieobjecttype)
             .thenReturn(mockInformatieobjecttypeUrl1)
         val mockInformatieobjecttype2 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype2.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype2.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype2.eindeGeldigheid).thenReturn(null)
         val mockInformatieobjecttypeUrl2 = URI("https://example.com/informatieobjecttype/2")
         whenever(mockZaaktypeInformatieobjecttype2.informatieobjecttype)
             .thenReturn(mockInformatieobjecttypeUrl2)
@@ -148,10 +154,16 @@ internal class CatalogiApiPluginTest : BaseTest() {
         whenever(resultPage2.results).thenReturn(listOf(mockZaaktypeInformatieobjecttype2))
 
         val mockInformatieobjecttype1 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype1.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype1.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype1.eindeGeldigheid).thenReturn(null)
         val mockInformatieobjecttypeUrl1 = URI("https://example.com/informatieobjecttype/1")
         whenever(mockZaaktypeInformatieobjecttype1.informatieobjecttype)
             .thenReturn(mockInformatieobjecttypeUrl1)
         val mockInformatieobjecttype2 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype2.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype2.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype2.eindeGeldigheid).thenReturn(null)
         val mockInformatieobjecttypeUrl2 = URI("https://example.com/informatieobjecttype/2")
         whenever(mockZaaktypeInformatieobjecttype2.informatieobjecttype)
             .thenReturn(mockInformatieobjecttypeUrl2)
@@ -177,6 +189,192 @@ internal class CatalogiApiPluginTest : BaseTest() {
         assertEquals(2, informatieobjecttypes.size)
         assertEquals(mockInformatieobjecttype1, informatieobjecttypes[0])
         assertEquals(mockInformatieobjecttype2, informatieobjecttypes[1])
+    }
+
+    @Test
+    fun `should filter informatieobjecttypes that are still in concept`() {
+        val zaakTypeUrl = URI("https://example.com/zaaktype")
+        val resultPage = mock<Page<ZaaktypeInformatieobjecttype>>()
+        whenever(
+            client.getZaaktypeInformatieobjecttypes(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                ZaaktypeInformatieobjecttypeRequest(
+                    zaaktype = zaakTypeUrl,
+                    page = 1
+                )
+            )
+        ).thenReturn(resultPage)
+
+        val mockZaaktypeInformatieobjecttype1 = mock<ZaaktypeInformatieobjecttype>()
+        val mockZaaktypeInformatieobjecttype2 = mock<ZaaktypeInformatieobjecttype>()
+        whenever(resultPage.results).thenReturn(
+            listOf(
+                mockZaaktypeInformatieobjecttype1,
+                mockZaaktypeInformatieobjecttype2
+            )
+        )
+
+        val mockInformatieobjecttype1 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype1.concept).thenReturn(true)
+        whenever(mockInformatieobjecttype1.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype1.eindeGeldigheid).thenReturn(null)
+        val mockInformatieobjecttypeUrl1 = URI("https://example.com/informatieobjecttype/1")
+        val mockInformatieobjecttype2 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype2.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype2.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype2.eindeGeldigheid).thenReturn(null)
+        val mockInformatieobjecttypeUrl2 = URI("https://example.com/informatieobjecttype/2")
+
+        whenever(mockZaaktypeInformatieobjecttype1.informatieobjecttype)
+            .thenReturn(mockInformatieobjecttypeUrl1)
+        whenever(mockZaaktypeInformatieobjecttype2.informatieobjecttype)
+            .thenReturn(mockInformatieobjecttypeUrl2)
+
+        whenever(
+            client.getInformatieobjecttype(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                mockInformatieobjecttypeUrl1
+            )
+        ).thenReturn(mockInformatieobjecttype1)
+
+        whenever(
+            client.getInformatieobjecttype(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                mockInformatieobjecttypeUrl2
+            )
+        ).thenReturn(mockInformatieobjecttype2)
+
+        val informatieobjecttypes = plugin.getInformatieobjecttypes(zaakTypeUrl)
+
+        assertEquals(1, informatieobjecttypes.size)
+        assertEquals(mockInformatieobjecttype2, informatieobjecttypes[0])
+    }
+
+    @Test
+    fun `should filter informatieobjecttypes that are not valid yet`() {
+        val zaakTypeUrl = URI("https://example.com/zaaktype")
+        val resultPage = mock<Page<ZaaktypeInformatieobjecttype>>()
+        whenever(
+            client.getZaaktypeInformatieobjecttypes(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                ZaaktypeInformatieobjecttypeRequest(
+                    zaaktype = zaakTypeUrl,
+                    page = 1
+                )
+            )
+        ).thenReturn(resultPage)
+
+        val mockZaaktypeInformatieobjecttype1 = mock<ZaaktypeInformatieobjecttype>()
+        val mockZaaktypeInformatieobjecttype2 = mock<ZaaktypeInformatieobjecttype>()
+        whenever(resultPage.results).thenReturn(
+            listOf(
+                mockZaaktypeInformatieobjecttype1,
+                mockZaaktypeInformatieobjecttype2
+            )
+        )
+
+        val mockInformatieobjecttype1 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype1.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype1.beginGeldigheid).thenReturn(LocalDate.now().plusDays(1))
+        whenever(mockInformatieobjecttype1.eindeGeldigheid).thenReturn(null)
+        val mockInformatieobjecttypeUrl1 = URI("https://example.com/informatieobjecttype/1")
+        val mockInformatieobjecttype2 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype2.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype2.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype2.eindeGeldigheid).thenReturn(null)
+        val mockInformatieobjecttypeUrl2 = URI("https://example.com/informatieobjecttype/2")
+
+        whenever(mockZaaktypeInformatieobjecttype1.informatieobjecttype)
+            .thenReturn(mockInformatieobjecttypeUrl1)
+        whenever(mockZaaktypeInformatieobjecttype2.informatieobjecttype)
+            .thenReturn(mockInformatieobjecttypeUrl2)
+
+        whenever(
+            client.getInformatieobjecttype(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                mockInformatieobjecttypeUrl1
+            )
+        ).thenReturn(mockInformatieobjecttype1)
+
+        whenever(
+            client.getInformatieobjecttype(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                mockInformatieobjecttypeUrl2
+            )
+        ).thenReturn(mockInformatieobjecttype2)
+
+        val informatieobjecttypes = plugin.getInformatieobjecttypes(zaakTypeUrl)
+
+        assertEquals(1, informatieobjecttypes.size)
+        assertEquals(mockInformatieobjecttype2, informatieobjecttypes[0])
+    }
+
+    @Test
+    fun `should filter informatieojecttypes that are no longer valid`() {
+        val zaakTypeUrl = URI("https://example.com/zaaktype")
+        val resultPage = mock<Page<ZaaktypeInformatieobjecttype>>()
+        whenever(
+            client.getZaaktypeInformatieobjecttypes(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                ZaaktypeInformatieobjecttypeRequest(
+                    zaaktype = zaakTypeUrl,
+                    page = 1
+                )
+            )
+        ).thenReturn(resultPage)
+
+        val mockZaaktypeInformatieobjecttype1 = mock<ZaaktypeInformatieobjecttype>()
+        val mockZaaktypeInformatieobjecttype2 = mock<ZaaktypeInformatieobjecttype>()
+        whenever(resultPage.results).thenReturn(
+            listOf(
+                mockZaaktypeInformatieobjecttype1,
+                mockZaaktypeInformatieobjecttype2
+            )
+        )
+
+        val mockInformatieobjecttype1 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype1.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype1.beginGeldigheid).thenReturn(LocalDate.now().minusWeeks(1))
+        whenever(mockInformatieobjecttype1.eindeGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        val mockInformatieobjecttypeUrl1 = URI("https://example.com/informatieobjecttype/1")
+        val mockInformatieobjecttype2 = mock<Informatieobjecttype>()
+        whenever(mockInformatieobjecttype2.concept).thenReturn(false)
+        whenever(mockInformatieobjecttype2.beginGeldigheid).thenReturn(LocalDate.now().minusDays(1))
+        whenever(mockInformatieobjecttype2.eindeGeldigheid).thenReturn(null)
+        val mockInformatieobjecttypeUrl2 = URI("https://example.com/informatieobjecttype/2")
+
+        whenever(mockZaaktypeInformatieobjecttype1.informatieobjecttype)
+            .thenReturn(mockInformatieobjecttypeUrl1)
+        whenever(mockZaaktypeInformatieobjecttype2.informatieobjecttype)
+            .thenReturn(mockInformatieobjecttypeUrl2)
+
+        whenever(
+            client.getInformatieobjecttype(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                mockInformatieobjecttypeUrl1
+            )
+        ).thenReturn(mockInformatieobjecttype1)
+
+        whenever(
+            client.getInformatieobjecttype(
+                plugin.authenticationPluginConfiguration,
+                plugin.url,
+                mockInformatieobjecttypeUrl2
+            )
+        ).thenReturn(mockInformatieobjecttype2)
+
+        val informatieobjecttypes = plugin.getInformatieobjecttypes(zaakTypeUrl)
+
+        assertEquals(1, informatieobjecttypes.size)
+        assertEquals(mockInformatieobjecttype2, informatieobjecttypes[0])
     }
 
     @Test
@@ -302,7 +500,6 @@ internal class CatalogiApiPluginTest : BaseTest() {
 
     @Test
     fun `should get besluit type`() {
-        val exampleUrl = URI("example.com")
         val documentId = UUID.randomUUID().toString()
         val document = mock<Document>()
         val besluittype = "Allocated"


### PR DESCRIPTION
This change has been approved by Thomas Minke.

Amsterdam made some zaakinformatieobjecttypes invalid by setting the "eindegeldigheid" to  a date in the past. But this did not have the desired effect, the types still came back.

After checking the properties of a type and consulting with Thomas Minke we decided to filter based on concept, beginGeldigheid and eindeGeldigheid

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [x] Release notes have been written for these changes. (will be done shortly)

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
> https://github.com/valtimo-platform/valtimo-documentation/pull/741

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [x] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable