### PR TITLE
Fix process-link type update for autodeployment

### DIFF
--- a/process-link/src/test/kotlin/com/ritense/processlink/TestApplication.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/TestApplication.kt
@@ -17,7 +17,8 @@
 package com.ritense.processlink
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ritense.processlink.domain.CustomProcessLinkMapper
+import com.ritense.processlink.domain.AnotherTestProcessLinkMapper
+import com.ritense.processlink.domain.TestProcessLinkMapper
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.boot.test.context.TestConfiguration
@@ -34,9 +35,10 @@ class TestApplication {
     class TestConfig {
 
         @Bean
-        fun customProcessLinkMapper(objectMapper: ObjectMapper) : CustomProcessLinkMapper {
-            return CustomProcessLinkMapper(objectMapper)
-        }
+        fun testProcessLinkMapper(objectMapper: ObjectMapper) = TestProcessLinkMapper(objectMapper)
+
+        @Bean
+        fun anotherTestProcessLinkMapper(objectMapper: ObjectMapper) = AnotherTestProcessLinkMapper(objectMapper)
 
     }
 }

--- a/process-link/src/test/kotlin/com/ritense/processlink/autodeployment/ProcessLinkDeploymentApplicationReadyEventListenerIntTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/autodeployment/ProcessLinkDeploymentApplicationReadyEventListenerIntTest.kt
@@ -18,7 +18,7 @@ package com.ritense.processlink.autodeployment
 
 import com.ritense.authorization.AuthorizationContext
 import com.ritense.processlink.BaseIntegrationTest
-import com.ritense.processlink.domain.CustomProcessLink
+import com.ritense.processlink.domain.TestProcessLink
 import com.ritense.processlink.repository.ProcessLinkRepository
 import com.ritense.valtimo.camunda.domain.CamundaProcessDefinition
 import com.ritense.valtimo.camunda.service.CamundaRepositoryService
@@ -47,8 +47,8 @@ class ProcessLinkDeploymentApplicationReadyEventListenerIntTest @Autowired const
 
         assertThat(processLinks, hasSize(1))
         val processLink = processLinks.first()
-        assertThat(processLink, Matchers.isA(CustomProcessLink::class.java))
-        processLink as CustomProcessLink
+        assertThat(processLink, Matchers.isA(TestProcessLink::class.java))
+        processLink as TestProcessLink
         assertThat(processLink.someValue, Matchers.equalTo("changed"))
     }
 

--- a/process-link/src/test/kotlin/com/ritense/processlink/configuration/TestProcessLinkLiquibaseAutoConfiguration.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/configuration/TestProcessLinkLiquibaseAutoConfiguration.kt
@@ -17,13 +17,13 @@
 package com.ritense.processlink.configuration
 
 import com.ritense.valtimo.contract.config.LiquibaseMasterChangeLogLocation
-import javax.sql.DataSource
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
+import javax.sql.DataSource
 
 @AutoConfiguration
 @ConditionalOnClass(DataSource::class)

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLink.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLink.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,29 +16,29 @@
 
 package com.ritense.processlink.domain
 
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
 import jakarta.persistence.Column
 import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
 import java.util.UUID
 
 @Entity
-@DiscriminatorValue(PROCESS_LINK_TYPE_TEST)
-class CustomProcessLink(
+@DiscriminatorValue(PROCESS_LINK_TYPE)
+class AnotherTestProcessLink(
     id: UUID,
     processDefinitionId: String,
     activityId: String,
     activityType: ActivityTypeWithEventName,
 
-    @Column(name = "some_value")
-    val someValue: String = "test"
+    @Column(name = "another_value")
+    val anotherValue: String = "another-test"
 
 ) : ProcessLink(
     id,
     processDefinitionId,
     activityId,
     activityType,
-    PROCESS_LINK_TYPE_TEST,
+    PROCESS_LINK_TYPE,
 ) {
 
     override fun copy(
@@ -55,13 +55,13 @@ class CustomProcessLink(
         processDefinitionId: String = this.processDefinitionId,
         activityId: String = this.activityId,
         activityType: ActivityTypeWithEventName = this.activityType,
-        someValue: String = this.someValue
-    ) = CustomProcessLink(
+        anotherValue: String = this.anotherValue
+    ) = AnotherTestProcessLink(
         id = id,
         processDefinitionId = processDefinitionId,
         activityId = activityId,
         activityType = activityType,
-        someValue = someValue
+        anotherValue = anotherValue
     )
 
     override fun equals(other: Any?): Boolean {
@@ -69,18 +69,18 @@ class CustomProcessLink(
         if (javaClass != other?.javaClass) return false
         if (!super.equals(other)) return false
 
-        other as CustomProcessLink
+        other as AnotherTestProcessLink
 
-        return someValue == other.someValue
+        return anotherValue == other.anotherValue
     }
 
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + someValue.hashCode()
+        result = 31 * result + anotherValue.hashCode()
         return result
     }
 
     companion object {
-        const val PROCESS_LINK_TYPE_TEST = "test"
+        const val PROCESS_LINK_TYPE = "another-test"
     }
 }

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkCreateRequestDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkCreateRequestDto.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
+import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
+
+@JsonTypeName(PROCESS_LINK_TYPE)
+data class AnotherTestProcessLinkCreateRequestDto(
+    override val processDefinitionId: String,
+    override val activityId: String,
+    override val activityType: ActivityTypeWithEventName,
+    val anotherValue: String = "another-test"
+) : ProcessLinkCreateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkDeployDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkDeployDto.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.ritense.processlink.autodeployment.ProcessLinkDeployDto
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
+
+@JsonTypeName(PROCESS_LINK_TYPE)
+data class AnotherTestProcessLinkDeployDto(
+    override val processDefinitionId: String,
+    override val activityId: String,
+    override val activityType: ActivityTypeWithEventName,
+    val anotherValue: String = "another-test"
+) : ProcessLinkDeployDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkExportResponseDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkExportResponseDto.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,15 @@
 package com.ritense.processlink.domain
 
 import com.fasterxml.jackson.annotation.JsonTypeName
-import com.ritense.processlink.autodeployment.ProcessLinkDeployDto
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
+import com.ritense.processlink.web.rest.dto.ProcessLinkExportResponseDto
 
-@JsonTypeName(PROCESS_LINK_TYPE_TEST)
-data class CustomProcessLinkDeployDto(
-    override val processDefinitionId: String,
+@JsonTypeName(PROCESS_LINK_TYPE)
+data class AnotherTestProcessLinkExportResponseDto(
     override val activityId: String,
     override val activityType: ActivityTypeWithEventName,
-    val someValue: String = "test"
-) : ProcessLinkDeployDto {
+    val anotherValue: String = "another-test"
+) : ProcessLinkExportResponseDto {
     override val processLinkType: String
-        get() = PROCESS_LINK_TYPE_TEST
+        get() = PROCESS_LINK_TYPE
 }

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkMapper.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkMapper.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ritense.exporter.request.ExportRequest
+import com.ritense.processlink.autodeployment.ProcessLinkDeployDto
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
+import com.ritense.processlink.exporter.CustomProcessLinkNestedExportRequest
+import com.ritense.processlink.mapper.ProcessLinkMapper
+import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
+import com.ritense.processlink.web.rest.dto.ProcessLinkExportResponseDto
+import com.ritense.processlink.web.rest.dto.ProcessLinkResponseDto
+import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
+import java.util.UUID
+
+class AnotherTestProcessLinkMapper(
+    objectMapper: ObjectMapper
+) : ProcessLinkMapper {
+
+    init {
+        objectMapper.registerSubtypes(
+            AnotherTestProcessLinkCreateRequestDto::class.java,
+            AnotherTestProcessLinkDeployDto::class.java,
+            AnotherTestProcessLinkExportResponseDto::class.java,
+            AnotherTestProcessLinkResponseDto::class.java,
+            AnotherTestProcessLinkUpdateRequestDto::class.java
+        )
+    }
+
+    override fun supportsProcessLinkType(processLinkType: String) = processLinkType == PROCESS_LINK_TYPE
+
+    override fun toProcessLinkResponseDto(processLink: ProcessLink): ProcessLinkResponseDto {
+        processLink as AnotherTestProcessLink
+        return AnotherTestProcessLinkResponseDto(
+            id = processLink.id,
+            processDefinitionId = processLink.processDefinitionId,
+            activityId = processLink.activityId,
+            activityType = processLink.activityType,
+            anotherValue = processLink.anotherValue
+        )
+    }
+
+    override fun toProcessLinkUpdateRequestDto(
+        deployDto: ProcessLinkDeployDto,
+        existingProcessLinkId: UUID
+    ): ProcessLinkUpdateRequestDto {
+        deployDto as AnotherTestProcessLinkDeployDto
+        return AnotherTestProcessLinkUpdateRequestDto(
+            id = existingProcessLinkId,
+            anotherValue = deployDto.anotherValue
+        )
+    }
+
+    override fun toProcessLinkCreateRequestDto(deployDto: ProcessLinkDeployDto): ProcessLinkCreateRequestDto {
+        deployDto as AnotherTestProcessLinkDeployDto
+        return AnotherTestProcessLinkCreateRequestDto(
+            processDefinitionId = deployDto.processDefinitionId,
+            activityId = deployDto.activityId,
+            activityType = deployDto.activityType,
+            anotherValue = deployDto.anotherValue
+        )
+    }
+
+    override fun toProcessLinkExportResponseDto(processLink: ProcessLink): ProcessLinkExportResponseDto {
+        processLink as AnotherTestProcessLink
+        return AnotherTestProcessLinkExportResponseDto(
+            activityId = processLink.activityId,
+            activityType = processLink.activityType,
+            anotherValue = processLink.anotherValue
+        )
+    }
+
+    override fun toNewProcessLink(createRequestDto: ProcessLinkCreateRequestDto): ProcessLink {
+        createRequestDto as AnotherTestProcessLinkCreateRequestDto
+        return AnotherTestProcessLink(
+            id = UUID.randomUUID(),
+            processDefinitionId = createRequestDto.processDefinitionId,
+            activityId = createRequestDto.activityId,
+            activityType = createRequestDto.activityType,
+            anotherValue = createRequestDto.anotherValue
+        )
+    }
+
+    override fun toUpdatedProcessLink(
+        processLinkToUpdate: ProcessLink,
+        updateRequestDto: ProcessLinkUpdateRequestDto
+    ): ProcessLink {
+        updateRequestDto as AnotherTestProcessLinkUpdateRequestDto
+
+        return AnotherTestProcessLink(
+            id = updateRequestDto.id,
+            processDefinitionId = processLinkToUpdate.processDefinitionId,
+            activityId = processLinkToUpdate.activityId,
+            activityType = processLinkToUpdate.activityType,
+            anotherValue = updateRequestDto.anotherValue
+        )
+    }
+
+    override fun createRelatedExportRequests(processLink: ProcessLink): Set<ExportRequest> {
+        return setOf(CustomProcessLinkNestedExportRequest())
+    }
+
+    override fun getImporterType() = PROCESS_LINK_TYPE
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkResponseDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkResponseDto.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
+import com.ritense.processlink.web.rest.dto.ProcessLinkResponseDto
+import java.util.UUID
+
+data class AnotherTestProcessLinkResponseDto(
+    override val id: UUID,
+    override val processDefinitionId: String,
+    override val activityId: String,
+    override val activityType: ActivityTypeWithEventName,
+    override val processLinkType: String = PROCESS_LINK_TYPE,
+    val anotherValue: String
+) : ProcessLinkResponseDto

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkUpdateRequestDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/AnotherTestProcessLinkUpdateRequestDto.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 Ritense BV, the Netherlands.
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@
 package com.ritense.processlink.domain
 
 import com.fasterxml.jackson.annotation.JsonTypeName
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
 import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import java.util.UUID
 
-@JsonTypeName(PROCESS_LINK_TYPE_TEST)
-data class CustomProcessLinkUpdateRequestDto(
+@JsonTypeName(PROCESS_LINK_TYPE)
+data class AnotherTestProcessLinkUpdateRequestDto(
     override val id: UUID,
-    val someValue: String = "test"
+    val anotherValue: String = "another-test"
 ) : ProcessLinkUpdateRequestDto {
     override val processLinkType: String
-        get() = PROCESS_LINK_TYPE_TEST
+        get() = PROCESS_LINK_TYPE
 }

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLink.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLink.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import java.util.UUID
+
+@Entity
+@DiscriminatorValue(PROCESS_LINK_TYPE_TEST)
+class TestProcessLink(
+    id: UUID,
+    processDefinitionId: String,
+    activityId: String,
+    activityType: ActivityTypeWithEventName,
+
+    @Column(name = "some_value")
+    val someValue: String = "test"
+
+) : ProcessLink(
+    id,
+    processDefinitionId,
+    activityId,
+    activityType,
+    PROCESS_LINK_TYPE_TEST,
+) {
+
+    override fun copy(
+        id: UUID,
+        processDefinitionId: String
+    ) = copy(
+        id = id,
+        processDefinitionId = processDefinitionId,
+        activityId = activityId
+    )
+
+    fun copy(
+        id: UUID = this.id,
+        processDefinitionId: String = this.processDefinitionId,
+        activityId: String = this.activityId,
+        activityType: ActivityTypeWithEventName = this.activityType,
+        someValue: String = this.someValue
+    ) = TestProcessLink(
+        id = id,
+        processDefinitionId = processDefinitionId,
+        activityId = activityId,
+        activityType = activityType,
+        someValue = someValue
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as TestProcessLink
+
+        return someValue == other.someValue
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + someValue.hashCode()
+        return result
+    }
+
+    companion object {
+        const val PROCESS_LINK_TYPE_TEST = "test"
+    }
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkCreateRequestDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkCreateRequestDto.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
+
+@JsonTypeName(PROCESS_LINK_TYPE_TEST)
+data class TestProcessLinkCreateRequestDto(
+    override val processDefinitionId: String,
+    override val activityId: String,
+    override val activityType: ActivityTypeWithEventName,
+    val someValue: String = "test"
+) : ProcessLinkCreateRequestDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_TEST
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkCreateRequestDtoTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkCreateRequestDtoTest.kt
@@ -17,7 +17,7 @@
 package com.ritense.processlink.domain
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
 import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
 import com.ritense.valtimo.contract.json.MapperSingleton
 import org.hamcrest.MatcherAssert.assertThat
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 
-class CustomProcessLinkCreateRequestDtoTest {
+class TestProcessLinkCreateRequestDtoTest {
 
     private val mapper = MapperSingleton.get().copy().apply {
-        this.registerSubtypes(CustomProcessLinkCreateRequestDto::class.java, CustomProcessLinkUpdateRequestDto::class.java)
+        this.registerSubtypes(TestProcessLinkCreateRequestDto::class.java, TestProcessLinkUpdateRequestDto::class.java)
     }
 
     @Test
@@ -45,8 +45,8 @@ class CustomProcessLinkCreateRequestDtoTest {
             }
         """.trimIndent())
 
-        assertThat(value, instanceOf(CustomProcessLinkCreateRequestDto::class.java))
-        value as CustomProcessLinkCreateRequestDto
+        assertThat(value, instanceOf(TestProcessLinkCreateRequestDto::class.java))
+        value as TestProcessLinkCreateRequestDto
         assertThat(value.processLinkType, equalTo(PROCESS_LINK_TYPE_TEST))
         assertThat(value.someValue, equalTo("test"))
     }
@@ -62,15 +62,15 @@ class CustomProcessLinkCreateRequestDtoTest {
             }
         """.trimIndent())
 
-        assertThat(value, instanceOf(CustomProcessLinkCreateRequestDto::class.java))
-        value as CustomProcessLinkCreateRequestDto
+        assertThat(value, instanceOf(TestProcessLinkCreateRequestDto::class.java))
+        value as TestProcessLinkCreateRequestDto
         assertThat(value.processLinkType, equalTo(PROCESS_LINK_TYPE_TEST))
         assertThat(value.someValue, equalTo("test"))
     }
 
     @Test
     fun `should serialize correctly`() {
-        val value = CustomProcessLinkCreateRequestDto("process-definition:1","serviceTask1", ActivityTypeWithEventName.SERVICE_TASK_START, "test")
+        val value = TestProcessLinkCreateRequestDto("process-definition:1","serviceTask1", ActivityTypeWithEventName.SERVICE_TASK_START, "test")
 
         val json = mapper.writeValueAsString(value)
 

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkDeployDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkDeployDto.kt
@@ -16,15 +16,17 @@
 
 package com.ritense.processlink.domain
 
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
-import com.ritense.processlink.web.rest.dto.ProcessLinkResponseDto
-import java.util.UUID
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.ritense.processlink.autodeployment.ProcessLinkDeployDto
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
 
-data class CustomProcessLinkResponseDto(
-    override val id: UUID,
+@JsonTypeName(PROCESS_LINK_TYPE_TEST)
+data class TestProcessLinkDeployDto(
     override val processDefinitionId: String,
     override val activityId: String,
     override val activityType: ActivityTypeWithEventName,
-    override val processLinkType: String = PROCESS_LINK_TYPE_TEST,
-    val someValue: String
-) : ProcessLinkResponseDto
+    val someValue: String = "test"
+) : ProcessLinkDeployDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_TEST
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkExportResponseDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkExportResponseDto.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.processlink.domain
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.web.rest.dto.ProcessLinkExportResponseDto
+
+@JsonTypeName(PROCESS_LINK_TYPE_TEST)
+data class TestProcessLinkExportResponseDto(
+    override val activityId: String,
+    override val activityType: ActivityTypeWithEventName,
+    val someValue: String = "test"
+) : ProcessLinkExportResponseDto {
+    override val processLinkType: String
+        get() = PROCESS_LINK_TYPE_TEST
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkMapper.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkMapper.kt
@@ -19,7 +19,7 @@ package com.ritense.processlink.domain
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.exporter.request.ExportRequest
 import com.ritense.processlink.autodeployment.ProcessLinkDeployDto
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
 import com.ritense.processlink.exporter.CustomProcessLinkNestedExportRequest
 import com.ritense.processlink.mapper.ProcessLinkMapper
 import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
@@ -28,25 +28,25 @@ import com.ritense.processlink.web.rest.dto.ProcessLinkResponseDto
 import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import java.util.UUID
 
-class CustomProcessLinkMapper(
+class TestProcessLinkMapper(
     objectMapper: ObjectMapper
 ) : ProcessLinkMapper {
 
     init {
         objectMapper.registerSubtypes(
-            CustomProcessLinkCreateRequestDto::class.java,
-            CustomProcessLinkDeployDto::class.java,
-            CustomProcessLinkExportResponseDto::class.java,
-            CustomProcessLinkResponseDto::class.java,
-            CustomProcessLinkUpdateRequestDto::class.java
+            TestProcessLinkCreateRequestDto::class.java,
+            TestProcessLinkDeployDto::class.java,
+            TestProcessLinkExportResponseDto::class.java,
+            TestProcessLinkResponseDto::class.java,
+            TestProcessLinkUpdateRequestDto::class.java
         )
     }
 
     override fun supportsProcessLinkType(processLinkType: String) = processLinkType == PROCESS_LINK_TYPE_TEST
 
     override fun toProcessLinkResponseDto(processLink: ProcessLink): ProcessLinkResponseDto {
-        processLink as CustomProcessLink
-        return CustomProcessLinkResponseDto(
+        processLink as TestProcessLink
+        return TestProcessLinkResponseDto(
             id = processLink.id,
             processDefinitionId = processLink.processDefinitionId,
             activityId = processLink.activityId,
@@ -59,16 +59,16 @@ class CustomProcessLinkMapper(
         deployDto: ProcessLinkDeployDto,
         existingProcessLinkId: UUID
     ): ProcessLinkUpdateRequestDto {
-        deployDto as CustomProcessLinkDeployDto
-        return CustomProcessLinkUpdateRequestDto(
+        deployDto as TestProcessLinkDeployDto
+        return TestProcessLinkUpdateRequestDto(
             id = existingProcessLinkId,
             someValue = deployDto.someValue
         )
     }
 
     override fun toProcessLinkCreateRequestDto(deployDto: ProcessLinkDeployDto): ProcessLinkCreateRequestDto {
-        deployDto as CustomProcessLinkDeployDto
-        return CustomProcessLinkCreateRequestDto(
+        deployDto as TestProcessLinkDeployDto
+        return TestProcessLinkCreateRequestDto(
             processDefinitionId = deployDto.processDefinitionId,
             activityId = deployDto.activityId,
             activityType = deployDto.activityType,
@@ -77,8 +77,8 @@ class CustomProcessLinkMapper(
     }
 
     override fun toProcessLinkExportResponseDto(processLink: ProcessLink): ProcessLinkExportResponseDto {
-        processLink as CustomProcessLink
-        return CustomProcessLinkExportResponseDto(
+        processLink as TestProcessLink
+        return TestProcessLinkExportResponseDto(
             activityId = processLink.activityId,
             activityType = processLink.activityType,
             someValue = processLink.someValue
@@ -86,8 +86,8 @@ class CustomProcessLinkMapper(
     }
 
     override fun toNewProcessLink(createRequestDto: ProcessLinkCreateRequestDto): ProcessLink {
-        createRequestDto as CustomProcessLinkCreateRequestDto
-        return CustomProcessLink(
+        createRequestDto as TestProcessLinkCreateRequestDto
+        return TestProcessLink(
             id = UUID.randomUUID(),
             processDefinitionId = createRequestDto.processDefinitionId,
             activityId = createRequestDto.activityId,
@@ -100,9 +100,9 @@ class CustomProcessLinkMapper(
         processLinkToUpdate: ProcessLink,
         updateRequestDto: ProcessLinkUpdateRequestDto
     ): ProcessLink {
-        updateRequestDto as CustomProcessLinkUpdateRequestDto
+        updateRequestDto as TestProcessLinkUpdateRequestDto
 
-        return CustomProcessLink(
+        return TestProcessLink(
             id = updateRequestDto.id,
             processDefinitionId = processLinkToUpdate.processDefinitionId,
             activityId = processLinkToUpdate.activityId,
@@ -115,5 +115,5 @@ class CustomProcessLinkMapper(
         return setOf(CustomProcessLinkNestedExportRequest())
     }
 
-    override fun getImporterType() = "test"
+    override fun getImporterType() = PROCESS_LINK_TYPE_TEST
 }

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkResponseDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkResponseDto.kt
@@ -16,16 +16,15 @@
 
 package com.ritense.processlink.domain
 
-import com.fasterxml.jackson.annotation.JsonTypeName
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
-import com.ritense.processlink.web.rest.dto.ProcessLinkExportResponseDto
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.web.rest.dto.ProcessLinkResponseDto
+import java.util.UUID
 
-@JsonTypeName(PROCESS_LINK_TYPE_TEST)
-data class CustomProcessLinkExportResponseDto(
+data class TestProcessLinkResponseDto(
+    override val id: UUID,
+    override val processDefinitionId: String,
     override val activityId: String,
     override val activityType: ActivityTypeWithEventName,
-    val someValue: String = "test"
-) : ProcessLinkExportResponseDto {
-    override val processLinkType: String
-        get() = PROCESS_LINK_TYPE_TEST
-}
+    override val processLinkType: String = PROCESS_LINK_TYPE_TEST,
+    val someValue: String
+) : ProcessLinkResponseDto

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkUpdateRequestDto.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkUpdateRequestDto.kt
@@ -17,16 +17,15 @@
 package com.ritense.processlink.domain
 
 import com.fasterxml.jackson.annotation.JsonTypeName
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
-import com.ritense.processlink.web.rest.dto.ProcessLinkCreateRequestDto
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
+import java.util.UUID
 
 @JsonTypeName(PROCESS_LINK_TYPE_TEST)
-data class CustomProcessLinkCreateRequestDto(
-    override val processDefinitionId: String,
-    override val activityId: String,
-    override val activityType: ActivityTypeWithEventName,
+data class TestProcessLinkUpdateRequestDto(
+    override val id: UUID,
     val someValue: String = "test"
-) : ProcessLinkCreateRequestDto {
+) : ProcessLinkUpdateRequestDto {
     override val processLinkType: String
         get() = PROCESS_LINK_TYPE_TEST
 }

--- a/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkUpdateRequestDtoTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/domain/TestProcessLinkUpdateRequestDtoTest.kt
@@ -17,21 +17,21 @@
 package com.ritense.processlink.domain
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.ritense.processlink.domain.CustomProcessLink.Companion.PROCESS_LINK_TYPE_TEST
+import com.ritense.processlink.domain.TestProcessLink.Companion.PROCESS_LINK_TYPE_TEST
 import com.ritense.processlink.web.rest.dto.ProcessLinkUpdateRequestDto
 import com.ritense.valtimo.contract.json.MapperSingleton
-import java.util.UUID
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.instanceOf
 import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
+import java.util.UUID
 
-class CustomProcessLinkUpdateRequestDtoTest {
+class TestProcessLinkUpdateRequestDtoTest {
 
     private val mapper = MapperSingleton.get().copy().apply {
-        this.registerSubtypes(CustomProcessLinkCreateRequestDto::class.java, CustomProcessLinkUpdateRequestDto::class.java)
+        this.registerSubtypes(TestProcessLinkCreateRequestDto::class.java, TestProcessLinkUpdateRequestDto::class.java)
     }
 
     @Test
@@ -44,8 +44,8 @@ class CustomProcessLinkUpdateRequestDtoTest {
             }
         """.trimIndent())
 
-        assertThat(value, instanceOf(CustomProcessLinkUpdateRequestDto::class.java))
-        value as CustomProcessLinkUpdateRequestDto
+        assertThat(value, instanceOf(TestProcessLinkUpdateRequestDto::class.java))
+        value as TestProcessLinkUpdateRequestDto
         assertThat(value.processLinkType, equalTo(PROCESS_LINK_TYPE_TEST))
         assertThat(value.someValue, equalTo("test"))
     }
@@ -59,15 +59,15 @@ class CustomProcessLinkUpdateRequestDtoTest {
             }
         """.trimIndent())
 
-        assertThat(value, instanceOf(CustomProcessLinkUpdateRequestDto::class.java))
-        value as CustomProcessLinkUpdateRequestDto
+        assertThat(value, instanceOf(TestProcessLinkUpdateRequestDto::class.java))
+        value as TestProcessLinkUpdateRequestDto
         assertThat(value.processLinkType, equalTo(PROCESS_LINK_TYPE_TEST))
         assertThat(value.someValue, equalTo("test"))
     }
 
     @Test
     fun `should serialize correctly`() {
-        val value = CustomProcessLinkUpdateRequestDto(UUID.randomUUID(), "test")
+        val value = TestProcessLinkUpdateRequestDto(UUID.randomUUID(), "test")
 
         val json = mapper.writeValueAsString(value)
 

--- a/process-link/src/test/kotlin/com/ritense/processlink/importer/ProcessLinkImporterIntTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/importer/ProcessLinkImporterIntTest.kt
@@ -20,7 +20,7 @@ import com.ritense.authorization.AuthorizationContext
 import com.ritense.importer.ImportRequest
 import com.ritense.importer.ValtimoImportTypes.Companion.PROCESS_DEFINITION
 import com.ritense.processlink.BaseIntegrationTest
-import com.ritense.processlink.domain.CustomProcessLink
+import com.ritense.processlink.domain.TestProcessLink
 import com.ritense.processlink.repository.ProcessLinkRepository
 import com.ritense.valtimo.camunda.domain.CamundaProcessDefinition
 import com.ritense.valtimo.camunda.service.CamundaRepositoryService
@@ -41,7 +41,7 @@ class ProcessLinkImporterIntTest @Autowired constructor(
 
     @Test
     fun `should dependsOn types from mappers`() {
-        assertThat(processLinkImporter.dependsOn()).isEqualTo(setOf(PROCESS_DEFINITION, "test"))
+        assertThat(processLinkImporter.dependsOn()).containsAll(setOf(PROCESS_DEFINITION, "test"))
     }
 
     @Test
@@ -55,7 +55,7 @@ class ProcessLinkImporterIntTest @Autowired constructor(
         val processLinks =
             processLinkRepository.findByProcessDefinitionIdAndActivityId(processDefinition.id, "my-service-task")
 
-        val processLink = requireNotNull(processLinks.single() as? CustomProcessLink)
+        val processLink = requireNotNull(processLinks.single() as? TestProcessLink)
         assertThat(processLink.someValue).isEqualTo("importer test")
     }
 

--- a/process-link/src/test/kotlin/com/ritense/processlink/service/CopyProcessLinkOnProcessDeploymentListenerIntTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/service/CopyProcessLinkOnProcessDeploymentListenerIntTest.kt
@@ -19,7 +19,7 @@ package com.ritense.processlink.service
 import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthorization
 import com.ritense.processlink.BaseIntegrationTest
 import com.ritense.processlink.domain.ActivityTypeWithEventName
-import com.ritense.processlink.domain.CustomProcessLinkCreateRequestDto
+import com.ritense.processlink.domain.TestProcessLinkCreateRequestDto
 import com.ritense.valtimo.camunda.domain.CamundaProcessDefinition
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byKey
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersion
@@ -97,7 +97,7 @@ internal class CopyProcessLinkOnProcessDeploymentListenerIntTest : BaseIntegrati
 
     private fun createProcessLink(processDefinition: CamundaProcessDefinition) {
         processLinkService.createProcessLink(
-            CustomProcessLinkCreateRequestDto(
+            TestProcessLinkCreateRequestDto(
                 processDefinition.id,
                 SERVICE_TASK_ID,
                 ActivityTypeWithEventName.SERVICE_TASK_START

--- a/process-link/src/test/kotlin/com/ritense/processlink/service/ProcessLinkServiceIntTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/service/ProcessLinkServiceIntTest.kt
@@ -1,0 +1,36 @@
+package com.ritense.processlink.service
+
+import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthorization
+import com.ritense.processlink.BaseIntegrationTest
+import com.ritense.processlink.domain.AnotherTestProcessLink
+import com.ritense.processlink.domain.AnotherTestProcessLink.Companion.PROCESS_LINK_TYPE
+import com.ritense.processlink.domain.AnotherTestProcessLinkUpdateRequestDto
+import com.ritense.processlink.domain.TestProcessLink
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class ProcessLinkServiceIntTest @Autowired constructor(
+    private val processLinkService: ProcessLinkService
+): BaseIntegrationTest() {
+
+    @Test
+    fun `should update existing processLink to new type`(): Unit = runWithoutAuthorization {
+        val processLink = processLinkService.getProcessLinksByProcessDefinitionKey("auto-deploy-process-link-with-long-key")
+            .filterIsInstance<TestProcessLink>().first()
+
+        processLinkService.updateProcessLink(
+            AnotherTestProcessLinkUpdateRequestDto(
+                processLink.id,
+                "success!"
+            )
+        )
+
+        val updatedProcessLink = processLinkService.getProcessLink(processLink.id, AnotherTestProcessLink::class.java)
+        assertThat(updatedProcessLink.processLinkType).isEqualTo(PROCESS_LINK_TYPE)
+        assertThat(updatedProcessLink.anotherValue).isNotEqualTo(processLink.someValue)
+        assertThat(updatedProcessLink.anotherValue).isEqualTo("success!")
+    }
+}

--- a/process-link/src/test/kotlin/com/ritense/processlink/web/rest/ProcessLinkResourceIT.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/web/rest/ProcessLinkResourceIT.kt
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.ritense.processlink.BaseIntegrationTest
 import com.ritense.processlink.autodeployment.ProcessLinkDeploymentApplicationReadyEventListener
 import com.ritense.processlink.domain.ActivityTypeWithEventName.SERVICE_TASK_START
-import com.ritense.processlink.domain.CustomProcessLink
-import com.ritense.processlink.domain.CustomProcessLinkCreateRequestDto
-import com.ritense.processlink.domain.CustomProcessLinkUpdateRequestDto
+import com.ritense.processlink.domain.TestProcessLink
+import com.ritense.processlink.domain.TestProcessLinkCreateRequestDto
+import com.ritense.processlink.domain.TestProcessLinkUpdateRequestDto
 import com.ritense.processlink.repository.ProcessLinkRepository
 import org.hamcrest.Matchers.hasSize
 import org.junit.jupiter.api.BeforeEach
@@ -62,7 +62,7 @@ internal class ProcessLinkResourceIT @Autowired constructor(
 
     @Test
     fun `should create a process-link`() {
-        val createDto = CustomProcessLinkCreateRequestDto(
+        val createDto = TestProcessLinkCreateRequestDto(
             processDefinitionId = PROCESS_DEF_ID,
             activityId = ACTIVITY_ID,
             activityType = SERVICE_TASK_START
@@ -81,7 +81,7 @@ internal class ProcessLinkResourceIT @Autowired constructor(
 
     @Test
     fun `should create a process-link without processLinkType`() {
-        val createDto = CustomProcessLinkCreateRequestDto(
+        val createDto = TestProcessLinkCreateRequestDto(
             processDefinitionId = PROCESS_DEF_ID,
             activityId = ACTIVITY_ID,
             activityType = SERVICE_TASK_START
@@ -125,7 +125,7 @@ internal class ProcessLinkResourceIT @Autowired constructor(
     fun `should update a process-link`() {
         val processLinkId = createProcessLink()
 
-        val updateDto = CustomProcessLinkUpdateRequestDto(
+        val updateDto = TestProcessLinkUpdateRequestDto(
             id = processLinkId
         )
 
@@ -161,7 +161,7 @@ internal class ProcessLinkResourceIT @Autowired constructor(
 
     private fun createProcessLink(): UUID {
         return processLinkRepository.save(
-            CustomProcessLink(
+            TestProcessLink(
                 UUID.randomUUID(),
                 processDefinitionId = PROCESS_DEF_ID,
                 activityId = ACTIVITY_ID,

--- a/process-link/src/test/kotlin/com/ritense/processlink/web/rest/ProcessLinkResourceTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/web/rest/ProcessLinkResourceTest.kt
@@ -18,10 +18,10 @@ package com.ritense.processlink.web.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ritense.processlink.domain.ActivityTypeWithEventName
-import com.ritense.processlink.domain.CustomProcessLink
-import com.ritense.processlink.domain.CustomProcessLinkCreateRequestDto
-import com.ritense.processlink.domain.CustomProcessLinkMapper
-import com.ritense.processlink.domain.CustomProcessLinkUpdateRequestDto
+import com.ritense.processlink.domain.TestProcessLink
+import com.ritense.processlink.domain.TestProcessLinkCreateRequestDto
+import com.ritense.processlink.domain.TestProcessLinkMapper
+import com.ritense.processlink.domain.TestProcessLinkUpdateRequestDto
 import com.ritense.processlink.mapper.ProcessLinkMapper
 import com.ritense.processlink.service.ProcessLinkService
 import com.ritense.valtimo.contract.json.MapperSingleton
@@ -57,7 +57,7 @@ internal class ProcessLinkResourceTest {
     fun init() {
         objectMapper = MapperSingleton.get()
         processLinkService = mock()
-        processLinkMappers = listOf(CustomProcessLinkMapper(objectMapper))
+        processLinkMappers = listOf(TestProcessLinkMapper(objectMapper))
         processLinkResource = ProcessLinkResource(processLinkService, processLinkMappers)
 
         val mappingJackson2HttpMessageConverter = MappingJackson2HttpMessageConverter()
@@ -78,13 +78,13 @@ internal class ProcessLinkResourceTest {
         val activityType = ActivityTypeWithEventName.SERVICE_TASK_START
 
         val processLinks = listOf(
-            CustomProcessLink(
+            TestProcessLink(
                 id = id1,
                 processDefinitionId = processDefinitionId,
                 activityId = activityId,
                 activityType = activityType
             ),
-            CustomProcessLink(
+            TestProcessLink(
                 id = id2,
                 processDefinitionId = processDefinitionId,
                 activityId = activityId,
@@ -116,7 +116,7 @@ internal class ProcessLinkResourceTest {
 
     @Test
     fun `should add process link`() {
-        val processLinkDto = CustomProcessLinkCreateRequestDto(
+        val processLinkDto = TestProcessLinkCreateRequestDto(
             processDefinitionId = UUID.randomUUID().toString(),
             activityId = "someActivity",
             activityType = ActivityTypeWithEventName.SERVICE_TASK_START
@@ -137,7 +137,7 @@ internal class ProcessLinkResourceTest {
 
     @Test
     fun `should update process link`() {
-        val processLinkDto = CustomProcessLinkUpdateRequestDto(
+        val processLinkDto = TestProcessLinkUpdateRequestDto(
             id = UUID.randomUUID(),
         )
 

--- a/process-link/src/test/kotlin/com/ritense/processlink/web/rest/ProcessLinkTaskResourceTest.kt
+++ b/process-link/src/test/kotlin/com/ritense/processlink/web/rest/ProcessLinkTaskResourceTest.kt
@@ -17,7 +17,7 @@
 package com.ritense.processlink.web.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ritense.processlink.domain.CustomProcessLinkMapper
+import com.ritense.processlink.domain.TestProcessLinkMapper
 import com.ritense.processlink.exception.ProcessLinkNotFoundException
 import com.ritense.processlink.mapper.ProcessLinkMapper
 import com.ritense.processlink.service.ProcessLinkActivityService
@@ -51,7 +51,7 @@ internal class ProcessLinkTaskResourceTest {
     fun init() {
         objectMapper = MapperSingleton.get()
         processLinkActivityService = mock()
-        processLinkMappers = listOf(CustomProcessLinkMapper(objectMapper))
+        processLinkMappers = listOf(TestProcessLinkMapper(objectMapper))
         processLinkTaskResource = ProcessLinkTaskResource(processLinkActivityService)
 
         val mappingJackson2HttpMessageConverter = MappingJackson2HttpMessageConverter()

--- a/process-link/src/test/resources/config/liquibase/changelog/20230417-add-custom-process-link.xml
+++ b/process-link/src/test/resources/config/liquibase/changelog/20230417-add-custom-process-link.xml
@@ -24,9 +24,8 @@
             <tableExists tableName="process_link"/>
         </preConditions>
         <addColumn tableName="process_link">
-            <column name="some_value" type="varchar(256)">
-                <constraints nullable="false"/>
-            </column>
+            <column name="some_value" type="varchar(256)" />
+            <column name="another_value" type="varchar(256)" />
         </addColumn>
     </changeSet>
 


### PR DESCRIPTION
Updating a process-link to a different type via autodeployment was not possible because the mapper was selected by the current `processLinkType`.