### PR TITLE
Fix error when trying to import or export a case-definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.kotlin
 /build/
 /classes/
 !gradle/wrapper/gradle-wrapper.jar

--- a/case/src/main/kotlin/com/ritense/case/security/config/CaseHttpSecurityConfigurer.kt
+++ b/case/src/main/kotlin/com/ritense/case/security/config/CaseHttpSecurityConfigurer.kt
@@ -93,7 +93,7 @@ class CaseHttpSecurityConfigurer : HttpSecurityConfigurer {
                     .requestMatchers(
                         antMatcher(
                             GET,
-                            "/api/management/v1/case/{caseDefinitionName}/{caseDefinitionVersion}/export"
+                            "/api/management/v1/case/{caseDefinitionName}/version/{caseDefinitionVersion}/export"
                         )
                     ).hasAuthority(ADMIN)
                     .requestMatchers(antMatcher(POST, "/api/management/v1/case/import")).hasAuthority(ADMIN)

--- a/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionImporter.kt
+++ b/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionImporter.kt
@@ -68,6 +68,6 @@ class CaseDefinitionImporter(
 
     private companion object {
         val logger = KotlinLogging.logger {}
-        val FILENAME_REGEX = """/case/definition/([^/]+)\.case-definition\.json""".toRegex()
+        val FILENAME_REGEX = """.*/case/definition/([^/]+)\.case-definition\.json""".toRegex()
     }
 }

--- a/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionImporter.kt
+++ b/case/src/main/kotlin/com/ritense/case/service/CaseDefinitionImporter.kt
@@ -68,6 +68,6 @@ class CaseDefinitionImporter(
 
     private companion object {
         val logger = KotlinLogging.logger {}
-        val FILENAME_REGEX = """.*/case/definition/([^/]+)\.case-definition\.json""".toRegex()
+        val FILENAME_REGEX = """/case/definition/([^/]+)\.case-definition\.json""".toRegex()
     }
 }

--- a/case/src/test/kotlin/com/ritense/case/web/rest/CaseDefinitionResourceIntTest.kt
+++ b/case/src/test/kotlin/com/ritense/case/web/rest/CaseDefinitionResourceIntTest.kt
@@ -1103,7 +1103,7 @@ class CaseDefinitionResourceIntTest : BaseIntegrationTest() {
         val caseDefinitionVersion = 1
         val result = mockMvc.perform(
             get(
-                "/api/management/v1/case/{caseDefinitionName}/{caseDefinitionVersion}/export",
+                "/api/management/v1/case/{caseDefinitionName}/version/{caseDefinitionVersion}/export",
                 caseDefinitionName, caseDefinitionVersion
             )
         ).andExpect(status().isOk)


### PR DESCRIPTION
When importing, the `fileName = "config/case/bezwaar/1-0-1/case/definition/bezwaar.case-definition.json"`

```
val FILENAME_REGEX = """/case/definition/([^/]+)\.case-definition\.json""".toRegex()
fileName.matches(FILENAME_REGEX) // <- returns false
```