### PR TITLE
Add logging for unsupported process-link activity type

### DIFF
--- a/process-link/src/main/kotlin/com/ritense/processlink/service/ProcessLinkService.kt
+++ b/process-link/src/main/kotlin/com/ritense/processlink/service/ProcessLinkService.kt
@@ -150,6 +150,7 @@ class ProcessLinkService(
 
     fun getSupportedProcessLinkTypes(activityType: String): List<ProcessLinkType> {
         if (!ActivityTypeWithEventName.contains(activityType)) {
+            logger.warn { "Unsupported activity type: $activityType" }
             return emptyList()
         }
         return processLinkTypes.mapNotNull {


### PR DESCRIPTION
## Summary
- log and return empty list if process-link activity type is not recognized

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68404e9e7b0c8326b211d7fb59bba4d9