### PR TITLE
bugfix/prevent-log-spam

### DIFF
--- a/logging/src/main/resources/config/logging/logback/valtimo-database-appender.xml
+++ b/logging/src/main/resources/config/logging/logback/valtimo-database-appender.xml
@@ -33,6 +33,7 @@
                 <username>${spring.datasource.username}</username>
                 <user>${spring.datasource.username}</user>
                 <password>${spring.datasource.password}</password>
+                <autoCommit>false</autoCommit>
             </dataSource>
         </connectionSource>
         <insertHeaders>true</insertHeaders>


### PR DESCRIPTION
When not setting the `org.postgresql.jdbc.PgConnection` log level for every logged line the auto commit is set to false and reset to true when closing the DB connection.  This generated a lot of extra actions which were then logged. 