### PR TITLE
Fix for Index out of Bounds exception in KeycloakUserManagementService.findByUserIdentifier()

### DIFF
--- a/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakUserManagementService.java
+++ b/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakUserManagementService.java
@@ -144,10 +144,13 @@ public class KeycloakUserManagementService implements UserManagementService {
             switch (OauthConfigHolder.getCurrentInstance().getIdentifierField()) {
                 case USERID ->
                     user = keycloakService.usersResource(keycloak).get(userIdentifier).toRepresentation();
-                case USERNAME ->
-                    user = keycloakService.usersResource(keycloak).search(userIdentifier).get(0);
+                case USERNAME -> {
+                    var users = keycloakService.usersResource(keycloak).search(userIdentifier);
+                    if (!users.isEmpty()) {
+                        user = users.get(0);
+                    }
+                }
             }
-
         }
         Boolean isUserEnabled = user != null ? user.isEnabled() : null;
         return Boolean.TRUE.equals(isUserEnabled) ? toValtimoUserByRetrievingRoles(user) : null;

--- a/keycloak-iam/src/test/java/com/valtimo/keycloak/service/KeycloakUserManagementServiceTest.java
+++ b/keycloak-iam/src/test/java/com/valtimo/keycloak/service/KeycloakUserManagementServiceTest.java
@@ -22,21 +22,30 @@ import static com.ritense.valtimo.contract.authentication.AuthoritiesConstants.U
 import static com.valtimo.keycloak.service.KeycloakUserManagementService.MAX_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ritense.valtimo.contract.authentication.ManageableUser;
 import com.ritense.valtimo.contract.authentication.model.SearchByUserGroupsCriteria;
+import com.ritense.valtimo.contract.config.ValtimoProperties;
 import jakarta.ws.rs.NotFoundException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+
+import com.ritense.valtimo.contract.OauthConfigHolder;
+import com.ritense.valtimo.contract.config.ValtimoProperties.Oauth;
 
 class KeycloakUserManagementServiceTest {
 
@@ -46,6 +55,11 @@ class KeycloakUserManagementServiceTest {
     private UserRepresentation jamesVance;
     private UserRepresentation johnDoe;
     private UserRepresentation ashaMiller;
+
+    @BeforeAll
+    static void setUp() {
+        new OauthConfigHolder(new Oauth());
+    }
 
     @BeforeEach
     public void before() {
@@ -66,6 +80,11 @@ class KeycloakUserManagementServiceTest {
             .thenReturn(Set.of());
         when(keycloakService.clientRolesResource(any()).get(any()).getRoleGroupMembers())
             .thenReturn(Set.of());
+    }
+
+    @AfterEach
+    public void after() {
+        reset(keycloakService);
     }
 
     @Test
@@ -161,6 +180,45 @@ class KeycloakUserManagementServiceTest {
 
         var userIds = users.stream().map(ManageableUser::getId).collect(Collectors.toList());
         assertThat(userIds).containsOnlyOnce(jamesVance.getId(), johnDoe.getId());
+    }
+
+    @Test
+    void findByUserIdentifierShouldReturnUserWhenSearchingOnUserId() {
+        OauthConfigHolder.getCurrentInstance().setIdentifierField(ValtimoProperties.IdentifierField.USERID);
+
+        when(keycloakService.usersResource(any()).get(eq(johnDoe.getId())).toRepresentation())
+            .thenReturn(johnDoe);
+
+        var user = userManagementService.findByUserIdentifier(johnDoe.getId());
+
+        verify(keycloakService.usersResource(any()).get(eq(johnDoe.getId()))).toRepresentation();
+        assertThat(user).isNotNull();
+    }
+
+    @Test
+    void findByUserIdentifierShouldReturnUserWhenSearchingOnUsername() {
+        OauthConfigHolder.getCurrentInstance().setIdentifierField(ValtimoProperties.IdentifierField.USERNAME);
+
+        when(keycloakService.usersResource(any()).search(eq(johnDoe.getUsername())))
+            .thenReturn(List.of(johnDoe));
+
+        var user = userManagementService.findByUserIdentifier(johnDoe.getUsername());
+
+        verify(keycloakService.usersResource(any())).search(eq(johnDoe.getUsername()));
+        assertThat(user).isNotNull();
+    }
+
+    @Test
+    void findByUserIdentifierShouldNotThrowAnExceptionWhenSearchingOnUsernameAndNoUserIsNotFound() {
+        OauthConfigHolder.getCurrentInstance().setIdentifierField(ValtimoProperties.IdentifierField.USERNAME);
+
+        when(keycloakService.usersResource(any()).search(eq(johnDoe.getUsername())))
+            .thenReturn(List.of());
+
+        var user = userManagementService.findByUserIdentifier(johnDoe.getUsername());
+
+        verify(keycloakService.usersResource(any())).search(eq(johnDoe.getUsername()));
+        assertThat(user).isNull();
     }
 
     private UserRepresentation newUser(String firstName, String lastName, List<String> roles) {


### PR DESCRIPTION
When the user-idenifier is configured as `username` when searching for a user which is not found in Keycloak, this resulted in an Index Out Of Bound exception. This has been resolved by first checking if the result of the search is not empty and only then get the first item of the search result list.

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [X] The contribution only contains changes that are not breaking.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [X] Not applicable

### Tests
Unit tests have been added that cover these changes
- [X] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [X] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [X] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [X] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [X] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [X] Not applicable