### PR TITLE
Bugfix for multiple besluittypes with same omschrijving attached with the same zaaktype.

### DIFF
--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiPlugin.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiPlugin.kt
@@ -367,8 +367,9 @@ class CatalogiApiPlugin(
         withLoggingContext(CATALOGI_API.ZAAKTYPE to zaakTypeUrl.toString()) {
             logger.debug { "Getting Besluittype by omschrijving: $omschrijving for zaaktype $zaakTypeUrl" }
             return getBesluittypen(zaakTypeUrl)
+                .filter { it.eindeGeldigheid == null || it.eindeGeldigheid.isAfter(LocalDate.now()) }
                 .singleOrNull { it.omschrijving.equals(omschrijving, ignoreCase = true) }
-                ?: throw StatustypeNotFoundException("With 'omschrijving': '$omschrijving'")
+                ?: throw IllegalStateException("Besluittype with 'omschrijving': '$omschrijving' is not found")
         }
     }
 


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable