### PR TITLE
Using the correct lock when uploading files in parts

### DIFF
--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -381,7 +381,7 @@ class DocumentenApiPlugin(
 
         val bestandsdelenRequest = BestandsdelenRequest(
             inhoud = inhoudAsInputStream,
-            lock = documentCreateResult.getLockFromBestandsdelen()
+            lock = documentCreateResult.getLockOrEmpty()
         )
 
         client.storeDocumentInParts(
@@ -391,7 +391,7 @@ class DocumentenApiPlugin(
             documentCreateResult,
         )
 
-        val documentLock = DocumentLock(documentCreateResult.getLockFromBestandsdelen())
+        val documentLock = DocumentLock(documentCreateResult.getLockOrEmpty())
         client.unlockInformatieObject(
             authenticationPluginConfiguration,
             URI.create(documentCreateResult.url),

--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentResult.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/CreateDocumentResult.kt
@@ -24,15 +24,10 @@ class CreateDocumentResult(
     val bestandsnaam: String,
     val bestandsomvang: Long,
     val beginRegistratie: LocalDateTime,
-    val bestandsdelen: List<Bestandsdeel>
+    val bestandsdelen: List<Bestandsdeel>,
+    val lock: String?
 ) {
-    fun getLockFromBestandsdelen(): String {
-        if (bestandsdelen.isEmpty()) {
-            return ""
-        }
-
-        return bestandsdelen[0].lock
-    }
+    fun getLockOrEmpty() = lock.orEmpty()
 
     fun getDocumentUUIDFromUrl(): String {
         return url.substring(url.lastIndexOf("/") + 1)

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/DocumentenApiPluginTest.kt
@@ -102,7 +102,8 @@ internal class DocumentenApiPluginTest {
             "returnedFileName",
             1L,
             LocalDateTime.of(2020, 1, 1, 1, 1, 1),
-            listOf()
+            listOf(),
+            null
         )
 
         whenever(executionMock.getVariable("localDocumentVariableName"))
@@ -193,7 +194,8 @@ internal class DocumentenApiPluginTest {
             "returnedFileName",
             1L,
             LocalDateTime.now(),
-            listOf()
+            listOf(),
+            null
         )
 
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR))
@@ -284,7 +286,8 @@ internal class DocumentenApiPluginTest {
             "returnedFileName",
             1L,
             LocalDateTime.now(),
-            listOf()
+            listOf(),
+            null
         )
 
         whenever(executionMock.getVariable(RESOURCE_ID_PROCESS_VAR))

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/CreateDocumentResultTest.kt
@@ -30,7 +30,8 @@ internal class CreateDocumentResultTest {
             "",
             0L,
             LocalDateTime.now(),
-            listOf()
+            listOf(),
+            null
         )
 
         assertEquals("847789d3-a8b3-469a-ae01-a49a6bd21783", result.getDocumentUUIDFromUrl())
@@ -43,7 +44,7 @@ internal class CreateDocumentResultTest {
             0,
             0,
             true,
-            "847789d3-a8b3-469a-ae01-a49a6bd21783"
+            "a894d4fc-593a-444f-821e-e2af32259e45"
         )
         val result = CreateDocumentResult(
             "",
@@ -51,10 +52,11 @@ internal class CreateDocumentResultTest {
             "",
             0L,
             LocalDateTime.now(),
-            listOf(bestandsdeel)
+            listOf(bestandsdeel),
+            "847789d3-a8b3-469a-ae01-a49a6bd21783"
         )
 
-        assertEquals("847789d3-a8b3-469a-ae01-a49a6bd21783", result.getLockFromBestandsdelen())
+        assertEquals("847789d3-a8b3-469a-ae01-a49a6bd21783", result.getLockOrEmpty())
     }
 
     @Test
@@ -65,10 +67,11 @@ internal class CreateDocumentResultTest {
             "",
             0L,
             LocalDateTime.now(),
-            listOf()
+            listOf(),
+            null
         )
 
-        assertEquals("", result.getLockFromBestandsdelen())
+        assertEquals("", result.getLockOrEmpty())
     }
 
 }

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
@@ -199,7 +199,7 @@ DocumentenApiClientTest {
                 1,
                 0,
                 false,
-                "de9c883a-cdfc-493b-9c38-5824e334a1b1"
+                "a2a4663c-44f5-447b-b9fd-0063bbc71502"
             )
         )
 
@@ -209,7 +209,8 @@ DocumentenApiClientTest {
             "bestandsnaam.jpg",
             0L,
             LocalDateTime.now(),
-            bestandsdelen
+            bestandsdelen,
+            "de9c883a-cdfc-493b-9c38-5824e334a1b1"
         )
 
         client.storeDocumentInParts(


### PR DESCRIPTION
When uploading a file to the Documenten API in parts, we are supposed to use the `lock` from the root of the object that is returned from the `storeDocument` call.

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes

For context; uploading a file to the Documenten API in parts works as follows:

1. [A POST request](https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/redoc-1.5.0#tag/enkelvoudiginformatieobjecten/operation/enkelvoudiginformatieobject_create) is made to the Documenten API containing all the relevant information, but the `inhoud` is left blank/`null`.
2. In the response of this request, we get some relevant information along with a `lock` and `bestandsdelen`.
3. The `bestandsdelen` contains information about the parts that need to be uploaded, such as the order and the size of each part, as well as a `lock` property.
4. All the parts are [independently uploaded](https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/redoc-1.5.0#tag/bestandsdelen/operation/bestandsdeel_update) and the lock that is returned by the initial POST request is passed along with each part that is being uploaded.

As you may have noticed, there are two different lock properties that are returned in the response mentioned at step 2. One in the root of the response. And one in each object of the `bestandsdelen` array. According to Maykin, they are the same and testing this locally with their Documenten API confirms that for their implementation. However another implementation by Contezza, uses a different value for both locks. According to them, the lock that should be used is the one in the root of the response of the initial POST request. This PR changes the lock we use to the one in the root object.

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable