### PR TITLE
Incorrect order of updating a case and starting a process

### DIFF
--- a/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentService.java
+++ b/process-document/src/main/java/com/ritense/processdocument/service/impl/CamundaProcessJsonSchemaDocumentService.java
@@ -293,6 +293,8 @@ public class CamundaProcessJsonSchemaDocumentService implements ProcessDocumentS
                 )
             );
 
+            request.doAdditionalModifications(document);
+
             //Part 2 process start
             final var processDefinitionKey = new CamundaProcessDefinitionKey(request.processDefinitionKey());
             final var processInstanceWithDefinition = startProcess(
@@ -306,8 +308,6 @@ public class CamundaProcessJsonSchemaDocumentService implements ProcessDocumentS
                 UUID.fromString(document.id().toString()),
                 processInstanceWithDefinition.getProcessDefinition().getName()
             ));
-
-            request.doAdditionalModifications(document);
 
             return new ModifyDocumentAndStartProcessResultSucceeded(document, camundaProcessInstanceId);
         } catch (RuntimeException ex) {


### PR DESCRIPTION
If the process is created before the case is updated, then said process can modify the case before the other chance is applied. This can lead to missing information in the case.