### PR TITLE
bugfix - upload in parts failed on missing variable (#1598)

### DIFF
--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -120,7 +120,7 @@ class DocumentenApiPlugin(
             inhoudAsInputStream = contentAsInputStream,
             beschrijving = description,
             informatieobjecttype = informatieobjecttype,
-            storedDocumentUrl = storedDocumentUrl
+            storedDocumentKey = storedDocumentUrl
         )
     }
 
@@ -138,7 +138,7 @@ class DocumentenApiPlugin(
         val contentAsInputStream = storageService.getResourceContentAsInputStream(resourceId)
         val metadata = storageService.getResourceMetadata(resourceId)
 
-        val documentCreateResult = storeDocument(
+        storeDocument(
             execution = execution,
             metadata = metadata,
             titel = null,
@@ -149,7 +149,7 @@ class DocumentenApiPlugin(
             inhoudAsInputStream = contentAsInputStream,
             beschrijving = null,
             informatieobjecttype = null,
-            storedDocumentUrl = DOCUMENT_URL_PROCESS_VAR,
+            storedDocumentKey = DOCUMENT_URL_PROCESS_VAR,
         )
 
     }
@@ -270,7 +270,7 @@ class DocumentenApiPlugin(
         inhoudAsInputStream: InputStream,
         beschrijving: String?,
         informatieobjecttype: String?,
-        storedDocumentUrl: String,
+        storedDocumentKey: String,
     ): CreateDocumentResult {
         val vertrouwelijkheidaanduidingEnum = Vertrouwelijkheid.fromKey(
             vertrouwelijkheidaanduiding ?: getMetadataField(
@@ -309,7 +309,7 @@ class DocumentenApiPlugin(
             documentCreateResult.beginRegistratie
         )
         applicationEventPublisher.publishEvent(event)
-        execution.setVariable(storedDocumentUrl, documentCreateResult.url)
+        execution.setVariable(storedDocumentKey, documentCreateResult.url)
         val documentId = documentCreateResult.url.substringAfterLast('/')
         execution.setVariable(DOCUMENT_ID_PROCESS_VAR, documentId)
         try {
@@ -351,7 +351,7 @@ class DocumentenApiPlugin(
             inhoudAsInputStream = InputStream.nullInputStream(),
             beschrijving = null,
             informatieobjecttype = null,
-            storedDocumentUrl = ""
+            storedDocumentKey = DOCUMENT_URL_PROCESS_VAR
         )
 
         val bestandsdelenRequest = BestandsdelenRequest(


### PR DESCRIPTION
Changed the name of storedDocumentUrl to storedDocumentKey because it was not an actual URL but the key for a process variable.

The storeDocumentInParts method now also sets this key

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [ ] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [ ] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [ ] Not applicable