### PR TITLE
Bugfix: Don't query BPMN from other cases

### DIFF
--- a/core/src/main/java/com/ritense/valtimo/service/CamundaProcessService.java
+++ b/core/src/main/java/com/ritense/valtimo/service/CamundaProcessService.java
@@ -22,9 +22,10 @@ import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpe
 import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byActive;
 import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byKey;
 import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byLatestVersion;
-import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byNotLinkedToCaseDefinition;
-import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byVersionTag;
+import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byLatestVersionAndLinkedToCaseDefinitionId;
 import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byLatestVersionTag;
+import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byLinkedToCaseDefinitionId;
+import static com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.byNotLinkedToCaseDefinition;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.ritense.authorization.Action;
@@ -381,7 +382,7 @@ public class CamundaProcessService {
     ) {
         denyAuthorization();
         return AuthorizationContext.runWithoutAuthorization(() -> camundaRepositoryService.findProcessDefinitions(
-            byVersionTag(CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX + caseDefinitionId.toString())
+            byLinkedToCaseDefinitionId(caseDefinitionId)
                 .and(byKey(processDefinitionKey))
         ));
     }
@@ -391,11 +392,9 @@ public class CamundaProcessService {
         String processDefinitionKey
     ) {
         denyAuthorization();
-        String versionTag = CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX + caseDefinitionId.toString();
         return AuthorizationContext.runWithoutAuthorization(() -> camundaRepositoryService.findProcessDefinition(
-            byVersionTag(versionTag)
+            byLatestVersionAndLinkedToCaseDefinitionId(caseDefinitionId)
                 .and(byKey(processDefinitionKey))
-                .and(byLatestVersionTag(versionTag))
         ));
     }
 

--- a/core/src/main/kotlin/com/ritense/valtimo/camunda/repository/CamundaDecisionDefinitionSpecificationHelper.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/camunda/repository/CamundaDecisionDefinitionSpecificationHelper.kt
@@ -17,6 +17,8 @@
 package com.ritense.valtimo.camunda.repository
 
 import com.ritense.valtimo.camunda.domain.CamundaDecisionDefinition
+import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import com.ritense.valtimo.service.CamundaProcessService.CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX
 import org.springframework.data.jpa.domain.Specification
 
 class CamundaDecisionDefinitionSpecificationHelper {
@@ -54,8 +56,12 @@ class CamundaDecisionDefinitionSpecificationHelper {
         }
 
         @JvmStatic
-        fun byVersionTag(versionTag: String) = Specification<CamundaDecisionDefinition> { root, _, cb ->
-            cb.equal(root.get<Any>(VERSION_TAG), versionTag)
+        fun byVersionTag(versionTag: String?) = Specification<CamundaDecisionDefinition> { root, _, cb ->
+            if (versionTag == null) {
+                root.get<Any>(VERSION_TAG).isNull
+            } else {
+                cb.equal(root.get<Any>(VERSION_TAG), versionTag)
+            }
         }
 
         @JvmStatic
@@ -66,6 +72,37 @@ class CamundaDecisionDefinitionSpecificationHelper {
             sub.where(
                 cb.and(
                     cb.equal(subRoot.get<Any>(KEY), root.get<Any>(KEY)),
+                    cb.or(
+                        cb.equal(subRoot.get<Any>(TENANT_ID), root.get<Any>(TENANT_ID)),
+                        cb.and(subRoot.get<Any>(TENANT_ID).isNull, root.get<Any>(TENANT_ID).isNull)
+                    )
+                )
+            )
+            sub.groupBy(subRoot.get<Any>(TENANT_ID), subRoot.get<Any>(KEY))
+            cb.equal(root.get<Any>(VERSION), sub)
+        }
+
+        @JvmStatic
+        fun byLinkedToCaseDefinitionId(caseDefinitionId: CaseDefinitionId) = Specification { root, query, cb ->
+            byVersionTag(CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX + caseDefinitionId)
+                .toPredicate(root, query, cb)
+        }
+
+        @JvmStatic
+        fun byLatestVersionAndLinkedToCaseDefinitionId(caseDefinitionId: CaseDefinitionId) = Specification { root, query, cb ->
+            byLatestVersionTag(CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX + caseDefinitionId)
+                .toPredicate(root, query, cb)
+        }
+
+        @JvmStatic
+        fun byLatestVersionTag(versionTag: String?) = Specification { root, query, cb ->
+            val sub = query.subquery(Long::class.java)
+            val subRoot = sub.from(CamundaDecisionDefinition::class.java)
+            sub.select(cb.max(subRoot.get(VERSION)))
+            sub.where(
+                cb.and(
+                    cb.equal(subRoot.get<Any>(KEY), root.get<Any>(KEY)),
+                    byVersionTag(versionTag).toPredicate(root, query, cb),
                     cb.or(
                         cb.equal(subRoot.get<Any>(TENANT_ID), root.get<Any>(TENANT_ID)),
                         cb.and(subRoot.get<Any>(TENANT_ID).isNull, root.get<Any>(TENANT_ID).isNull)

--- a/core/src/main/kotlin/com/ritense/valtimo/camunda/repository/CamundaProcessDefinitionSpecificationHelper.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/camunda/repository/CamundaProcessDefinitionSpecificationHelper.kt
@@ -17,6 +17,8 @@
 package com.ritense.valtimo.camunda.repository
 
 import com.ritense.valtimo.camunda.domain.CamundaProcessDefinition
+import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import com.ritense.valtimo.service.CamundaProcessService.CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX
 import org.camunda.bpm.engine.impl.persistence.entity.SuspensionState
 import org.springframework.data.jpa.domain.Specification
 
@@ -56,8 +58,12 @@ class CamundaProcessDefinitionSpecificationHelper {
         }
 
         @JvmStatic
-        fun byVersionTag(versionTag: String) = Specification<CamundaProcessDefinition> { root, _, cb ->
-            cb.equal(root.get<Any>(VERSION_TAG), versionTag)
+        fun byVersionTag(versionTag: String?) = Specification<CamundaProcessDefinition> { root, _, cb ->
+            if (versionTag == null) {
+                root.get<Any>(VERSION_TAG).isNull
+            } else {
+                cb.equal(root.get<Any>(VERSION_TAG), versionTag)
+            }
         }
 
         @JvmStatic
@@ -79,14 +85,26 @@ class CamundaProcessDefinitionSpecificationHelper {
         }
 
         @JvmStatic
-        fun byLatestVersionTag(versionTag: String) = Specification<CamundaProcessDefinition> { root, query, cb ->
+        fun byLinkedToCaseDefinitionId(caseDefinitionId: CaseDefinitionId) = Specification { root, query, cb ->
+            byVersionTag(CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX + caseDefinitionId)
+                .toPredicate(root, query, cb)
+        }
+
+        @JvmStatic
+        fun byLatestVersionAndLinkedToCaseDefinitionId(caseDefinitionId: CaseDefinitionId) = Specification { root, query, cb ->
+            byLatestVersionTag(CAMUNDA_CASE_DEFINITION_VERSION_TAG_PREFIX + caseDefinitionId)
+                .toPredicate(root, query, cb)
+        }
+
+        @JvmStatic
+        fun byLatestVersionTag(versionTag: String?) = Specification { root, query, cb ->
             val sub = query.subquery(Long::class.java)
             val subRoot = sub.from(CamundaProcessDefinition::class.java)
             sub.select(cb.max(subRoot.get(VERSION)))
             sub.where(
                 cb.and(
                     cb.equal(subRoot.get<Any>(KEY), root.get<Any>(KEY)),
-                    cb.equal(subRoot.get<Any>(VERSION_TAG), versionTag),
+                    byVersionTag(versionTag).toPredicate(root, query, cb),
                     cb.or(
                         cb.equal(subRoot.get<Any>(TENANT_ID), root.get<Any>(TENANT_ID)),
                         cb.and(subRoot.get<Any>(TENANT_ID).isNull, root.get<Any>(TENANT_ID).isNull)

--- a/core/src/main/kotlin/com/ritense/valtimo/camunda/service/CamundaRepositoryService.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/camunda/service/CamundaRepositoryService.kt
@@ -27,8 +27,9 @@ import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionRepository
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byId
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byKey
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersion
+import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersionTag
+import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byNotLinkedToCaseDefinition
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byVersion
-import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byVersionTag
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.model.bpmn.instance.CallActivity
@@ -119,9 +120,10 @@ class CamundaRepositoryService(
                 val spec = byKey(it.calledElement)
                 when (it.camundaCalledElementBinding) {
                     "version" -> findProcessDefinition(spec.and(byVersion(it.camundaCalledElementVersion.toInt())))
-                    "versionTag" -> findProcessDefinition(spec.and(byVersionTag(it.camundaCalledElementVersionTag)))
+                    "versionTag" -> findProcessDefinition(spec.and(byLatestVersionTag(it.camundaCalledElementVersionTag)))
+                        ?: findProcessDefinition(spec.and(byNotLinkedToCaseDefinition()))
                     "deployment" -> null
-                    else -> findProcessDefinition(spec.and(byLatestVersion()))
+                    else /* latest */ -> findProcessDefinition(spec.and(byLatestVersion())) // TODO: Support case definition version
                 }
             }
             .filter { found -> !linkedProcessDefinitions.any { linked -> linked.id == found.id  } }

--- a/core/src/main/kotlin/com/ritense/valtimo/camunda/service/CamundaRepositoryService.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/camunda/service/CamundaRepositoryService.kt
@@ -123,7 +123,7 @@ class CamundaRepositoryService(
                     "versionTag" -> findProcessDefinition(spec.and(byLatestVersionTag(it.camundaCalledElementVersionTag)))
                         ?: findProcessDefinition(spec.and(byNotLinkedToCaseDefinition()))
                     "deployment" -> null
-                    else /* latest */ -> findProcessDefinition(spec.and(byLatestVersion())) // TODO: Support case definition version
+                    else /* latest */ -> findProcessDefinition(spec.and(byLatestVersion()))
                 }
             }
             .filter { found -> !linkedProcessDefinitions.any { linked -> linked.id == found.id  } }

--- a/core/src/main/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporter.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporter.kt
@@ -23,9 +23,10 @@ import com.ritense.exporter.request.DecisionDefinitionExportRequest
 import com.ritense.exporter.request.ProcessDefinitionExportRequest
 import com.ritense.valtimo.camunda.repository.CamundaDecisionDefinitionSpecificationHelper
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byKey
-import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersion
+import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersionAndLinkedToCaseDefinitionId
+import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersionTag
+import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byNotLinkedToCaseDefinition
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byVersion
-import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byVersionTag
 import com.ritense.valtimo.camunda.service.CamundaRepositoryService
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
 import org.camunda.bpm.engine.RepositoryService
@@ -77,9 +78,11 @@ class ProcessDefinitionExporter(
                 val processDefinitionId = checkNotNull(
                     when (it.camundaCalledElementBinding) {
                         "version" -> camundaRepositoryService.findProcessDefinition(spec.and(byVersion(it.camundaCalledElementVersion.toInt())))
-                        "versionTag" -> camundaRepositoryService.findProcessDefinition(spec.and(byVersionTag(it.camundaCalledElementVersionTag)))
+                        "versionTag" -> camundaRepositoryService.findProcessDefinition(spec.and(byLatestVersionTag(it.camundaCalledElementVersionTag)))
+                            ?: camundaRepositoryService.findProcessDefinition(spec.and(byNotLinkedToCaseDefinition()))
                         "deployment" -> null
-                        else -> camundaRepositoryService.findProcessDefinition(spec.and(byLatestVersion()))
+                        else /* latest */ -> camundaRepositoryService.findProcessDefinition(spec.and(byLatestVersionAndLinkedToCaseDefinitionId(caseDefinitionId)))
+                            ?: camundaRepositoryService.findProcessDefinition(spec.and(byNotLinkedToCaseDefinition()))
                     }
                 ) {
                     "Process definition with key '${it.calledElement}' could not be found!"
@@ -98,9 +101,11 @@ class ProcessDefinitionExporter(
                 val decisionDefinitionId = checkNotNull(
                     when (it.camundaDecisionRefBinding) {
                         "version" -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byVersion(it.camundaDecisionRefVersion.toInt())))
-                        "versionTag" -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byVersionTag(it.camundaDecisionRefVersionTag)))
+                        "versionTag" -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byLatestVersionTag(it.camundaDecisionRefVersionTag)))
+                            ?: camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byNotLinkedToCaseDefinition()))
                         "deployment" -> null
-                        else -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byLatestVersion()))
+                        else /* latest */ -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byLatestVersionAndLinkedToCaseDefinitionId(caseDefinitionId)))
+                            ?: camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byNotLinkedToCaseDefinition()))
                     }
                 ) {
                     "Decision definition with reference '${it.camundaDecisionRef}' could not be found!"

--- a/core/src/main/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporter.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporter.kt
@@ -23,9 +23,8 @@ import com.ritense.exporter.request.DecisionDefinitionExportRequest
 import com.ritense.exporter.request.ProcessDefinitionExportRequest
 import com.ritense.valtimo.camunda.repository.CamundaDecisionDefinitionSpecificationHelper
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byKey
-import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersionAndLinkedToCaseDefinitionId
+import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersion
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersionTag
-import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byNotLinkedToCaseDefinition
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byVersion
 import com.ritense.valtimo.camunda.service.CamundaRepositoryService
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
@@ -79,10 +78,8 @@ class ProcessDefinitionExporter(
                     when (it.camundaCalledElementBinding) {
                         "version" -> camundaRepositoryService.findProcessDefinition(spec.and(byVersion(it.camundaCalledElementVersion.toInt())))
                         "versionTag" -> camundaRepositoryService.findProcessDefinition(spec.and(byLatestVersionTag(it.camundaCalledElementVersionTag)))
-                            ?: camundaRepositoryService.findProcessDefinition(spec.and(byNotLinkedToCaseDefinition()))
                         "deployment" -> null
-                        else /* latest */ -> camundaRepositoryService.findProcessDefinition(spec.and(byLatestVersionAndLinkedToCaseDefinitionId(caseDefinitionId)))
-                            ?: camundaRepositoryService.findProcessDefinition(spec.and(byNotLinkedToCaseDefinition()))
+                        else /* latest */ -> camundaRepositoryService.findProcessDefinition(spec.and(byLatestVersion()))
                     }
                 ) {
                     "Process definition with key '${it.calledElement}' could not be found!"
@@ -102,10 +99,8 @@ class ProcessDefinitionExporter(
                     when (it.camundaDecisionRefBinding) {
                         "version" -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byVersion(it.camundaDecisionRefVersion.toInt())))
                         "versionTag" -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byLatestVersionTag(it.camundaDecisionRefVersionTag)))
-                            ?: camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byNotLinkedToCaseDefinition()))
                         "deployment" -> null
-                        else /* latest */ -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byLatestVersionAndLinkedToCaseDefinitionId(caseDefinitionId)))
-                            ?: camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byNotLinkedToCaseDefinition()))
+                        else /* latest */ -> camundaRepositoryService.findDecisionDefinition(spec.and(CamundaDecisionDefinitionSpecificationHelper.byLatestVersion()))
                     }
                 ) {
                     "Decision definition with reference '${it.camundaDecisionRef}' could not be found!"

--- a/core/src/test/java/com/ritense/valtimo/BaseIntegrationTest.java
+++ b/core/src/test/java/com/ritense/valtimo/BaseIntegrationTest.java
@@ -33,9 +33,12 @@ import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.ResourcePatternUtils;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.io.IOException;
 
 @SpringBootTest(properties = {"valtimo.outbox.enabled=true"}, classes = {CoreTestConfiguration.class})
 @ExtendWith(SpringExtension.class)
@@ -66,6 +69,9 @@ public abstract class BaseIntegrationTest {
     @MockitoSpyBean
     public TaskService camundaTaskService;
 
+    @Autowired
+    public ResourceLoader resourceLoader;
+
     @BeforeAll
     static void beforeAll() {
     }
@@ -81,6 +87,14 @@ public abstract class BaseIntegrationTest {
     public interface AuditEventListener {
         @EventListener(classes = AuditEvent.class)
         void handle(AuditEvent auditEvent);
+    }
+
+    protected String getFileAsString(String path) throws IOException {
+        return new String(
+            ResourcePatternUtils.getResourcePatternResolver(resourceLoader)
+            .getResource("classpath:" + path)
+            .getInputStream().readAllBytes()
+        );
     }
 
 }

--- a/core/src/test/java/com/ritense/valtimo/service/CamundaProcessServiceIntTest.java
+++ b/core/src/test/java/com/ritense/valtimo/service/CamundaProcessServiceIntTest.java
@@ -16,9 +16,9 @@
 
 package com.ritense.valtimo.service;
 
+import static com.ritense.authorization.AuthorizationContext.runWithoutAuthorization;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.ritense.authorization.AuthorizationContext;
 import com.ritense.valtimo.BaseIntegrationTest;
 import com.ritense.valtimo.camunda.domain.CamundaProcessDefinition;
 import com.ritense.valtimo.contract.case_.CaseDefinitionId;
@@ -67,7 +67,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
         var latestDeploymentId = findLatestProcessDefinitionDeployedProcess("deployedProcess")
             .map(CamundaProcessDefinition::getDeploymentId);
         List<Resource> processes = List.of(bpmn);
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("deployedProcess", "1.0.0"),
                 "aProcessName.bpmn",
@@ -93,8 +93,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
 
     @NotNull
     private Optional<CamundaProcessDefinition> findLatestProcessDefinitionDeployedProcess(String processName) {
-        return AuthorizationContext
-            .runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions())
+        return runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions())
             .stream()
             .filter(processDefinition -> processDefinition.getKey().equals(processName))
             .findFirst();
@@ -103,7 +102,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
     @Test
     void shouldDeployNewDmn() {
         List<Resource> tables = List.of(dmn);
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("deployedProcess", "1.0.0"),
                 "aDmnName.dmn",
@@ -120,7 +119,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
         List<Resource> testFiles = List.of(test);
         String textFileName = "aTextFile.txt";
         Assertions.assertThrows(FileExtensionNotSupportedException.class,
-            () -> AuthorizationContext.runWithoutAuthorization(() -> {
+            () -> runWithoutAuthorization(() -> {
                 camundaProcessService.deploy(
                     CaseDefinitionId.of("deployedProcess", "1.0.0"),
                     textFileName,
@@ -130,8 +129,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
             }
         ));
         List<DecisionDefinition> dmnDefinitions = repositoryService.createDecisionDefinitionQuery().list();
-        List<CamundaProcessDefinition> bpmnDefinitions = AuthorizationContext
-                .runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions());
+        List<CamundaProcessDefinition> bpmnDefinitions = runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions());
         Assertions.assertFalse(dmnDefinitions.stream().anyMatch(dmnDefinition -> dmnDefinition.getResourceName().equals(textFileName)));
         Assertions.assertFalse(bpmnDefinitions.stream().anyMatch(bpmnDefinition -> bpmnDefinition.getResourceName().equals(textFileName)));
     }
@@ -141,7 +139,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
         List<Resource> testFiles = List.of(test);
         String sampleFileName = "aFileName";
         Assertions.assertThrows(NoFileExtensionFoundException.class,
-            () -> AuthorizationContext.runWithoutAuthorization(() -> {
+            () -> runWithoutAuthorization(() -> {
                 camundaProcessService.deploy(
                     CaseDefinitionId.of("deployedProcess", "1.0.0"),
                     sampleFileName,
@@ -151,8 +149,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
                 }
             ));
         List<DecisionDefinition> dmnDefinitions = repositoryService.createDecisionDefinitionQuery().list();
-        List<CamundaProcessDefinition> bpmnDefinitions = AuthorizationContext
-                .runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions());
+        List<CamundaProcessDefinition> bpmnDefinitions = runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions());
         Assertions.assertFalse(dmnDefinitions.stream().anyMatch(dmnDefinition -> dmnDefinition.getResourceName().equals(sampleFileName)));
         Assertions.assertFalse(bpmnDefinitions.stream().anyMatch(bpmnDefinition -> bpmnDefinition.getResourceName().equals(sampleFileName)));
     }
@@ -163,12 +160,11 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
         var stream = getFileStream("systemProcess.xml", processes);
         var systemProcessModel = Bpmn.readModelFromStream(stream);
         repositoryService.createDeployment().addModelInstance("systemProcess.bpmn", systemProcessModel).deploy();
-        List<CamundaProcessDefinition> definitions = AuthorizationContext
-            .runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions());
+        List<CamundaProcessDefinition> definitions = runWithoutAuthorization(() -> camundaProcessService.getDeployedDefinitions());
         Assertions.assertTrue(definitions.stream().anyMatch(processDefinition -> processDefinition.getKey().equals("secondProcess")));
 
         Assertions.assertThrows(ProcessNotDeployableException.class,
-            () -> AuthorizationContext.runWithoutAuthorization(() -> {
+            () -> runWithoutAuthorization(() -> {
                 camundaProcessService.deploy(
                     CaseDefinitionId.of("deployedProcess", "1.0.0"),
                     "aProcessName.bpmn",
@@ -184,7 +180,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
     @Test
     void shouldDeploySameFileForDifferentCasedefinitions() throws IOException {
         List<Resource> processes = List.of(bpmn);
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-1", "1.0.0"),
                 "aProcessName.bpmn",
@@ -192,7 +188,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
             );
             return null;
         });
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-2", "1.0.0"),
                 "aProcessName.bpmn",
@@ -205,7 +201,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
     @Test
     void whenDeployingSameFileShouldNotDeployAgain() throws IOException {
         List<Resource> processes = List.of(bpmn);
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-1", "1.0.0"),
                 "aProcessName.bpmn",
@@ -213,7 +209,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
             );
             return null;
         });
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-1", "1.0.0"),
                 "aProcessName.bpmn",
@@ -233,7 +229,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
     @Test
     void shouldDeploySameFileForCasedefinitionAndUnlinked() throws IOException {
         List<Resource> processes = List.of(bpmn);
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-1", "1.0.0"),
                 "aProcessName.bpmn",
@@ -241,7 +237,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
             );
             return null;
         });
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 null,
                 "aProcessName.bpmn",
@@ -254,7 +250,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
     @Test
     void shouldDeployFileWithMultipleProcessDefinitions() throws IOException {
         List<Resource> processes = List.of(bpmn);
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-1", "1.0.0"),
                 "aProcessName.bpmn",
@@ -267,7 +263,7 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
     @Test
     void shouldDeployDifferentProcessesWithSameFilenameForSameCasedefinitions() throws IOException {
         List<Resource> processes = List.of(bpmn);
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-1", "1.0.0"),
                 "aProcessName.bpmn",
@@ -275,12 +271,59 @@ class CamundaProcessServiceIntTest extends BaseIntegrationTest {
             );
             return null;
         });
-        AuthorizationContext.runWithoutAuthorization(() -> {
+        runWithoutAuthorization(() -> {
             camundaProcessService.deploy(
                 CaseDefinitionId.of("some-case-definition-1", "1.0.0"),
                 "aProcessName.bpmn",
                 getFileStream("uniqueProcess.xml", processes)
             );
+            return null;
+        });
+    }
+
+    @Test
+    void shouldGetAllVersionsForAProcessDefinitionForASingleCaseDefinitionButNotFromOtherCaseDefinitions() throws IOException {
+        runWithoutAuthorization(() -> {
+            var caseDefinitionId = new CaseDefinitionId("everything", "1.0.0");
+            var userTaskProcessString = getFileAsString("config/case/everything/1-0-0/bpmn/user-task-process.bpmn")
+                .replace("name=\"User task process\"", "name=\"Updated User task process\"");
+            camundaProcessService.deploy(
+                caseDefinitionId,
+                "user-task-process.bpmn",
+                new ByteArrayInputStream(userTaskProcessString.getBytes())
+            );
+
+            var definitions = camundaProcessService.getDefinitionsByKeyAndCaseDefinition(
+                caseDefinitionId,
+                "user-task-process"
+            );
+
+            assertThat(definitions.size()).isEqualTo(2);
+            assertThat(definitions.stream().anyMatch(it -> "User task process".equals(it.getName()))).isTrue();
+            assertThat(definitions.stream().anyMatch(it -> "Updated User task process".equals(it.getName()))).isTrue();
+            assertThat(definitions.stream().anyMatch(it -> "Other User task process".equals(it.getName()))).isFalse();
+            return null;
+        });
+    }
+
+    @Test
+    void shouldGetLatestVersionForAProcessDefinitionForASingleCaseDefinition() throws IOException {
+        runWithoutAuthorization(() -> {
+            var caseDefinitionId = new CaseDefinitionId("everything", "1.0.0");
+            var userTaskProcessString = getFileAsString("config/case/everything/1-0-0/bpmn/user-task-process.bpmn")
+                .replace("name=\"User task process\"", "name=\"Updated User task process\"");
+            camundaProcessService.deploy(
+                caseDefinitionId,
+                "user-task-process.bpmn",
+                new ByteArrayInputStream(userTaskProcessString.getBytes())
+            );
+
+            var definition = camundaProcessService.getLatestDefinitionByKeyAndCaseDefinition(
+                caseDefinitionId,
+                "user-task-process"
+            );
+
+            assertThat(definition.getName()).isEqualTo("Updated User task process");
             return null;
         });
     }

--- a/core/src/test/kotlin/com/ritense/valtimo/camunda/repository/CamundaProcessDefinitionSpecificationHelperIntTest.kt
+++ b/core/src/test/kotlin/com/ritense/valtimo/camunda/repository/CamundaProcessDefinitionSpecificationHelperIntTest.kt
@@ -56,7 +56,7 @@ class CamundaProcessDefinitionSpecificationHelperIntTest @Autowired constructor(
 
         val resultIds = definitionRepository.findAll(
             CamundaProcessDefinitionSpecificationHelper.byKey(USER_TASK_PROCESS)
-                .and(CamundaProcessDefinitionSpecificationHelper.byVersion(2))
+                .and(CamundaProcessDefinitionSpecificationHelper.byVersion(deployedProcessDefinition.version))
         ).map { it.id }
 
         Assertions.assertThat(resultIds).contains(deployedProcessDefinition.id)

--- a/core/src/test/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporterIntTest.kt
+++ b/core/src/test/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporterIntTest.kt
@@ -24,8 +24,10 @@ import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificat
 import com.ritense.valtimo.camunda.repository.CamundaProcessDefinitionSpecificationHelper.Companion.byLatestVersion
 import com.ritense.valtimo.camunda.service.CamundaRepositoryService
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
+import com.ritense.valtimo.service.CamundaProcessService
 import org.assertj.core.api.Assertions.assertThat
 import org.camunda.bpm.engine.RepositoryService
+import org.camunda.bpm.engine.repository.DecisionDefinition
 import org.camunda.bpm.model.bpmn.Bpmn
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -33,11 +35,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 import java.io.ByteArrayInputStream
 
-@Transactional(readOnly = true)
+@Transactional
 class ProcessDefinitionExporterIntTest @Autowired constructor(
     private val repositoryService: RepositoryService,
     private val camundaRepositoryService: CamundaRepositoryService,
-    private val processDefinitionExporter: ProcessDefinitionExporter
+    private val processDefinitionExporter: ProcessDefinitionExporter,
+    private val camundaProcessService: CamundaProcessService,
 ) : BaseIntegrationTest() {
 
     @Test
@@ -63,6 +66,69 @@ class ProcessDefinitionExporterIntTest @Autowired constructor(
         assertThat(result.relatedRequests).contains(
             DecisionDefinitionExportRequest(
                 getDecisionDefinitionId("dmn-sample"),
+                CaseDefinitionId.of("everything", "1.0.0")
+            )
+        )
+
+        val dmnGlobalSample = getDecisionDefinition("dmn-global-sample")
+        assertThat(dmnGlobalSample.versionTag).isNull()
+        assertThat(result.relatedRequests).contains(
+            DecisionDefinitionExportRequest(
+                dmnGlobalSample.id,
+                CaseDefinitionId.of("everything", "1.0.0")
+            )
+        )
+
+        assertThat(result.relatedRequests).contains(
+            ProcessDefinitionExportRequest(
+                getProcessDefinitionId("test-process"), caseDefinitionId
+            )
+        )
+    }
+
+    @Test
+    fun `should export process definition with reference to latest DMN`(): Unit = runWithoutAuthorization {
+        val firstDecisionDefinitionId = getDecisionDefinitionId("dmn-sample")
+        val processDefinitionKey = "dmn-sample"
+        val processDefinitionId = getProcessDefinitionId(processDefinitionKey)
+        val caseDefinitionId = CaseDefinitionId("everything", "1.0.0")
+        val newDmnString = getFileAsString("config/case/everything/1-0-0/dmn/dmn-sample.dmn")
+            .replace("name=\"Decision 1\"", "name=\"Sample Decision\"")
+        val deployment = camundaProcessService.deploy(caseDefinitionId, "dmn-sample.dmn", newDmnString.byteInputStream())
+        val secondDecisionDefinitionId = deployment.deployedDecisionDefinitions.first().id
+
+        val result =
+            processDefinitionExporter.export(ProcessDefinitionExportRequest(processDefinitionId, caseDefinitionId))
+
+        assertThat(result.exportFiles).isNotEmpty()
+        assertThat(firstDecisionDefinitionId).isNotEqualTo(secondDecisionDefinitionId)
+        assertThat(result.relatedRequests).contains(
+            DecisionDefinitionExportRequest(
+                secondDecisionDefinitionId,
+                CaseDefinitionId.of("everything", "1.0.0")
+            )
+        )
+    }
+
+    @Test
+    fun `should export process definition with reference to overridden DMN`(): Unit = runWithoutAuthorization {
+        val globalDecisionDefinitionId = getDecisionDefinitionId("dmn-global-sample")
+        val processDefinitionKey = "dmn-sample"
+        val processDefinitionId = getProcessDefinitionId(processDefinitionKey)
+        val caseDefinitionId = CaseDefinitionId("everything", "1.0.0")
+        val newDmnString = getFileAsString("config/global/dmn/dmn-global-sample.dmn")
+            .replace("name=\"Decision 1\"", "name=\"Global Sample Decision\"")
+        val deployment = camundaProcessService.deploy(caseDefinitionId, "dmn-global-sample.dmn", newDmnString.byteInputStream())
+        val caseDecisionDefinitionId = deployment.deployedDecisionDefinitions.first().id
+
+        val result =
+            processDefinitionExporter.export(ProcessDefinitionExportRequest(processDefinitionId, caseDefinitionId))
+
+        assertThat(result.exportFiles).isNotEmpty()
+        assertThat(globalDecisionDefinitionId).isNotEqualTo(caseDecisionDefinitionId)
+        assertThat(result.relatedRequests).contains(
+            DecisionDefinitionExportRequest(
+                caseDecisionDefinitionId,
                 CaseDefinitionId.of("everything", "1.0.0")
             )
         )
@@ -104,7 +170,7 @@ class ProcessDefinitionExporterIntTest @Autowired constructor(
             assertThat(exception.message).isEqualTo("Decision definition with reference 'invalidDmnRef' could not be found!")
         }
 
-    fun getProcessDefinitionId(processDefinitionKey: String): String {
+    private fun getProcessDefinitionId(processDefinitionKey: String): String {
         return requireNotNull(
             camundaRepositoryService.findProcessDefinition(
                 byKey(processDefinitionKey)
@@ -113,11 +179,14 @@ class ProcessDefinitionExporterIntTest @Autowired constructor(
         ).id
     }
 
-    fun getDecisionDefinitionId(decisionDefinitionKey: String): String {
+    private fun getDecisionDefinition(decisionDefinitionKey: String): DecisionDefinition {
         return repositoryService.createDecisionDefinitionQuery()
             .decisionDefinitionKey(decisionDefinitionKey)
             .latestVersion()
             .singleResult()
-            .id
+    }
+
+    private fun getDecisionDefinitionId(decisionDefinitionKey: String): String {
+        return getDecisionDefinition(decisionDefinitionKey).id
     }
 }

--- a/core/src/test/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporterIntTest.kt
+++ b/core/src/test/kotlin/com/ritense/valtimo/exporter/ProcessDefinitionExporterIntTest.kt
@@ -69,21 +69,6 @@ class ProcessDefinitionExporterIntTest @Autowired constructor(
                 CaseDefinitionId.of("everything", "1.0.0")
             )
         )
-
-        val dmnGlobalSample = getDecisionDefinition("dmn-global-sample")
-        assertThat(dmnGlobalSample.versionTag).isNull()
-        assertThat(result.relatedRequests).contains(
-            DecisionDefinitionExportRequest(
-                dmnGlobalSample.id,
-                CaseDefinitionId.of("everything", "1.0.0")
-            )
-        )
-
-        assertThat(result.relatedRequests).contains(
-            ProcessDefinitionExportRequest(
-                getProcessDefinitionId("test-process"), caseDefinitionId
-            )
-        )
     }
 
     @Test
@@ -105,30 +90,6 @@ class ProcessDefinitionExporterIntTest @Autowired constructor(
         assertThat(result.relatedRequests).contains(
             DecisionDefinitionExportRequest(
                 secondDecisionDefinitionId,
-                CaseDefinitionId.of("everything", "1.0.0")
-            )
-        )
-    }
-
-    @Test
-    fun `should export process definition with reference to overridden DMN`(): Unit = runWithoutAuthorization {
-        val globalDecisionDefinitionId = getDecisionDefinitionId("dmn-global-sample")
-        val processDefinitionKey = "dmn-sample"
-        val processDefinitionId = getProcessDefinitionId(processDefinitionKey)
-        val caseDefinitionId = CaseDefinitionId("everything", "1.0.0")
-        val newDmnString = getFileAsString("config/global/dmn/dmn-global-sample.dmn")
-            .replace("name=\"Decision 1\"", "name=\"Global Sample Decision\"")
-        val deployment = camundaProcessService.deploy(caseDefinitionId, "dmn-global-sample.dmn", newDmnString.byteInputStream())
-        val caseDecisionDefinitionId = deployment.deployedDecisionDefinitions.first().id
-
-        val result =
-            processDefinitionExporter.export(ProcessDefinitionExportRequest(processDefinitionId, caseDefinitionId))
-
-        assertThat(result.exportFiles).isNotEmpty()
-        assertThat(globalDecisionDefinitionId).isNotEqualTo(caseDecisionDefinitionId)
-        assertThat(result.relatedRequests).contains(
-            DecisionDefinitionExportRequest(
-                caseDecisionDefinitionId,
                 CaseDefinitionId.of("everything", "1.0.0")
             )
         )

--- a/core/src/test/resources/config/case/everything/1-0-0/bpmn/dmn-sample.bpmn
+++ b/core/src/test/resources/config/case/everything/1-0-0/bpmn/dmn-sample.bpmn
@@ -8,7 +8,7 @@
     <bpmn:endEvent id="endEvent">
       <bpmn:incoming>Flow_1u3af6x</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:businessRuleTask id="dmnTask" name="DMN task" camunda:decisionRef="dmn-global-sample">
+    <bpmn:businessRuleTask id="dmnTask" name="DMN task" camunda:decisionRef="dmn-sample">
       <bpmn:incoming>Flow_1rc1m35</bpmn:incoming>
       <bpmn:outgoing>Flow_0axe6y3</bpmn:outgoing>
     </bpmn:businessRuleTask>

--- a/core/src/test/resources/config/case/everything/1-0-0/bpmn/dmn-sample.bpmn
+++ b/core/src/test/resources/config/case/everything/1-0-0/bpmn/dmn-sample.bpmn
@@ -8,7 +8,7 @@
     <bpmn:endEvent id="endEvent">
       <bpmn:incoming>Flow_1u3af6x</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:businessRuleTask id="dmnTask" name="DMN task" camunda:decisionRef="dmn-sample">
+    <bpmn:businessRuleTask id="dmnTask" name="DMN task" camunda:decisionRef="dmn-global-sample">
       <bpmn:incoming>Flow_1rc1m35</bpmn:incoming>
       <bpmn:outgoing>Flow_0axe6y3</bpmn:outgoing>
     </bpmn:businessRuleTask>

--- a/core/src/test/resources/config/case/other/1-0-0/bpmn/user-task-process.bpmn
+++ b/core/src/test/resources/config/case/other/1-0-0/bpmn/user-task-process.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1qofjly" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+  <bpmn:process id="user-task-process" name="Other User task process" isExecutable="true">
+    <bpmn:startEvent id="start-event">
+      <bpmn:outgoing>sequence-flow-1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sequence-flow-1" sourceRef="start-event" targetRef="user-do-something" />
+    <bpmn:endEvent id="end-event">
+      <bpmn:incoming>sequence-flow-2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="sequence-flow-2" sourceRef="user-do-something" targetRef="end-event" />
+    <bpmn:userTask id="user-do-something" name="User do something" camunda:candidateGroups="ROLE_ADMIN">
+      <bpmn:incoming>sequence-flow-1</bpmn:incoming>
+      <bpmn:outgoing>sequence-flow-2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="user-task-process">
+      <bpmndi:BPMNEdge id="SequenceFlow_1gkaz89_di" bpmnElement="sequence-flow-2">
+        <di:waypoint x="400" y="120" />
+        <di:waypoint x="491" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0obzkuw_di" bpmnElement="sequence-flow-1">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="300" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start-event">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0hzhcsl_di" bpmnElement="end-event">
+        <dc:Bounds x="491" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_0flb6n1_di" bpmnElement="user-do-something">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/core/src/test/resources/config/case/other/1-0-0/case/definition/other.case-definition.json
+++ b/core/src/test/resources/config/case/other/1-0-0/case/definition/other.case-definition.json
@@ -1,0 +1,7 @@
+{
+    "key": "other",
+    "name": "Other",
+    "versionTag": "1.0.0",
+    "canHaveAssignee": true,
+    "autoAssignTasks": true
+}

--- a/form/src/test/java/com/ritense/form/service/impl/FormIoFormDefinitionServiceIntTest.java
+++ b/form/src/test/java/com/ritense/form/service/impl/FormIoFormDefinitionServiceIntTest.java
@@ -24,8 +24,6 @@ import com.ritense.form.domain.FormIoFormDefinition;
 import com.ritense.form.domain.request.CreateFormDefinitionRequest;
 import com.ritense.form.domain.request.ModifyFormDefinitionRequest;
 import java.util.Optional;
-import com.ritense.valtimo.contract.case_.CaseDefinitionChecker;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,14 +31,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 class FormIoFormDefinitionServiceIntTest extends BaseIntegrationTest {
 
-    private FormIoFormDefinitionService formIoFormDefinitionService;
     @Autowired
-    private CaseDefinitionChecker caseDefinitionChecker;
-
-    @BeforeEach
-    void setUp() {
-        formIoFormDefinitionService = new FormIoFormDefinitionService(formDefinitionRepository, caseDefinitionChecker);
-    }
+    private FormIoFormDefinitionService formIoFormDefinitionService;
 
     @Test
     void shouldCreateFormDefinition() {


### PR DESCRIPTION
Problem: `byLatestVersion()` can give you BPMNs from other cases