### PR TITLE
Revert "Fix `pv:` for finished processes (#1727)"

### DIFF
--- a/plugin/src/test/kotlin/com/ritense/plugin/BaseIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/ritense/plugin/BaseIntegrationTest.kt
@@ -17,7 +17,6 @@
 package com.ritense.plugin
 
 import com.ritense.valtimo.contract.authentication.UserManagementService
-import org.camunda.bpm.engine.HistoryService
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
@@ -30,7 +29,4 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 class BaseIntegrationTest {
     @MockBean
     lateinit var userManagementService: UserManagementService
-
-    @MockBean
-    lateinit var historyService: HistoryService
 }

--- a/value-resolver/src/main/kotlin/com/ritense/valueresolver/ProcessVariableValueResolverFactory.kt
+++ b/value-resolver/src/main/kotlin/com/ritense/valueresolver/ProcessVariableValueResolverFactory.kt
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.module.kotlin.treeToValue
 import com.flipkart.zjsonpatch.JsonPatch
 import com.ritense.valtimo.contract.json.patch.JsonPatchBuilder
 import org.camunda.bpm.engine.RuntimeService
-import org.camunda.bpm.engine.HistoryService
 import org.camunda.bpm.engine.delegate.VariableScope
+import org.camunda.bpm.engine.impl.context.Context
 import java.util.function.Function
 
 /**
@@ -34,7 +34,6 @@ import java.util.function.Function
  */
 class ProcessVariableValueResolverFactory(
     private val runtimeService: RuntimeService,
-    private val historicService: HistoryService,
     private val objectMapper: ObjectMapper,
 ) : ValueResolverFactory {
 
@@ -63,7 +62,7 @@ class ProcessVariableValueResolverFactory(
     }
 
     override fun createResolver(documentId: String): Function<String, Any?> {
-        val processInstanceIds = historicService.createHistoricProcessInstanceQuery()
+        val processInstanceIds = runtimeService.createProcessInstanceQuery()
             .processInstanceBusinessKey(documentId)
             .list()
             .map { it.id }
@@ -71,7 +70,7 @@ class ProcessVariableValueResolverFactory(
 
         return Function { requestedValue ->
             val jsonPointer = toJsonPointer(requestedValue)
-            val values = historicService.createHistoricVariableInstanceQuery()
+            val values = runtimeService.createVariableInstanceQuery()
                 .processInstanceIdIn(*processInstanceIds)
                 .variableName(jsonPointer.matchingProperty)
                 .list()

--- a/value-resolver/src/main/kotlin/com/ritense/valueresolver/autoconfiguration/ValueResolverAutoConfiguration.kt
+++ b/value-resolver/src/main/kotlin/com/ritense/valueresolver/autoconfiguration/ValueResolverAutoConfiguration.kt
@@ -24,7 +24,6 @@ import com.ritense.valueresolver.ValueResolverService
 import com.ritense.valueresolver.ValueResolverServiceImpl
 import com.ritense.valueresolver.security.config.ValueResolverHttpSecurityConfigurer
 import com.ritense.valueresolver.web.rest.ValueResolverResource
-import org.camunda.bpm.engine.HistoryService
 import org.camunda.bpm.engine.RuntimeService
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -67,10 +66,9 @@ class ValueResolverAutoConfiguration {
     @ConditionalOnMissingBean(ProcessVariableValueResolverFactory::class)
     fun processVariableValueResolver(
         runtimeService: RuntimeService,
-        historyService: HistoryService,
         objectMapper: ObjectMapper,
     ): ValueResolverFactory {
-        return ProcessVariableValueResolverFactory(runtimeService, historyService, objectMapper)
+        return ProcessVariableValueResolverFactory(runtimeService, objectMapper)
     }
 
     @Bean

--- a/value-resolver/src/test/kotlin/com/ritense/valueresolver/ProcessVariableValueResolverTest.kt
+++ b/value-resolver/src/test/kotlin/com/ritense/valueresolver/ProcessVariableValueResolverTest.kt
@@ -23,15 +23,13 @@ import com.ritense.valtimo.contract.json.MapperSingleton
 import java.time.LocalDate
 import java.util.UUID
 import org.assertj.core.api.Assertions
-import org.camunda.bpm.engine.HistoryService
 import org.camunda.bpm.engine.RuntimeService
 import org.camunda.bpm.engine.impl.context.Context
 import org.camunda.bpm.engine.impl.interceptor.CommandContext
+import org.camunda.bpm.engine.variable.Variables
 import org.camunda.bpm.engine.variable.impl.value.ObjectValueImpl
 import org.camunda.bpm.engine.variable.impl.value.builder.SerializedObjectValueBuilderImpl
 import org.camunda.community.mockito.delegate.DelegateCaseVariableInstanceFake
-import org.camunda.bpm.engine.history.HistoricProcessInstance
-import org.camunda.bpm.engine.history.HistoricVariableInstance
 import org.camunda.community.mockito.delegate.DelegateTaskFake
 import org.camunda.community.mockito.process.ProcessInstanceFake
 import org.junit.jupiter.api.BeforeEach
@@ -43,13 +41,8 @@ import org.mockito.kotlin.whenever
 
 internal class ProcessVariableValueResolverTest {
     private val runtimeService: RuntimeService = mock(defaultAnswer = RETURNS_DEEP_STUBS)
-    private val historyService: HistoryService = mock(defaultAnswer = RETURNS_DEEP_STUBS)
     private val objectMapper = MapperSingleton.get()
-    private val processVariableValueResolver = ProcessVariableValueResolverFactory(
-        runtimeService,
-        historyService,
-        objectMapper
-    )
+    private val processVariableValueResolver = ProcessVariableValueResolverFactory(runtimeService, objectMapper)
 
     @BeforeEach
     fun setUp() {
@@ -152,13 +145,11 @@ internal class ProcessVariableValueResolverTest {
     fun `should resolve requestedValue from process variables by document ID`() {
         val somePropertyName = "somePropertyName"
         val documentInstanceId = UUID.randomUUID().toString()
-        val processInstance = mock<HistoricProcessInstance>()
-        whenever(processInstance.id).thenReturn(UUID.randomUUID().toString())
-        whenever(historyService.createHistoricProcessInstanceQuery().processInstanceBusinessKey(documentInstanceId).list())
+        val processInstance = ProcessInstanceFake.builder().processInstanceId(UUID.randomUUID().toString()).build()
+        whenever(runtimeService.createProcessInstanceQuery().processInstanceBusinessKey(documentInstanceId).list())
             .thenReturn(listOf(processInstance))
-        val variableInstance = mock<HistoricVariableInstance>()
-        whenever(variableInstance.value).thenReturn(true)
-        whenever(historyService.createHistoricVariableInstanceQuery()
+        val variableInstance = DelegateCaseVariableInstanceFake().create(somePropertyName, Variables.booleanValue(true))
+        whenever(runtimeService.createVariableInstanceQuery()
             .processInstanceIdIn(processInstance.id)
             .variableName(somePropertyName)
             .list())
@@ -187,14 +178,14 @@ internal class ProcessVariableValueResolverTest {
                 }
             """)
         val documentInstanceId = UUID.randomUUID().toString()
-        val processInstance: HistoricProcessInstance = mock()
-        whenever(processInstance.id).thenReturn(UUID.randomUUID().toString())
-        whenever(historyService.createHistoricProcessInstanceQuery().processInstanceBusinessKey(documentInstanceId).list())
+        val processInstance = ProcessInstanceFake.builder().processInstanceId(UUID.randomUUID().toString()).build()
+        whenever(runtimeService.createProcessInstanceQuery().processInstanceBusinessKey(documentInstanceId).list())
             .thenReturn(listOf(processInstance))
-        val variableInstance: HistoricVariableInstance = mock()
-        whenever(variableInstance.name).thenReturn("person")
-        whenever(variableInstance.value).thenReturn(personVariable)
-        whenever(historyService.createHistoricVariableInstanceQuery()
+        val variableInstance = DelegateCaseVariableInstanceFake().create(
+            "person",
+            SerializedObjectValueBuilderImpl(ObjectValueImpl(personVariable)).create()
+        )
+        whenever(runtimeService.createVariableInstanceQuery()
             .processInstanceIdIn(processInstance.id)
             .variableName("person")
             .list())

--- a/value-resolver/src/test/kotlin/com/ritense/valueresolver/ValueResolverFactoryServiceImplTest.kt
+++ b/value-resolver/src/test/kotlin/com/ritense/valueresolver/ValueResolverFactoryServiceImplTest.kt
@@ -19,7 +19,6 @@ package com.ritense.valueresolver
 import com.ritense.valtimo.contract.json.MapperSingleton
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
-import org.camunda.bpm.engine.HistoryService
 import org.camunda.bpm.engine.RuntimeService
 import org.camunda.community.mockito.delegate.DelegateTaskFake
 import org.junit.jupiter.api.Test
@@ -30,10 +29,9 @@ import org.mockito.kotlin.verify
 internal class ValueResolverFactoryServiceImplTest {
 
     private val runtimeService: RuntimeService = mock()
-    private val historyService: HistoryService = mock()
     private val objectMapper = MapperSingleton.get()
     private val resolverService = ValueResolverServiceImpl(
-        listOf(ProcessVariableValueResolverFactory(runtimeService, historyService, objectMapper), FixedValueResolverFactory())
+        listOf(ProcessVariableValueResolverFactory(runtimeService, objectMapper), FixedValueResolverFactory())
     )
 
     @Test
@@ -41,8 +39,8 @@ internal class ValueResolverFactoryServiceImplTest {
         val exception = assertThrows<RuntimeException> {
             val resolverService = ValueResolverServiceImpl(
                 listOf(
-                    ProcessVariableValueResolverFactory(runtimeService, historyService, objectMapper),
-                    ProcessVariableValueResolverFactory(runtimeService, historyService, objectMapper)
+                    ProcessVariableValueResolverFactory(runtimeService, objectMapper),
+                    ProcessVariableValueResolverFactory(runtimeService, objectMapper)
                 )
             )
 


### PR DESCRIPTION
This reverts commit 2751cec78987dc50f667918ecfff0f68cf6e5f59.

<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [ ] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [ ] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [ ] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [ ] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [ ] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [ ] Not applicable
