### PR TITLE
Switch to searchByUsername with 'exact' enabled when looking up a user in keycloak via it's username

### DIFF
--- a/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakUserManagementService.java
+++ b/keycloak-iam/src/main/java/com/valtimo/keycloak/service/KeycloakUserManagementService.java
@@ -161,7 +161,7 @@ public class KeycloakUserManagementService implements UserManagementService {
                         case USERID ->
                             user = keycloakService.usersResource(keycloak).get(userIdentifier).toRepresentation();
                         case USERNAME -> {
-                            var users = keycloakService.usersResource(keycloak).search(userIdentifier);
+                            var users = keycloakService.usersResource(keycloak).searchByUsername(userIdentifier, true);
                             if (!users.isEmpty()) {
                                 user = users.get(0);
                             }

--- a/keycloak-iam/src/test/java/com/valtimo/keycloak/service/KeycloakUserManagementServiceTest.java
+++ b/keycloak-iam/src/test/java/com/valtimo/keycloak/service/KeycloakUserManagementServiceTest.java
@@ -205,12 +205,12 @@ class KeycloakUserManagementServiceTest {
     void findByUserIdentifierShouldReturnUserWhenSearchingOnUsername() {
         OauthConfigHolder.getCurrentInstance().setIdentifierField(ValtimoProperties.IdentifierField.USERNAME);
 
-        when(keycloakService.usersResource(any()).search(eq(johnDoe.getUsername())))
+        when(keycloakService.usersResource(any()).searchByUsername(eq(johnDoe.getUsername()), eq(true)))
             .thenReturn(List.of(johnDoe));
 
         var user = userManagementService.findByUserIdentifier(johnDoe.getUsername());
 
-        verify(keycloakService.usersResource(any())).search(eq(johnDoe.getUsername()));
+        verify(keycloakService.usersResource(any())).searchByUsername(eq(johnDoe.getUsername()), eq(true));
         assertThat(user).isNotNull();
     }
 
@@ -221,19 +221,28 @@ class KeycloakUserManagementServiceTest {
         userManagementService.findByEmail(email);
         userManagementService.findByEmail(email);
 
-        verify(keycloakService.usersResource(any()), times(1)).search(null, null, null, email, 0, 1, true, true);
+        verify(keycloakService.usersResource(any()), times(1)).search(
+            null,
+            null,
+            null,
+            email,
+            0,
+            1,
+            true,
+            true
+        );
     }
 
     @Test
     void findByUserIdentifierShouldNotThrowAnExceptionWhenSearchingOnUsernameAndNoUserIsNotFound() {
         OauthConfigHolder.getCurrentInstance().setIdentifierField(ValtimoProperties.IdentifierField.USERNAME);
 
-        when(keycloakService.usersResource(any()).search(eq(johnDoe.getUsername())))
+        when(keycloakService.usersResource(any()).searchByUsername(eq(johnDoe.getUsername()), eq(true)))
             .thenReturn(List.of());
 
         var user = userManagementService.findByUserIdentifier(johnDoe.getUsername());
 
-        verify(keycloakService.usersResource(any())).search(eq(johnDoe.getUsername()));
+        verify(keycloakService.usersResource(any())).searchByUsername(eq(johnDoe.getUsername()), eq(true));
         assertThat(user).isNull();
     }
 


### PR DESCRIPTION
Switched to keycloak admin client searchByUsername with 'exact' enabled  when searching for user on username to prevent hits on 'overlapping' usernames.

### Describe the changes
Link to the related Github issue: 
https://github.com/valtimo-platform/valtimo-issues/issues/42

### Breaking changes
- [X] The contribution only contains changes that are not breaking.

### Tests
Unit tests have been added that cover these changes
- [X] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [X] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [X] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [X] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [X] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [X] Not applicable
