### PR TITLE
Fix draft system issues

### DIFF
--- a/case/src/main/kotlin/com/ritense/case/repository/CaseDefinitionSpecificationHelper.kt
+++ b/case/src/main/kotlin/com/ritense/case/repository/CaseDefinitionSpecificationHelper.kt
@@ -26,6 +26,7 @@ class CaseDefinitionSpecificationHelper {
 
         const val KEY: String = "key"
         const val ACTIVE: String = "active"
+        const val FINAL: String = "final"
 
         @JvmStatic
         fun query() = Specification<CaseDefinition> { _, _, cb ->
@@ -35,6 +36,11 @@ class CaseDefinitionSpecificationHelper {
         @JvmStatic
         fun byActive(active: Boolean = true) = Specification<CaseDefinition> { root, _, cb ->
             cb.equal(root.get<Any>(ACTIVE), active)
+        }
+
+        @JvmStatic
+        fun byFinal(final: Boolean = true) = Specification<CaseDefinition> { root, _, cb ->
+            cb.equal(root.get<Any>(FINAL), final)
         }
 
         @JvmStatic

--- a/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionService.kt
+++ b/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionService.kt
@@ -25,6 +25,7 @@ import com.ritense.case.exception.UnknownCaseDefinitionException
 import com.ritense.case.repository.CaseDefinitionListColumnRepository
 import com.ritense.case.repository.CaseDefinitionSpecificationHelper.Companion.byActive
 import com.ritense.case.repository.CaseDefinitionSpecificationHelper.Companion.byCaseDefinitionKey
+import com.ritense.case.repository.CaseDefinitionSpecificationHelper.Companion.byFinal
 import com.ritense.case.repository.CaseDefinitionSpecificationHelper.Companion.query
 import com.ritense.case.service.validations.CreateCaseListColumnValidator
 import com.ritense.case.service.validations.ListColumnValidator
@@ -121,6 +122,7 @@ class CaseDefinitionService(
         applicationEventPublisher.publishEvent(
             CaseDefinitionCreatedEvent(
                 caseDefinitionId = newSavedCaseDefinition.id,
+                caseDefinitionName = newSavedCaseDefinition.name,
                 basedOnCaseDefinitionId = basedOnCaseDefinitionId,
                 duplicate = basedOnCaseDefinitionId != null
             )
@@ -150,9 +152,10 @@ class CaseDefinitionService(
     fun getCaseDefinitions(
         caseDefinitionKey: String? = null,
         active: Boolean? = null,
+        final: Boolean? = null,
         pageable: Pageable,
     ): Page<CaseDefinition> {
-        if (active == null || active == false) {
+        if (active == null || !active) {
             denyManagementOperation()
         }
 
@@ -162,6 +165,9 @@ class CaseDefinitionService(
         }
         if (active != null) {
             spec = spec.and(byActive(active))
+        }
+        if (final != null) {
+            spec = spec.and(byFinal(final))
         }
         return caseDefinitionRepository.findAll(spec, pageable)
     }

--- a/case/src/main/kotlin/com/ritense/case/web/rest/CaseDefinitionResource.kt
+++ b/case/src/main/kotlin/com/ritense/case/web/rest/CaseDefinitionResource.kt
@@ -131,12 +131,13 @@ class CaseDefinitionResource(
     fun getCaseDefinitions(
         @RequestParam caseDefinitionKey: String?,
         @RequestParam active: Boolean?,
+        @RequestParam final: Boolean?,
         @SortDefaults(
             SortDefault(sort = ["name"]),
             SortDefault(sort = ["active", "id.versionTag"], direction = Sort.Direction.DESC)
         ) pageable: Pageable
     ): ResponseEntity<Page<CaseDefinitionResponseDto>> {
-        val caseDefinitions = service.getCaseDefinitions(caseDefinitionKey, active, pageable)
+        val caseDefinitions = service.getCaseDefinitions(caseDefinitionKey, active, final, pageable)
         return ResponseEntity.ok(caseDefinitions.map { CaseDefinitionResponseDto.of(it) })
     }
 
@@ -147,7 +148,7 @@ class CaseDefinitionResource(
         @PageableDefault(size = 5, sort = ["active", "id.versionTag"], direction = Sort.Direction.DESC)
         pageable: Pageable
     ): ResponseEntity<List<CaseVersionDto>> {
-        val caseDefinitions = service.getCaseDefinitions(caseDefinitionKey, null, pageable)
+        val caseDefinitions = service.getCaseDefinitions(caseDefinitionKey, null, null, pageable)
         return ResponseEntity.ok(caseDefinitions.map { CaseVersionDto.of(it) }.content)
     }
 

--- a/case/src/main/kotlin/com/ritense/case/web/rest/dto/CaseVersionDto.kt
+++ b/case/src/main/kotlin/com/ritense/case/web/rest/dto/CaseVersionDto.kt
@@ -19,13 +19,15 @@ package com.ritense.case.web.rest.dto
 import com.ritense.case_.domain.definition.CaseDefinition
 
 data class CaseVersionDto(
-    var versionTag: String,
-    var active: Boolean,
+    val versionTag: String,
+    val active: Boolean,
+    val final: Boolean,
 ) {
     companion object {
         fun of(caseDefinition: CaseDefinition) = CaseVersionDto(
             caseDefinition.id.versionTag.version,
             caseDefinition.active,
+            caseDefinition.final,
         )
     }
 }

--- a/case/src/main/kotlin/com/ritense/document/listener/DocumentDefinitionCaseEventListener.kt
+++ b/case/src/main/kotlin/com/ritense/document/listener/DocumentDefinitionCaseEventListener.kt
@@ -43,6 +43,8 @@ class DocumentDefinitionCaseEventListener(
             service.findAllBy(event.basedOnCaseDefinitionId!!).forEach { documentDefinition ->
                 service.deploy(documentDefinition.schema().toString(), event.caseDefinitionId)
             }
+        } else {
+            service.deploy(getEmptyDocumentDefinitionSchema(event), event.caseDefinitionId)
         }
     }
 
@@ -53,5 +55,21 @@ class DocumentDefinitionCaseEventListener(
         service.findAllBy(event.caseDefinitionId).forEach { documentDefinition ->
             service.removeDocumentDefinition(documentDefinition.id().name(), documentDefinition.id().caseDefinitionId())
         }
+    }
+
+    private fun getEmptyDocumentDefinitionSchema(event: CaseDefinitionCreatedEvent): String {
+        val documentDefinitionName = event.caseDefinitionId.key
+        val schemaTitle = event.caseDefinitionName
+        return """
+            {
+                "${'$'}id": "$documentDefinitionName.schema",
+                "${'$'}schema": "http://json-schema.org/draft-07/schema#",
+                "title": "$schemaTitle",
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                }
+            }
+        """.trimIndent()
     }
 }

--- a/case/src/test/kotlin/com/ritense/case/web/rest/CaseDefinitionResourceTest.kt
+++ b/case/src/test/kotlin/com/ritense/case/web/rest/CaseDefinitionResourceTest.kt
@@ -306,7 +306,7 @@ class CaseDefinitionResourceTest : BaseTest() {
     fun `should get case definitions`() {
         val caseDefinitionId = CaseDefinitionId("key", "1.0.0")
         val caseDefinition = caseDefinition(caseDefinitionId)
-        whenever(service.getCaseDefinitions(isNull(), isNull(), any())).thenReturn(PageImpl(listOf(caseDefinition)))
+        whenever(service.getCaseDefinitions(isNull(), isNull(), isNull(), any())).thenReturn(PageImpl(listOf(caseDefinition)))
 
         mockMvc.perform(
             get("/api/management/v1/case-definition")
@@ -327,7 +327,7 @@ class CaseDefinitionResourceTest : BaseTest() {
     fun `should get case definition versions`() {
         val caseDefinitionId = CaseDefinitionId("key", "1.0.0")
         val caseDefinition = caseDefinition(caseDefinitionId, "name", true, false)
-        whenever(service.getCaseDefinitions(eq(caseDefinitionId.key), isNull(), any())).thenReturn(
+        whenever(service.getCaseDefinitions(eq(caseDefinitionId.key), isNull(), isNull(), any())).thenReturn(
             PageImpl(
                 listOf(
                     caseDefinition
@@ -346,6 +346,7 @@ class CaseDefinitionResourceTest : BaseTest() {
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].versionTag").value(caseDefinition.id.versionTag.version))
             .andExpect(jsonPath("$[0].active").value(caseDefinition.active))
+            .andExpect(jsonPath("$[0].final").value(caseDefinition.final))
     }
 
     @Test

--- a/contract/src/main/kotlin/com/ritense/valtimo/contract/event/CaseDefinitionCreatedEvent.kt
+++ b/contract/src/main/kotlin/com/ritense/valtimo/contract/event/CaseDefinitionCreatedEvent.kt
@@ -20,6 +20,7 @@ import com.ritense.valtimo.contract.case_.CaseDefinitionId
 
 data class CaseDefinitionCreatedEvent(
     val caseDefinitionId: CaseDefinitionId,
+    val caseDefinitionName: String,
     val basedOnCaseDefinitionId: CaseDefinitionId? = null,
     val duplicate: Boolean = false,
 )


### PR DESCRIPTION
- Add `final` filter
- Add `final` to endpoint response
- Creating a Draft will now automatically create an empty document definition