### PR TITLE
Using the lockID of the bestandsdelen when uploading individual bestandsdelen

### DIFF
--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/DocumentenApiPlugin.kt
@@ -379,8 +379,7 @@ class DocumentenApiPlugin(
         )
 
         val bestandsdelenRequest = BestandsdelenRequest(
-            inhoud = inhoudAsInputStream,
-            lock = documentCreateResult.getLockOrEmpty()
+            inhoud = inhoudAsInputStream
         )
 
         client.storeDocumentInParts(

--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/BestandsdelenRequest.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/client/BestandsdelenRequest.kt
@@ -19,6 +19,5 @@ package com.ritense.documentenapi.client
 import java.io.InputStream
 
 data class BestandsdelenRequest(
-    val inhoud: InputStream,
-    val lock: String
+    val inhoud: InputStream
 )

--- a/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/domain/FileUploadPart.kt
+++ b/zgw/documenten-api/src/main/kotlin/com/ritense/documentenapi/domain/FileUploadPart.kt
@@ -38,7 +38,7 @@ data class FileUploadPart(
                 "Check bestandsdeel: $bestandsdeel."
         }
 
-        return createMultiValueMap(createFileResource(chunk), bestandsdelenRequest.lock)
+        return createMultiValueMap(createFileResource(chunk), bestandsdeel.lock)
     }
 
     private fun createFileResource(chunk: ByteArray): ByteArrayResource {

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/client/DocumentenApiClientTest.kt
@@ -177,8 +177,7 @@ DocumentenApiClientTest {
         val client = DocumentenApiClient(restClientBuilder, outboxService, objectMapper, mock(), authorizationService)
 
         val request = BestandsdelenRequest(
-            inhoud = InputStream.nullInputStream(),
-            lock = UUID.randomUUID().toString()
+            inhoud = InputStream.nullInputStream()
         )
 
         val putResponseBody = """

--- a/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/domain/FileUploadPartTest.kt
+++ b/zgw/documenten-api/src/test/kotlin/com/ritense/documentenapi/domain/FileUploadPartTest.kt
@@ -24,7 +24,7 @@ class FileUploadPartTest {
             lock = "test-lock"
         )
         val inputStream: InputStream = ByteArrayInputStream(ByteArray(10) { 1 })
-        val bestandsdelenRequest = BestandsdelenRequest(inputStream, lock = "test-lock")
+        val bestandsdelenRequest = BestandsdelenRequest(inputStream)
         val fileUploadPart = FileUploadPart(bestandsdeel, bestandsdelenRequest, "testfile.txt")
 
         // Act
@@ -48,7 +48,7 @@ class FileUploadPartTest {
             lock = "test-lock"
         )
         val inputStream: InputStream = ByteArrayInputStream(ByteArray(5) { 1 })
-        val bestandsdelenRequest = BestandsdelenRequest(inputStream, lock = "test-lock")
+        val bestandsdelenRequest = BestandsdelenRequest(inputStream)
         val fileUploadPart = FileUploadPart(bestandsdeel, bestandsdelenRequest, "testfile.txt")
 
         // Act & Assert


### PR DESCRIPTION
Instead of using the lock ID of the enkelvoudig informatieobject, we should be using the one from the bestandsdelen when uploading each bestandsdeel. (We should use the lock ID of the EIO to unlock it after uploading all parts.)

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/192

Previously there was some miscommunication between the developers of the Alfresco DRC/Documenten API and us.
When uploading a file/document in parts, first an enkelvoudig informatieobject (EIO) is created, which will return a lock for the EIO, as wel as expected bestandsdelen that all also have a lock.
Initially we used the `lock` that was returned by the first bestandsdeel when uploading bestandsdelen and when unlocking the enkelvoudig informatieobject (EIO). This was fine because these values were always the same (and remain the same for the DRC of Maykin Media). Alfresco however changed this and they use different values for the EIO lock and the locks of the bestandsdelen.

Initially we understood that instead of the lock of the bestandsdelen, the lock of the EIO should be used and we changed this accordingly.
However, the issue was only\* with the unlocking of the object. We changed all locks, causing the uploads to fail. This PR fixes that. We now use the lock of the bestandsdeel when uploading one, while still using the lock of the EIO when unlocking it.

<sup>\* The issue was also that we always used the lock of the first bestandsdeel for all subsequent files. This has also been changed to use the lock of each separate bestandsdeel.</sup>

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking. (Because all currently used implementations of the documenten API use the same values for the EIO lock and the bestandsdelen locks, this isn't an issue for those implementations.)

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
