### PR TITLE
Added a method to patch the metadata for the temp file upload.

### DIFF
--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
@@ -77,9 +77,26 @@ class TemporaryResourceStorageService(
             MetadataType.FILE_SIZE.key to dataFile.fileSize().toString()
         )
         val metaDataFile = Files.createTempFile(tempDir, "${random.nextLong().toULong()}-", ".json")
-        metaDataFile.toFile().writeText(objectMapper.writeValueAsString(metaDataContent))
+        writeMetaDataFile(metaDataFile, metaDataContent)
 
         return metaDataFile.nameWithoutExtension
+    }
+
+    /**
+     * This method can be used to enrich the metadata before it is handled.
+     */
+    fun patchResourceMetaData(id: String, metaData: Map<String, Any>) {
+        require(!metaData.containsKey(MetadataType.FILE_PATH.key)) { "${MetadataType.FILE_PATH.key} cannot be patched!" }
+
+        val metaDataFile = getMetaDataFileFromResourceId(id)
+        require(!metaDataFile.notExists()) { "No resource found with id '$id'" }
+
+        val originalMetaData = getMetadataFromFile(metaDataFile, false)
+        writeMetaDataFile(metaDataFile, originalMetaData + metaData)
+    }
+
+    private fun writeMetaDataFile(file: Path, metaDataContent: Map<String, Any>) {
+        file.toFile().writeText(objectMapper.writeValueAsString(metaDataContent))
     }
 
     fun deleteResource(id: String): Boolean {
@@ -108,16 +125,21 @@ class TemporaryResourceStorageService(
     internal fun getResourceMetadata(id: String, filterPath: Boolean): Map<String, Any> {
         val metaDataFile = getMetaDataFileFromResourceId(id)
         require(!metaDataFile.notExists()) { "No resource found with id '$id'" }
-        val typeRef = object : TypeReference<Map<String, Any>>() {}
-        return objectMapper.readValue(metaDataFile.readText(), typeRef)
-            .filter {
-                !filterPath || it.key != MetadataType.FILE_PATH.key
-            }
+
+        return getMetadataFromFile(metaDataFile, filterPath)
     }
 
     internal fun getMetaDataFileFromResourceId(resourceId: String): Path {
         val safeFileName = Path("$resourceId.json").fileName.toString()
         return Path.of(tempDir.pathString, safeFileName)
+    }
+
+    internal fun getMetadataFromFile(metaDataFile: Path, filterPath: Boolean): Map<String, Any> {
+        val typeRef = object : TypeReference<Map<String, Any>>() {}
+        return objectMapper.readValue(metaDataFile.readText(), typeRef)
+            .filter {
+                !filterPath || it.key != MetadataType.FILE_PATH.key
+            }
     }
 
     fun getMetadataValue(resourceStorageFieldId: String, metadataKey: String): String {

--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
@@ -85,14 +85,19 @@ class TemporaryResourceStorageService(
     /**
      * This method can be used to enrich the metadata before it is handled.
      */
-    fun patchResourceMetaData(id: String, metaData: Map<String, Any>) {
+    fun patchResourceMetaData(id: String, metaData: Map<String, Any?>) {
         require(!metaData.containsKey(MetadataType.FILE_PATH.key)) { "${MetadataType.FILE_PATH.key} cannot be patched!" }
 
         val metaDataFile = getMetaDataFileFromResourceId(id)
         require(!metaDataFile.notExists()) { "No resource found with id '$id'" }
 
         val originalMetaData = getMetadataFromFile(metaDataFile, false)
-        writeMetaDataFile(metaDataFile, originalMetaData + metaData)
+        // Since the metadata does not allow null values, this code removes the key when the value is null
+        val newMetaData = (originalMetaData + metaData)
+            .mapNotNull { (key, value) -> if(value != null) Pair(key, value) else null }
+            .toMap()
+
+        writeMetaDataFile(metaDataFile, newMetaData)
     }
 
     private fun writeMetaDataFile(file: Path, metaDataContent: Map<String, Any>) {

--- a/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/TemporaryResourceStorageServiceIntegrationTest.kt
+++ b/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/TemporaryResourceStorageServiceIntegrationTest.kt
@@ -109,18 +109,21 @@ class TemporaryResourceStorageServiceIntegrationTest : BaseIntegrationTest() {
     fun `should patch metadata`() {
         val fileData = "My file data"
         val fileName = "test.txt"
-        val customMetaDataKey = "testKey"
+        val changeKey = "changeKey"
+        val removeKey = "removeKey"
 
         val resourceId = temporaryResourceStorageService.store(
             fileData.byteInputStream(),
             mapOf(
                 MetadataType.FILE_NAME.key to fileName,
-                customMetaDataKey to "x"
+                changeKey to "x",
+                removeKey to "exists"
                 )
         )
 
         temporaryResourceStorageService.patchResourceMetaData(resourceId, mapOf(
-            customMetaDataKey to "y"
+            changeKey to "y",
+            removeKey to null
         ))
 
         val patchedMetaData = temporaryResourceStorageService.getResourceMetadata(resourceId, false)
@@ -128,7 +131,8 @@ class TemporaryResourceStorageServiceIntegrationTest : BaseIntegrationTest() {
         assertThat(patchedMetaData[MetadataType.FILE_NAME.key]).isEqualTo(fileName)
         assertThat(patchedMetaData[MetadataType.FILE_PATH.key]).asString().hasSizeGreaterThan(0)
         assertThat(patchedMetaData[MetadataType.FILE_SIZE.key]).isEqualTo(fileData.length.toString())
-        assertThat(patchedMetaData[customMetaDataKey]).isEqualTo("y")
+        assertThat(patchedMetaData[changeKey]).isEqualTo("y")
+        assertThat(patchedMetaData).doesNotContainKey(removeKey)
     }
 
     @Test


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Added a method which can be used to add or change the metadata for a temporary file before it is processed in the upload process. A custom task has to be added to the upload process to make this work.

### Breaking changes
- [x] The contribution only contains changes that are not breaking.

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable