### PR TITLE
Preventing the NotificatiesApiPlugin from unconditionally recreating the abonnement when one already exists.

### DIFF
--- a/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClient.kt
+++ b/zgw/notificaties-api/src/main/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClient.kt
@@ -19,14 +19,26 @@ package com.ritense.notificatiesapi.client
 import com.ritense.notificatiesapi.NotificatiesApiAuthentication
 import com.ritense.notificatiesapi.domain.Abonnement
 import com.ritense.notificatiesapi.domain.Kanaal
+import java.net.URI
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
-import java.net.URI
 
 class NotificatiesApiClient(
     private val restClientBuilder: RestClient.Builder
 ) {
+
+    fun getAbonnement(
+        authentication: NotificatiesApiAuthentication,
+        baseUrl: URI,
+        abonnmentId: String
+    ): Abonnement {
+        return buildNotificatiesRestClient(authentication, baseUrl)
+            .get()
+            .uri("abonnement/$abonnmentId")
+            .retrieve()
+            .body<Abonnement>()!!
+    }
 
     fun createAbonnement(
         authentication: NotificatiesApiAuthentication,

--- a/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClientTest.kt
+++ b/zgw/notificaties-api/src/test/kotlin/com/ritense/notificatiesapi/client/NotificatiesApiClientTest.kt
@@ -57,6 +57,53 @@ class NotificatiesApiClientTest {
     }
 
     @Test
+    fun `should get Abonnement in Notificaties API`() {
+
+        mockNotificatiesApi.enqueue(
+            mockResponse(
+                """
+                    {
+                      "url": "http://example.com/abonnement/test-abonnement",
+                      "callbackUrl": "http://example.com/callback",
+                      "auth": "Bearer token",
+                      "kanalen": [
+                        {
+                          "filters": {
+                            "url": "http://example.com",
+                            "someid": "1234"
+                          },
+                          "naam": "Test Kanaal"
+                        }
+                      ]
+                    }
+        """.trimIndent()
+            )
+        )
+
+        val result = client.getAbonnement(
+            authentication = TestAuthentication(),
+            baseUrl = mockNotificatiesApi.url("/").toUri(),
+            abonnmentId = "test-abonnement"
+        )
+        val recordedRequest = mockNotificatiesApi.takeRequest()
+
+        assertEquals("Bearer test", recordedRequest.getHeader("Authorization"))
+        assertEquals("/abonnement/test-abonnement", recordedRequest.path)
+
+        assertEquals("http://example.com/abonnement/test-abonnement", result.url)
+        assertEquals("http://example.com/callback", result.callbackUrl)
+        assertEquals("Bearer token", result.auth)
+        assertEquals("Test Kanaal", result.kanalen[0].naam)
+        assertEquals(
+            mapOf(
+                "url" to "http://example.com",
+                "someid" to "1234"
+            ), result.kanalen[0].filters
+        )
+
+    }
+
+    @Test
     fun `should create Kanaal in Notificaties API`() {
 
         mockNotificatiesApi.enqueue(


### PR DESCRIPTION
Currently, every time Valtimo boots up with a Notificaties API Plugin setup for auto-deployment, the Notificaties API Plugin will delete an abonnement and then create a new one. I've rewritten this so that it first checks if an abonnement already exists in the Notificaties API.

This is in response to complaints that too many Abonnementen are created by Valtimo/GZAC in the Notificaties API. In theory the old one should always be deleted before a new one is created, but this seemingly isn't always the case. By checking if it exists before creating a new one, we at least make it a bit more stable when multiple instances are booted up simultaneously (where multiple instances might try to remove the same Abonnement, but create separate ones in return).