### PR TITLE
Fix NullPointerException when process was started without a businessKey.

### DIFF
--- a/core/src/main/java/com/ritense/valtimo/camunda/processaudit/ProcessInstanceEvent.java
+++ b/core/src/main/java/com/ritense/valtimo/camunda/processaudit/ProcessInstanceEvent.java
@@ -21,6 +21,7 @@ import com.ritense.valtimo.contract.audit.AuditMetaData;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
+import org.apache.ibatis.jdbc.Null;
 
 public abstract class ProcessInstanceEvent extends AuditMetaData implements AuditEvent {
 
@@ -59,7 +60,7 @@ public abstract class ProcessInstanceEvent extends AuditMetaData implements Audi
     public UUID getDocumentId() {
         try {
             return UUID.fromString(businessKey);
-        } catch (IllegalArgumentException iae) {
+        } catch (NullPointerException | IllegalArgumentException ex) {
             return null;
         }
     }

--- a/core/src/test/java/com/ritense/valtimo/camunda/processaudit/ProcessInstanceEventTest.java
+++ b/core/src/test/java/com/ritense/valtimo/camunda/processaudit/ProcessInstanceEventTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.valtimo.camunda.processaudit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ProcessInstanceEventTest {
+
+    @Test
+    public void shouldReturnNullDocumentIdOnNullBusinessKey() {
+        ProcessInstanceEvent event = new ProcessInstanceEvent(
+                UUID.randomUUID(),
+                "origin",
+                LocalDateTime.now(),
+                "user",
+                "definitionId",
+                UUID.randomUUID().toString(),
+                null
+        ) {
+        };
+
+        assertThat(event.getDocumentId()).isNull();
+    }
+
+    @Test
+    public void shouldReturnNullDocumentIdOnInvalidBusinessKey() {
+        ProcessInstanceEvent event = new ProcessInstanceEvent(
+                UUID.randomUUID(),
+                "origin",
+                LocalDateTime.now(),
+                "user",
+                "definitionId",
+                UUID.randomUUID().toString(),
+                "invalid"
+        ) {
+        };
+
+        assertThat(event.getDocumentId()).isNull();
+    }
+
+    @Test
+    public void shouldReturnDocumentIdOnValidBusinessKey() {
+        UUID businessKey = UUID.randomUUID();
+        ProcessInstanceEvent event = new ProcessInstanceEvent(
+                UUID.randomUUID(),
+                "origin",
+                LocalDateTime.now(),
+                "user",
+                "definitionId",
+                UUID.randomUUID().toString(),
+                businessKey.toString()
+        ) {
+        };
+
+        assertThat(event.getDocumentId()).isEqualTo(businessKey);
+    }
+
+}


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
When starting a process without a businessKey (`null`), the audit event handler would throw a `NullPointerException`.

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [ ] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable