### PR TITLE
Adding a plugin action to add a zaak to the `relevanteAndereZaken` of the current (Open Zaken) zaak.

### DIFF
--- a/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -38,6 +38,7 @@ import com.ritense.zakenapi.domain.CreateZaakStatusRequest
 import com.ritense.zakenapi.domain.CreateZaakeigenschapRequest
 import com.ritense.zakenapi.domain.Opschorting
 import com.ritense.zakenapi.domain.PatchZaakRequest
+import com.ritense.zakenapi.domain.RelevanteZaak
 import com.ritense.zakenapi.domain.UpdateZaakeigenschapRequest
 import com.ritense.zakenapi.domain.Verlenging
 import com.ritense.zakenapi.domain.ZaakHersteltermijn
@@ -598,6 +599,44 @@ class ZakenApiPlugin(
                 .filter { it.eigenschap == eigenschapUrl }
                 .forEach { client.deleteZaakeigenschap(authenticationPluginConfiguration, url, it.url) }
             logger.info { "Zaakeigenschap with URL '${eigenschapUrl}' deleted for zaak with URL '$zaakUrl' and document with id '${documentId}'" }
+        }
+    }
+
+    @PluginAction(
+        key = "relateer-zaken",
+        title = "Add a zaak to relevanteAndereZaken",
+        description = "This adds the provided (via the action property) zaak to the relevanteAndereZaken of the current zaak",
+        activityTypes = [SERVICE_TASK_START]
+    )
+    fun relateerZaken(
+        execution: DelegateExecution,
+        @PluginActionProperty teRelaterenZaakUri: URI,
+        @PluginActionProperty aardRelatie: String,
+    ) {
+        logger.debug { "Making relation between the current zaak and the zaak with URL '$teRelaterenZaakUri'" }
+        val documentId = UUID.fromString(execution.businessKey)
+        val zaakUrl = zaakUrlProvider.getZaakUrl(documentId)
+
+        addZaakToRelevanteAndereZaken(zaakUrl, teRelaterenZaakUri, aardRelatie)
+
+        logger.info { "Created a relation between the current zaak '$zaakUrl' and the provided zaak '$teRelaterenZaakUri'" }
+    }
+
+    private fun addZaakToRelevanteAndereZaken(zaakUrl: URI, teRelaterenZaakUri: URI, aardRelatie: String) {
+        logger.trace { "Fetching zaak with URL '$zaakUrl' to determine existing relevanteAndereZaken" }
+
+        val currentZaak = client.getZaak(authenticationPluginConfiguration, zaakUrl)
+        val currentRelevanteAndereZaken = currentZaak.relevanteAndereZaken?.toMutableList() ?: mutableListOf()
+
+        if (currentRelevanteAndereZaken.none { relevanteZaak -> relevanteZaak.url == currentZaak.url }) {
+            currentRelevanteAndereZaken.add(RelevanteZaak(teRelaterenZaakUri, aardRelatie))
+
+            logger.trace { "Sending patch request add the zaak with URL '$teRelaterenZaakUri' to the relevanteAndereZaken of zaak with URL '$zaakUrl'" }
+            client.patchZaak(
+                authenticationPluginConfiguration, url, zaakUrl, PatchZaakRequest(
+                    relevanteAndereZaken = currentRelevanteAndereZaken
+                )
+            )
         }
     }
 

--- a/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -61,6 +61,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 
 internal class ZakenApiPluginTest {
 
@@ -1063,6 +1064,69 @@ internal class ZakenApiPluginTest {
 
         // then
         verify(zakenApiClient).deleteZaakeigenschap(any(), any(), any())
+    }
+
+    @Test
+    fun `should relateer zaken`() {
+
+        // given
+        val zakenApiClient: ZakenApiClient = mock()
+        val zaakUrlProvider: ZaakUrlProvider = mock()
+        val storageService: TemporaryResourceStorageService = mock()
+        val zaakInstanceLinkRepository: ZaakInstanceLinkRepository = mock()
+        val pluginService: PluginService = mock()
+        val zaakHersteltermijnRepository: ZaakHersteltermijnRepository = mock()
+        val platformTransactionManager: PlatformTransactionManager = mock()
+        val documentService: DocumentService = mock()
+        val processDocumentAssociationService: ProcessDocumentAssociationService = mock()
+        val authenticationMock = mock<ZakenApiAuthentication>()
+        val executionMock = mock<DelegateExecution>()
+        val zaakResponseMock: ZaakResponse = mock()
+
+        val documentId = UUID.randomUUID()
+        val zaakUrl = URI("https://example.com/zaken/1234")
+
+        val teRelaterenZaakUri = URI("https://example.com/zaken/5678")
+        val aardRelatie = "vervolg"
+
+        whenever(executionMock.businessKey).thenReturn(documentId.toString())
+        whenever(zaakUrlProvider.getZaakUrl(documentId)).thenReturn(zaakUrl)
+        whenever(zaakResponseMock.relevanteAndereZaken).thenReturn(listOf())
+        whenever(zakenApiClient.getZaak(authenticationMock, zaakUrl)).thenReturn(zaakResponseMock)
+
+        val plugin = ZakenApiPlugin(
+            zakenApiClient,
+            zaakUrlProvider,
+            storageService,
+            zaakInstanceLinkRepository,
+            pluginService,
+            zaakHersteltermijnRepository,
+            platformTransactionManager,
+            documentService,
+            processDocumentAssociationService
+        )
+        plugin.url = URI("https://zaken.plugin.url")
+        plugin.authenticationPluginConfiguration = authenticationMock
+
+        // when
+        plugin.relateerZaken(
+            execution = executionMock,
+            teRelaterenZaakUri = teRelaterenZaakUri,
+            aardRelatie = aardRelatie
+        )
+
+        // then
+        val captor = argumentCaptor<PatchZaakRequest>()
+        verify(zakenApiClient).patchZaak(
+            eq(authenticationMock),
+            eq(plugin.url),
+            eq(zaakUrl),
+            captor.capture())
+
+        val relevanteAndereZaken = captor.firstValue.relevanteAndereZaken
+        assertThat(relevanteAndereZaken).hasSize(1)
+        assertThat(relevanteAndereZaken!![0].url).isEqualTo(teRelaterenZaakUri)
+        assertThat(relevanteAndereZaken[0].aardRelatie).isEqualTo(aardRelatie)
     }
 
     @Test


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/196

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:** Related frontend-libraries PR: https://github.com/valtimo-platform/valtimo-frontend-libraries/pull/1482

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [x] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
