### PR TITLE
fix: don't throw error when no summary form found

### DIFF
--- a/app/gzac/build.gradle
+++ b/app/gzac/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation(project(":logging"))
     implementation(project(":zgw:portaaltaak"))
     implementation(project(":outbox:outbox-rabbitmq"))
+    implementation(project(":process-link-url"))
 
     implementation("io.github.oshai:kotlin-logging")
 

--- a/form/src/main/kotlin/com/ritense/form/web/rest/FormResource.kt
+++ b/form/src/main/kotlin/com/ritense/form/web/rest/FormResource.kt
@@ -72,16 +72,25 @@ class FormResource(
         @PathVariable formKey: String,
         @LoggableResource(resourceType = JsonSchemaDocument::class) @RequestParam(required = false) documentId: UUID?,
     ): ResponseEntity<JsonNode> {
-        return if (documentId != null) {
-            val document = documentService.get(documentId.toString())
-            val formDefinition = formDefinitionService
-                .getFormDefinitionByName(formKey, document.definitionId().caseDefinitionId()).orElse(null)
-            ResponseEntity.ok(
-                prefillFormService.getPrefilledFormDefinition(formDefinition.id, documentId).formDefinition
-            )
-        } else {
-            ResponseEntity.notFound().build()
+        if (documentId == null) {
+            return ResponseEntity.notFound().build()
         }
+
+        val document = documentService.get(documentId.toString())
+
+        val formDefinition = formDefinitionService
+            .getFormDefinitionByName(formKey, document.definitionId().caseDefinitionId())
+            .orElse(null)
+
+        if (formDefinition == null) {
+            return ResponseEntity.notFound().build()
+        }
+
+        val prefilledForm = prefillFormService
+            .getPrefilledFormDefinition(formDefinition.id, documentId)
+            .formDefinition
+
+        return ResponseEntity.ok(prefilledForm)
     }
 
     fun <T : FormSubmissionResult?> applyResult(result: T): ResponseEntity<T> {


### PR DESCRIPTION
closes https://ritense.tpondemand.com/entity/139294-be-not-existing-summary-tab-throws