### PR TITLE
feature/dont-update-task-assignee-on-http-error

### DIFF
--- a/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/config/ValtimoProperties.java
@@ -18,6 +18,7 @@ package com.ritense.valtimo.contract.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.ritense.valtimo.contract.OauthConfigHolder;
+import javax.annotation.Nonnull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
@@ -221,6 +222,7 @@ public class ValtimoProperties {
             this.fieldName = fieldName;
         }
 
+        @Nonnull
         @JsonCreator
         public static IdentifierField fromString(String text) {
             for (IdentifierField identifierField : IdentifierField.values()) {


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Don't migrate/update the task assignee when a http/keycloak error is thrown.

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [ ] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [ ] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [ ] Not applicable