### PR TITLE
Story/try catch on task list

### DIFF
--- a/authorization/src/test/kotlin/com/ritense/authorization/web/rest/PermissionResourceIT.kt
+++ b/authorization/src/test/kotlin/com/ritense/authorization/web/rest/PermissionResourceIT.kt
@@ -343,7 +343,7 @@ class PermissionResourceIT: BaseIntegrationTest() {
     }
 
     @Test
-    fun `requesting permission for not existing resource returns 403 forbidden`() {
+    fun `requesting permission for not existing resource returns available false`() {
 
         val permissionRequests = listOf(
             PermissionAvailableRequest(
@@ -363,11 +363,14 @@ class PermissionResourceIT: BaseIntegrationTest() {
                 .content(objectMapper.writeValueAsString(permissionRequests))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect { jsonPath("$[0].resource").value("test") }
+            .andExpect { jsonPath("$[0].action").value("update") }
+            .andExpect { jsonPath("$[0].available").value(false) }
     }
 
     @Test
-    fun `requesting permission for resource with no specification returns 403 forbidden`() {
+    fun `requesting permission for resource with no specification returns available false`() {
 
         val permissionRequests = listOf(
             PermissionAvailableRequest(
@@ -387,11 +390,14 @@ class PermissionResourceIT: BaseIntegrationTest() {
                 .content(objectMapper.writeValueAsString(permissionRequests))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect { jsonPath("$[0].resource").value("java.lang.String") }
+            .andExpect { jsonPath("$[0].action").value("view") }
+            .andExpect { jsonPath("$[0].available").value(false) }
     }
 
     @Test
-    fun `requesting permission for resource with context with no specification returns 403 forbidden`() {
+    fun `requesting permission for resource with context with no specification returns available false`() {
 
         val permissionRequests = listOf(
             PermissionAvailableRequest(
@@ -411,6 +417,9 @@ class PermissionResourceIT: BaseIntegrationTest() {
                 .content(objectMapper.writeValueAsString(permissionRequests))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect { jsonPath("$[0].resource").value("java.lang.String") }
+            .andExpect { jsonPath("$[0].action").value("view") }
+            .andExpect { jsonPath("$[0].available").value(false) }
     }
 }


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
**Relevant comments:**
In Utrecht CommUtr, we have tasks that reference to users or documents that no longer exists.
This throws errors when opening the task screen, resulting in the entire task screen being unable to load.

This change doesn't throw the error all the way to the endpoints, but rather logs an error and skips when it fails to find a document/user, so that any tasks that can be built are still returned

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [X] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [X] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [X] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [X] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [X] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [X] Not applicable