### PR TITLE
Fix actuator loggers POST failing on missing CSRF token

### DIFF
--- a/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorSecurityFilterChainFactory.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/security/ActuatorSecurityFilterChainFactory.kt
@@ -73,6 +73,9 @@ class ActuatorSecurityFilterChainFactory {
             }
             .authenticationManager(actuatorAuthenticationManager(passwordEncoder, username, password))
             .httpBasic { it.realmName(ACTUATOR_REALM) }
+            .csrf {
+                csrfConfigurer -> csrfConfigurer.ignoringRequestMatchers("${webEndpointProperties.basePath}/loggers/**")
+            }
 
         return http.build()
     }


### PR DESCRIPTION
Excluded loggers/** endpoints from having to supply a CSRF token with its log level POST call as this is not provided by Spring Boot Admin.

Before: 
curl -v -u "admin:password" http://localhost:8080/management/loggers | jq "." | grep -A 3 "sun.rmi.transport"
returns configured level: WARN

curl -v -u "admin:password" -H 'Content-Type: application/json' -d '{"configuredLevel":"trace"}' http://localhost:8080/management/loggers/sun.rmi.transport
returns 403


After:
curl -v -u "admin:password" http://localhost:8080/management/loggers | jq "." | grep -A 3 "sun.rmi.transport"
returns configured level: WARN

curl -v -u "admin:password" -H 'Content-Type: application/json' -d '{"configuredLevel":"trace"}' http://localhost:8080/management/loggers/sun.rmi.transport
returns 204 OK

curl -v -u "admin:password" http://localhost:8080/management/loggers | jq "." | grep -A 3 "sun.rmi.transport"
returns configured level: TRACE

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Default principle](https://en.wikipedia.org/wiki/Secure_by_default) has been applied to these changes
- [ ] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable