### PR TITLE
Story/allow hiding locked tasks

### DIFF
--- a/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
@@ -285,7 +285,7 @@ class CaseTaskListSearchService(
         )
 
         if (searchRequest.otherFilters != null && searchRequest.otherFilters.isNotEmpty()) {
-            predicates.add(getOtherFiltersPredicate(cb, taskRoot, documentRoot, searchRequest))
+            predicates.add(getOtherFiltersPredicate(cb, query, taskRoot, documentRoot, searchRequest))
         }
 
         if (searchRequest.statusFilter != null && searchRequest.statusFilter.isNotEmpty()) {
@@ -297,6 +297,7 @@ class CaseTaskListSearchService(
 
     private fun getOtherFiltersPredicate(
         cb: CriteriaBuilder,
+        query: CriteriaQuery<*>,
         taskRoot: Root<CamundaTask>,
         documentRoot: Root<JsonSchemaDocument>,
         searchRequest: AdvancedSearchRequest
@@ -304,6 +305,7 @@ class CaseTaskListSearchService(
         val jsonPredicates: Array<Predicate> = searchRequest.otherFilters.map { currentCriteria: AdvancedSearchRequest.OtherFilter ->
             buildQueryForSearchCriteria(
                 cb,
+                query,
                 taskRoot,
                 documentRoot,
                 currentCriteria
@@ -336,10 +338,13 @@ class CaseTaskListSearchService(
 
     private fun buildQueryForSearchCriteria(
         cb: CriteriaBuilder,
+        query: CriteriaQuery<*>,
         taskRoot: Root<CamundaTask>,
         documentRoot: Root<JsonSchemaDocument>,
         searchCriteria: AdvancedSearchRequest.OtherFilter
     ): Predicate {
+        handleSpecialPaths(cb, query, taskRoot, searchCriteria)?.let { return it }
+
         val value: Expression<Comparable<Any>> =
             if (searchCriteria.path.startsWith(DOC_PREFIX)) {
                 getValueExpressionForDocPrefix(cb, documentRoot, searchCriteria)
@@ -362,6 +367,25 @@ class CaseTaskListSearchService(
             DatabaseSearchType.BETWEEN -> searchBetween(cb, value, rangeFrom, rangeTo)
             DatabaseSearchType.IN -> searchIn(cb, value, searchCriteria.getValues())
             else -> throw NotImplementedException("Searching for search type '" + searchCriteria.searchType + "' hasn't been implemented.")
+        }
+    }
+
+    private fun handleSpecialPaths(
+        cb: CriteriaBuilder,
+        query: CriteriaQuery<*>,
+        taskRoot: Root<CamundaTask>,
+        searchCriteria: AdvancedSearchRequest.OtherFilter
+    ): Predicate? {
+        return if (searchCriteria.path == TASK_PREFIX + "hideInaccessibleTasks") {
+            val values = searchCriteria.getValues<Boolean>()
+
+            if (values.size == 1 && values[0] == true) {
+                getAuthorizationSpecification(CamundaTaskActionProvider.VIEW).toPredicate(taskRoot, query, cb)
+            } else {
+                cb.conjunction()
+            }
+        } else {
+            null
         }
     }
 

--- a/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
@@ -382,6 +382,8 @@ class CaseTaskListSearchService(
             if (values.size == 1 && values[0] == true) {
                 getAuthorizationSpecification(CamundaTaskActionProvider.VIEW).toPredicate(taskRoot, query, cb)
             } else {
+                // Returning a no-op/always true value so that
+                // the code doesn't continue and try to find `hideInaccessibleTasks` in the task table.
                 cb.conjunction()
             }
         } else {

--- a/process-document/src/test/java/com/ritense/processdocument/BaseTest.java
+++ b/process-document/src/test/java/com/ritense/processdocument/BaseTest.java
@@ -78,9 +78,7 @@ public abstract class BaseTest {
     }
 
     protected JsonSchemaDocumentDefinition definition() {
-        final JsonSchemaDocumentDefinitionId jsonSchemaDocumentDefinitionId = JsonSchemaDocumentDefinitionId.newId("house");
-        final JsonSchema jsonSchema = JsonSchema.fromResourceUri(path(jsonSchemaDocumentDefinitionId.name()));
-        return new JsonSchemaDocumentDefinition(jsonSchemaDocumentDefinitionId, jsonSchema);
+        return definition("house");
     }
 
     protected JsonSchemaDocumentDefinition definition(String name) {

--- a/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
+++ b/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
@@ -152,6 +152,21 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
             )
         )
 
+        searchFieldV2Service.create(
+            TaskListSearchFieldV2Dto(
+                id = UUID.randomUUID(),
+                ownerId = definition!!.id!!.name(),
+                key = "hideInaccessibleTasks",
+                title = "Hide inaccessible tasks",
+                path = "task:hideInaccessibleTasks",
+                order = 1,
+                dataType = DataType.BOOLEAN,
+                fieldType = FieldType.SINGLE,
+                matchType = SearchFieldMatchType.EXACT,
+                dropdownDataProvider = null
+            )
+        )
+
         runWithoutAuthorization {
             camundaProcessJsonSchemaDocumentService.startProcessForDocument(
                 StartProcessForDocumentRequest(
@@ -263,6 +278,52 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
 
         val searchResult = searchTasks(filter)
         assertThat(searchResult).hasSize(0)
+    }
+
+    @Test
+    @Throws(JsonProcessingException::class)
+    @WithMockUser(username = "user@ritense.com", authorities = [AuthoritiesConstants.USER, "ROLE_HOUSE_OWNER"])
+    fun shouldNotFindInaccessibleTasks() {
+        runWithoutAuthorization {
+            camundaProcessJsonSchemaDocumentService.startProcessForDocument(
+                StartProcessForDocumentRequest(
+                    originalDocument!!.resultingDocument().orElseThrow().id(),
+                    "conditional-candidate-group",
+                    mapOf("candidateGroup" to "ROLE_HOUSE_OWNER")
+                )
+            )
+        }
+
+        runWithoutAuthorization {
+            camundaProcessJsonSchemaDocumentService.startProcessForDocument(
+                StartProcessForDocumentRequest(
+                    originalDocument!!.resultingDocument().orElseThrow().id(),
+                    "conditional-candidate-group",
+                    mapOf("candidateGroup" to "ROLE_HOUSE_OWNER")
+                )
+            )
+        }
+
+        runWithoutAuthorization {
+            camundaProcessJsonSchemaDocumentService.startProcessForDocument(
+                StartProcessForDocumentRequest(
+                    originalDocument!!.resultingDocument().orElseThrow().id(),
+                    "conditional-candidate-group",
+                    mapOf("candidateGroup" to "ROLE_ADMIN")
+                )
+            )
+        }
+
+        val filter = SearchWithConfigRequest.SearchWithConfigFilter()
+        filter.key = "hideInaccessibleTasks"
+        filter.setValues(listOf(true))
+
+        val searchWithConfigRequest = SearchWithConfigRequest()
+        searchWithConfigRequest.otherFilters = listOf(filter)
+
+        val searchResult = caseTaskListSearchService.search("house", searchWithConfigRequest, PageRequest.of(0, 50))
+
+        assertThat(searchResult).hasSize(2)
     }
 
     @Test

--- a/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
+++ b/process-document/src/test/kotlin/com/ritense/processdocument/service/CaseTaskListSearchServiceIntTest.kt
@@ -152,21 +152,6 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
             )
         )
 
-        searchFieldV2Service.create(
-            TaskListSearchFieldV2Dto(
-                id = UUID.randomUUID(),
-                ownerId = definition!!.id!!.name(),
-                key = "hideInaccessibleTasks",
-                title = "Hide inaccessible tasks",
-                path = "task:hideInaccessibleTasks",
-                order = 1,
-                dataType = DataType.BOOLEAN,
-                fieldType = FieldType.SINGLE,
-                matchType = SearchFieldMatchType.EXACT,
-                dropdownDataProvider = null
-            )
-        )
-
         runWithoutAuthorization {
             camundaProcessJsonSchemaDocumentService.startProcessForDocument(
                 StartProcessForDocumentRequest(
@@ -284,10 +269,23 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
     @Throws(JsonProcessingException::class)
     @WithMockUser(username = "user@ritense.com", authorities = [AuthoritiesConstants.USER, "ROLE_HOUSE_OWNER"])
     fun shouldNotFindInaccessibleTasks() {
+        val museumDefinition = definition("museum")
+        val content = JsonDocumentContent("{\"street\": \"Funenpark\", \"houseNumber\": 1, \"isEnrolled\": \"yes\"}")
+
+        val museumDocument = runWithoutAuthorization<CreateDocumentResult> {
+            val result: CreateDocumentResult = documentService.createDocument(
+                NewDocumentRequest(
+                    museumDefinition!!.id().name(),
+                    content.asJson()
+                )
+            )
+            result
+        }
+
         runWithoutAuthorization {
             camundaProcessJsonSchemaDocumentService.startProcessForDocument(
                 StartProcessForDocumentRequest(
-                    originalDocument!!.resultingDocument().orElseThrow().id(),
+                    museumDocument.resultingDocument().orElseThrow().id(),
                     "conditional-candidate-group",
                     mapOf("candidateGroup" to "ROLE_HOUSE_OWNER")
                 )
@@ -297,7 +295,7 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
         runWithoutAuthorization {
             camundaProcessJsonSchemaDocumentService.startProcessForDocument(
                 StartProcessForDocumentRequest(
-                    originalDocument!!.resultingDocument().orElseThrow().id(),
+                    museumDocument.resultingDocument().orElseThrow().id(),
                     "conditional-candidate-group",
                     mapOf("candidateGroup" to "ROLE_HOUSE_OWNER")
                 )
@@ -307,12 +305,27 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
         runWithoutAuthorization {
             camundaProcessJsonSchemaDocumentService.startProcessForDocument(
                 StartProcessForDocumentRequest(
-                    originalDocument!!.resultingDocument().orElseThrow().id(),
+                    museumDocument.resultingDocument().orElseThrow().id(),
                     "conditional-candidate-group",
                     mapOf("candidateGroup" to "ROLE_ADMIN")
                 )
             )
         }
+
+        searchFieldV2Service.create(
+            TaskListSearchFieldV2Dto(
+                id = UUID.randomUUID(),
+                ownerId = museumDefinition.id!!.name(),
+                key = "hideInaccessibleTasks",
+                title = "Hide inaccessible tasks",
+                path = "task:hideInaccessibleTasks",
+                order = 1,
+                dataType = DataType.BOOLEAN,
+                fieldType = FieldType.SINGLE,
+                matchType = SearchFieldMatchType.EXACT,
+                dropdownDataProvider = null
+            )
+        )
 
         val filter = SearchWithConfigRequest.SearchWithConfigFilter()
         filter.key = "hideInaccessibleTasks"
@@ -321,7 +334,7 @@ class CaseTaskListSearchServiceIntTest : BaseIntegrationTest() {
         val searchWithConfigRequest = SearchWithConfigRequest()
         searchWithConfigRequest.otherFilters = listOf(filter)
 
-        val searchResult = caseTaskListSearchService.search("house", searchWithConfigRequest, PageRequest.of(0, 50))
+        val searchResult = caseTaskListSearchService.search("museum", searchWithConfigRequest, PageRequest.of(0, 50))
 
         assertThat(searchResult).hasSize(2)
     }

--- a/process-document/src/test/resources/bpmn/conditional-candidate-group.bpmn
+++ b/process-document/src/test/resources/bpmn/conditional-candidate-group.bpmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_12j1sji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0">
+  <bpmn:process id="conditional-candidate-group" name="Lening aanvraag process" isExecutable="true">
+    <bpmn:startEvent id="start-event" camunda:formKey="formio:new-load-request">
+      <bpmn:extensionElements>
+        <camunda:formData businessKey="emailadres">
+          <camunda:formField id="voornaam" label="Voornaam" type="string" />
+          <camunda:formField id="achternaam" label="Achternaam" type="string" />
+          <camunda:formField id="emailadres" label="Emailadres" type="string" />
+          <camunda:formField id="jaar-omzet" label="Jaar omzet" type="string" />
+          <camunda:formField id="leen-bedrag" label="Leen bedrag" type="string" />
+          <camunda:formField id="lening-startdatum" label="Startdatum lening" type="date" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_1abb79g</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end-event">
+      <bpmn:incoming>SequenceFlow_0j10547</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1abb79g" sourceRef="start-event" targetRef="form-task" />
+    <bpmn:sequenceFlow id="SequenceFlow_0j10547" sourceRef="form-task" targetRef="end-event" />
+    <bpmn:userTask id="form-task" name="Akkoord op lening?" camunda:formKey="formio:user-task" camunda:candidateGroups="${candidateGroup}">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="lening-akkoord" label="Lening akkoord?" type="boolean" />
+          <camunda:formField id="upload" label="File" type="FileUpload" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1abb79g</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0j10547</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="conditional-candidate-group">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start-event">
+        <dc:Bounds x="168" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_030pkfh_di" bpmnElement="end-event">
+        <dc:Bounds x="492" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_18proky_di" bpmnElement="form-task">
+        <dc:Bounds x="297" y="59" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1abb79g_di" bpmnElement="SequenceFlow_1abb79g">
+        <di:waypoint x="204" y="99" />
+        <di:waypoint x="297" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j10547_di" bpmnElement="SequenceFlow_0j10547">
+        <di:waypoint x="397" y="99" />
+        <di:waypoint x="492" y="99" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/process-document/src/test/resources/config/document/definition/museum.schema.json
+++ b/process-document/src/test/resources/config/document/definition/museum.schema.json
@@ -1,0 +1,18 @@
+{
+    "$id": "museum.schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Museum",
+    "type": "object",
+    "properties": {
+        "street": {
+            "type": "string",
+            "description": "The street name.",
+            "maxLength": 100
+        },
+        "housenumber": {
+            "description": "house number must be equal to or greater than zero.",
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/process-document/src/test/resources/config/pbac/all.role.json
+++ b/process-document/src/test/resources/config/pbac/all.role.json
@@ -2,6 +2,7 @@
     "changesetId": "roles-v1",
     "roles": [
         "ROLE_USER",
-        "ROLE_ADMIN"
+        "ROLE_ADMIN",
+        "ROLE_HOUSE_OWNER"
     ]
 }

--- a/process-document/src/test/resources/config/pbac/task.permission.json
+++ b/process-document/src/test/resources/config/pbac/task.permission.json
@@ -24,6 +24,25 @@
         },
         {
             "resourceType": "com.ritense.valtimo.camunda.domain.CamundaTask",
+            "action": "view",
+            "roleKey": "ROLE_HOUSE_OWNER",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.valtimo.camunda.domain.CamundaIdentityLink",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "groupId",
+                            "operator": "==",
+                            "value": "ROLE_HOUSE_OWNER"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resourceType": "com.ritense.valtimo.camunda.domain.CamundaTask",
             "action": "view_list",
             "roleKey": "ROLE_USER",
             "conditions": [
@@ -55,6 +74,25 @@
                             "field": "documentDefinitionId.name",
                             "operator": "==",
                             "value": "notahouse"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resourceType": "com.ritense.valtimo.camunda.domain.CamundaTask",
+            "action": "view_list",
+            "roleKey": "ROLE_HOUSE_OWNER",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "documentDefinitionId.name",
+                            "operator": "==",
+                            "value": "house"
                         }
                     ]
                 }

--- a/process-document/src/test/resources/config/pbac/task.permission.json
+++ b/process-document/src/test/resources/config/pbac/task.permission.json
@@ -92,7 +92,7 @@
                             "type": "field",
                             "field": "documentDefinitionId.name",
                             "operator": "==",
-                            "value": "house"
+                            "value": "museum"
                         }
                     ]
                 }


### PR DESCRIPTION
This pull request allows the creation of a task list filter that can hide tasks that are not accessible.

Currently it is possible to list tasks (using the `view_list` action) that are not accessible to users (due to not having the `view` action/permission). These tasks will be shown with a lock next to them. This is nice in a case overview, to be able to see that there is still work to do, even when you're not the one the work is assigned to.

However, these permissions apply to both the case overview and the task list. While it is nice to see these locked tasks in the case overview, it can be a hindrance in the task list. Users report that it is a hassle to find tasks they can pick up from the task overview, when many of them (in some cases the majority) are not accessible. Having the option to filter out locked tasks, can help here.

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [x] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable