### PR TITLE
Fix connecor removal

### DIFF
--- a/mail/wordpress-mail/src/main/kotlin/com/ritense/mail/wordpressmail/config/WordpressMailProperties.kt
+++ b/mail/wordpress-mail/src/main/kotlin/com/ritense/mail/wordpressmail/config/WordpressMailProperties.kt
@@ -19,5 +19,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "valtimo.wordpressmail")
 data class WordpressMailProperties(
-    val url: String
+    val url: String? = null
 )

--- a/mail/wordpress-mail/src/main/kotlin/com/ritense/mail/wordpressmail/service/WordpressMailClient.kt
+++ b/mail/wordpress-mail/src/main/kotlin/com/ritense/mail/wordpressmail/service/WordpressMailClient.kt
@@ -70,7 +70,7 @@ class WordpressMailClient(
     private fun restClient(): RestClient {
         return wordpressMailRestClientBuilder
             .clone()
-            .baseUrl(wordpressMailProperties.url)
+            .baseUrl(wordpressMailProperties.url!!)
             .build()
     }
 


### PR DESCRIPTION
```
Failed to bind properties under 'valtimo.wordpressmail' to com.ritense.mail.wordpressmail.config.WordpressMailProperties:

    Reason: java.lang.NullPointerException: Parameter specified as non-null is null: method com.ritense.mail.wordpressmail.config.WordpressMailProperties.<init>, parameter url
```