### PR TITLE
Bugfix/gzac issue 84

### DIFF
--- a/app/gzac/build.gradle
+++ b/app/gzac/build.gradle
@@ -41,4 +41,23 @@ bootRun {
     }
 }
 
+tasks.register("bootRunWithDocker", tasks.named("bootRun").get().class) {
+    group = "application"
+    description = "Starts docker containers and then runs this project as a Spring Boot application"
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = "com.ritense.gzac.GzacApplication"
+
+    dependsOn("composeUpGzac")
+    doFirst {
+        File f = file(".env.properties")
+        if (f.isFile()) {
+            def props = new Properties()
+            f.withInputStream { props.load(it) }
+            props.each { key, value ->
+                environment key.toString(), value.toString()
+            }
+        }
+    }
+}
+
 apply from: "$rootProject.projectDir/gradle/dockerComposeGzac.gradle"

--- a/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/result/FormFlowDefinitionDto.kt
+++ b/form-flow-valtimo/src/main/kotlin/com/ritense/valtimo/formflow/web/rest/result/FormFlowDefinitionDto.kt
@@ -39,7 +39,7 @@ data class FormFlowDefinitionDto(
                 key = formFlowDefinition.id.key,
                 version = formFlowDefinition.id.version,
                 startStep = formFlowDefinition.startStep,
-                steps = formFlowDefinition.steps.map { FormFlowStep.fromEntity(it) },
+                steps = formFlowDefinition.getOrderedSteps().map { FormFlowStep.fromEntity(it) },
                 readOnly = readOnly
             )
     }

--- a/form-flow/src/main/kotlin/com/ritense/formflow/domain/definition/FormFlowDefinition.kt
+++ b/form-flow/src/main/kotlin/com/ritense/formflow/domain/definition/FormFlowDefinition.kt
@@ -42,13 +42,36 @@ data class FormFlowDefinition(
         steps.forEach { step -> step.id.formFlowDefinition = this }
     }
 
-    fun createInstance(additionalProperties: Map<String, Any>) : FormFlowInstance {
-        return FormFlowInstance(formFlowDefinition = this,
-            additionalProperties = additionalProperties.toMutableMap())
+    fun createInstance(additionalProperties: Map<String, Any>): FormFlowInstance {
+        return FormFlowInstance(
+            formFlowDefinition = this,
+            additionalProperties = additionalProperties.toMutableMap()
+        )
     }
 
     fun getStepByKey(key: String): FormFlowStep {
         return steps.first { it.id.key == key }
+    }
+
+    fun getOrderedSteps(): List<FormFlowStep> {
+        val orderedSteps = getOrderedSteps(startStep)
+        if (orderedSteps.size != steps.size) {
+            orderedSteps += steps
+                .filter { orderedSteps.none { step -> it.id == step.id } }
+                .sortedBy { it.id.key }
+        }
+        return orderedSteps
+    }
+
+    private fun getOrderedSteps(
+        stepKey: String,
+        result: MutableList<FormFlowStep> = mutableListOf()
+    ): MutableList<FormFlowStep> {
+        if (result.any { stepKey == it.id.key }) return result
+        val step = steps.firstOrNull { it.id.key == stepKey } ?: return result
+        result += step
+        step.nextSteps.forEach { getOrderedSteps(it.step, result) }
+        return result
     }
 
 }

--- a/form-flow/src/main/kotlin/com/ritense/formflow/domain/definition/configuration/FormFlowStep.kt
+++ b/form-flow/src/main/kotlin/com/ritense/formflow/domain/definition/configuration/FormFlowStep.kt
@@ -46,6 +46,7 @@ data class FormFlowStep(
         if (key != other.id.key) return false
         if (title != other.title) return false
 
+        val nextSteps = getAllNextSteps()
         if (nextSteps.size != other.nextSteps.size) return false
         if (nextSteps.any { nextStep ->
             other.nextSteps.none { otherNextStep ->
@@ -62,12 +63,7 @@ data class FormFlowStep(
     }
 
     fun toDefinition(): FormFlowStepEntity {
-        val nextSteps =
-            if (this.nextStep != null)
-                listOf(FormFlowNextStep(step = this.nextStep).toDefinition())
-            else
-                this.nextSteps.map(FormFlowNextStep::toDefinition)
-
+        val nextSteps = getAllNextSteps().map(FormFlowNextStep::toDefinition)
 
         return FormFlowStepEntity(
             FormFlowStepId.create(key),
@@ -78,6 +74,13 @@ data class FormFlowStep(
             onComplete,
             type
         )
+    }
+
+    private fun getAllNextSteps(): List<FormFlowNextStep> {
+        return if (this.nextStep != null)
+            listOf(FormFlowNextStep(step = this.nextStep))
+        else
+            this.nextSteps
     }
 
     companion object {

--- a/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowInstance.kt
+++ b/form-flow/src/main/kotlin/com/ritense/formflow/domain/instance/FormFlowInstance.kt
@@ -83,7 +83,11 @@ class FormFlowInstance(
 
             formFlowStepInstance.complete(submissionData.toString())
 
-            navigateToNextStep()
+            val nextStep = navigateToNextStep()
+            check(nextStep != null || formFlowStepInstance.definition.onComplete.isNotEmpty()) {
+                "Form flow end reached but no action was taken because the 'onComplete' is empty. For form flow step: '${formFlowStepInstance.definition.id}'"
+            }
+            nextStep
         }
     }
 

--- a/form-flow/src/main/kotlin/com/ritense/formflow/service/FormFlowService.kt
+++ b/form-flow/src/main/kotlin/com/ritense/formflow/service/FormFlowService.kt
@@ -139,8 +139,10 @@ class FormFlowService(
     private fun getFutureSteps(step: FormFlowStep, result: MutableList<FormFlowStep> = mutableListOf()): List<FormFlowStep> {
         return withLoggingContext(FormFlowStep::class.java.canonicalName to step.id.toString()) {
             step.nextSteps.forEach { nextStep ->
-                val futureStep = step.id.formFlowDefinition!!.steps.first { it.id.key == nextStep.step }
-                if (!result.contains(futureStep)) {
+                val futureStep = step.id.formFlowDefinition?.steps?.firstOrNull { it.id.key == nextStep.step }
+                if (futureStep == null) {
+                    return result
+                } else if (!result.contains(futureStep)) {
                     result.add(futureStep)
                     return getFutureSteps(futureStep, result)
                 }

--- a/form-flow/src/test/kotlin/com/ritense/formflow/domain/FormFlowInstanceTest.kt
+++ b/form-flow/src/test/kotlin/com/ritense/formflow/domain/FormFlowInstanceTest.kt
@@ -88,7 +88,8 @@ internal class FormFlowInstanceTest : BaseTest() {
                 steps = mutableSetOf(
                     FormFlowStep(
                         id = FormFlowStepId.create("test"),
-                        type = FormFlowStepType("form", FormStepTypeProperties("my-form-definition"))
+                        type = FormFlowStepType("form", FormStepTypeProperties("my-form-definition")),
+                        onComplete = listOf("\${null}")
                     )
                 )
             )
@@ -99,6 +100,31 @@ internal class FormFlowInstanceTest : BaseTest() {
 
         assertThat(instance.getHistory()[0].submissionData, equalTo("{\"data\":\"data\"}"))
         assertNull(result)
+    }
+
+    @Test
+    fun `complete should throw error when no action exist on last step`() {
+        val instance = FormFlowInstance(
+            formFlowDefinition = FormFlowDefinition(
+                id = FormFlowDefinitionId("test", 1L),
+                startStep = "lastStep",
+                steps = mutableSetOf(
+                    FormFlowStep(
+                        id = FormFlowStepId.create("lastStep"),
+                        type = FormFlowStepType("form", FormStepTypeProperties("my-form-definition"))
+                    )
+                )
+            )
+        )
+
+        val error = assertThrows<IllegalStateException> {
+            instance.complete(instance.currentFormFlowStepInstanceId!!, JSONObject("{\"data\":\"data\"}"))
+        }
+
+        assertEquals(
+            "Form flow end reached but no action was taken because the 'onComplete' is empty. For form flow step: 'test:1:lastStep'",
+            error.message
+        )
     }
 
     @Test

--- a/form-flow/src/test/resources/config/form-flow/inkomens_loket.json
+++ b/form-flow/src/test/resources/config/form-flow/inkomens_loket.json
@@ -115,6 +115,9 @@
         },
         {
             "key": "end",
+            "onComplete": [
+                "${null}"
+            ],
             "type": {
                 "name": "form",
                 "properties": {

--- a/gradle/dockerComposeGzac.gradle
+++ b/gradle/dockerComposeGzac.gradle
@@ -52,9 +52,3 @@ dockerCompose {
     removeContainers = false
     removeVolumes = false
 }
-
-tasks.register("bootRunWithDocker") {
-    group = "application"
-    dependsOn("composeUpGzac")
-    dependsOn("bootRun")
-}


### PR DESCRIPTION
Contains:

- [Bugfix: Will no longer deploy a form flow step multiple times](https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/84)
- Bugfix: Will now throw an error when the 'onComplete' is missing in the last form-flow-step
- Feature: Form flow steps are displayed in correct order in the form flow editor
- Fix: bootRunWithDocker gradle task