### PR TITLE
bugfix - upload in parts failed on missing variable

### DIFF
--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -120,7 +120,7 @@ class DocumentenApiPlugin(
             inhoudAsInputStream = contentAsInputStream,
             beschrijving = description,
             informatieobjecttype = informatieobjecttype,
-            storedDocumentUrl = storedDocumentUrl
+            storedDocumentKey = storedDocumentUrl
         )
     }
 
@@ -138,7 +138,7 @@ class DocumentenApiPlugin(
         val contentAsInputStream = storageService.getResourceContentAsInputStream(resourceId)
         val metadata = storageService.getResourceMetadata(resourceId)
 
-        val documentCreateResult = storeDocument(
+        storeDocument(
             execution = execution,
             metadata = metadata,
             titel = null,
@@ -149,7 +149,7 @@ class DocumentenApiPlugin(
             inhoudAsInputStream = contentAsInputStream,
             beschrijving = null,
             informatieobjecttype = null,
-            storedDocumentUrl = DOCUMENT_URL_PROCESS_VAR,
+            storedDocumentKey = DOCUMENT_URL_PROCESS_VAR,
         )
 
     }
@@ -270,7 +270,7 @@ class DocumentenApiPlugin(
         inhoudAsInputStream: InputStream,
         beschrijving: String?,
         informatieobjecttype: String?,
-        storedDocumentUrl: String,
+        storedDocumentKey: String,
     ): CreateDocumentResult {
         val vertrouwelijkheidaanduidingEnum = Vertrouwelijkheid.fromKey(
             vertrouwelijkheidaanduiding ?: getMetadataField(
@@ -309,7 +309,7 @@ class DocumentenApiPlugin(
             documentCreateResult.beginRegistratie
         )
         applicationEventPublisher.publishEvent(event)
-        execution.setVariable(storedDocumentUrl, documentCreateResult.url)
+        execution.setVariable(storedDocumentKey, documentCreateResult.url)
         val documentId = documentCreateResult.url.substringAfterLast('/')
         execution.setVariable(DOCUMENT_ID_PROCESS_VAR, documentId)
         try {
@@ -351,7 +351,7 @@ class DocumentenApiPlugin(
             inhoudAsInputStream = InputStream.nullInputStream(),
             beschrijving = null,
             informatieobjecttype = null,
-            storedDocumentUrl = ""
+            storedDocumentKey = DOCUMENT_URL_PROCESS_VAR
         )
 
         val bestandsdelenRequest = BestandsdelenRequest(


### PR DESCRIPTION

### Describe the changes
The storeDocumentsInParts itself works without a problem but when testing the rest of the process for Amsterdam we noticed a missing process variable. This bug has now been fixed

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Documentation
- [x] Release notes have been written for these changes. 
Release notes where already written for the new changes

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x]Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable