### PR TITLE
Added delegate method to be able to remove the temp resource from a process

### DIFF
--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/ResourceStorageDelegate.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/ResourceStorageDelegate.kt
@@ -23,4 +23,8 @@ class ResourceStorageDelegate(
     fun getMetadata(resourceStorageFileId: String, metadataKey: String): String {
         return service.getMetadataValue(resourceStorageFileId, metadataKey)
     }
+
+    fun deleteResource(resourceStorageFileId: String): Boolean {
+        return service.deleteResource(resourceStorageFileId)
+    }
 }

--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
@@ -58,6 +58,10 @@ class TemporaryResourceStorageService(
         TEMP_DIR
     }
 
+    init {
+        logger.info { "Using the following path for temporary file resources: '$tempDir'" }
+    }
+
     fun store(inputStream: InputStream, metadata: Map<String, Any> = emptyMap()): String {
         val dataFile = BufferedInputStream(inputStream).use { bis ->
             if (uploadProperties.acceptedMimeTypes.isNotEmpty()) {

--- a/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/ResourceStorageDelegateTest.kt
+++ b/resource/temporary-resource-storage/src/test/kotlin/com/ritense/resource/service/ResourceStorageDelegateTest.kt
@@ -20,13 +20,14 @@ import com.ritense.temporaryresource.domain.getEnumFromKey
 import com.ritense.temporaryresource.repository.ResourceStorageMetadataRepository
 import jakarta.persistence.EntityNotFoundException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
@@ -50,7 +51,7 @@ class ResourceStorageDelegateTest {
         val expectedMetadataValue = "https://example.com/download"
 
         // Mocking getEnumFromKey to return a valid enum for the test case
-        `when`(service.getMetadataValue(fileId, metadataKey)).thenReturn(expectedMetadataValue)
+        whenever(service.getMetadataValue(fileId, metadataKey)).thenReturn(expectedMetadataValue)
 
         // Calling the method under test
         val actualMetadataValue = delegate.getMetadata(fileId, metadataKey)
@@ -80,7 +81,7 @@ class ResourceStorageDelegateTest {
         val expectedException = EntityNotFoundException("Entity not found")
 
         // Mocking service to throw EntityNotFoundException when getMetadataValue is called
-        `when`(service.getMetadataValue(fileId, metadataKey)).thenAnswer {
+        whenever(service.getMetadataValue(fileId, metadataKey)).thenAnswer {
             throw expectedException
         }
 
@@ -91,6 +92,28 @@ class ResourceStorageDelegateTest {
 
         // This asserts that the exception message is as expected
         assertEquals(expectedException.message, exception.message)
+    }
+
+    @Test
+    fun `should delete resource file`() {
+        val fileId = "123456789-123456789"
+
+        whenever(service.deleteResource(fileId)).thenReturn(true)
+
+        val deleted = delegate.deleteResource(fileId)
+
+        assertTrue(deleted)
+    }
+
+    @Test
+    fun `should not throw an exception when file is not deleted`() {
+        val fileId = "does-not-exist"
+
+        whenever(service.deleteResource(fileId)).thenReturn(false)
+
+        val deleted = delegate.deleteResource(fileId)
+
+        assertFalse(deleted)
     }
 
 }


### PR DESCRIPTION


<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Added delegate method to be able to remove the temp resource at the end of the upload process instead of waiting for the scheduled removal.

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable