### PR TITLE
bugfix - Mimetypes + parameters fail the acceptedMimeTypes check

### DIFF
--- a/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
+++ b/resource/temporary-resource-storage/src/main/kotlin/com/ritense/resource/service/TemporaryResourceStorageService.kt
@@ -62,7 +62,8 @@ class TemporaryResourceStorageService(
         val dataFile = BufferedInputStream(inputStream).use { bis ->
             if (uploadProperties.acceptedMimeTypes.isNotEmpty()) {
                 //Tika marks the stream, reads the first few bytes and resets it when done.
-                val mediaType = Tika().detect(bis)
+                // The mediatype will only contain the mimetype, any extra parameters are stripped off
+                val mediaType = Tika().detect(bis).split(";")[0].trim()
                 if (!uploadProperties.acceptedMimeTypes.contains(mediaType)) {
                     throw MimeTypeDeniedException("$mediaType is not whitelisted for uploads.")
                 }
@@ -94,7 +95,7 @@ class TemporaryResourceStorageService(
         val originalMetaData = getMetadataFromFile(metaDataFile, false)
         // Since the metadata does not allow null values, this code removes the key when the value is null
         val newMetaData = (originalMetaData + metaData)
-            .mapNotNull { (key, value) -> if(value != null) Pair(key, value) else null }
+            .mapNotNull { (key, value) -> if (value != null) Pair(key, value) else null }
             .toMap()
 
         writeMetaDataFile(metaDataFile, newMetaData)


### PR DESCRIPTION
mimetypes can include extra parameters separated by ';' like:
- image/png; format=ASCII
- plain/text; charset=utf-8
- etc

When a parameter is included the accepted mimecheck fails. This bugfix removes any included parameter before checking the mimetype

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable