### PR TITLE
updated catalogi endpoints to work based on case definition key and version tag

### DIFF
--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiAutoConfiguration.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/CatalogiApiAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.catalogiapi
 
+import com.ritense.case.service.CaseDefinitionService
 import com.ritense.case_.service.ActiveCaseDefinitionService
 import com.ritense.catalogiapi.client.CatalogiApiClient
 import com.ritense.catalogiapi.security.CatalogiApiHttpSecurityConfigurer
@@ -68,10 +69,14 @@ class CatalogiApiAutoConfiguration {
     @ConditionalOnMissingBean(CatalogiResource::class)
     fun catalogiResource(
         catalogiService: CatalogiService,
-        activeCaseDefinitionService: ActiveCaseDefinitionService
+        activeCaseDefinitionService: ActiveCaseDefinitionService,
+        caseDefinitionService: CaseDefinitionService,
+        documentService: DocumentService
     ) = CatalogiResource(
         catalogiService,
-        activeCaseDefinitionService
+        activeCaseDefinitionService,
+        caseDefinitionService,
+        documentService
     )
 
     @Order(400)

--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/security/CatalogiApiHttpSecurityConfigurer.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/security/CatalogiApiHttpSecurityConfigurer.kt
@@ -28,14 +28,15 @@ class CatalogiApiHttpSecurityConfigurer : HttpSecurityConfigurer {
     override fun configure(http: HttpSecurity) {
         try {
             http.authorizeHttpRequests { requests ->
-                requests.requestMatchers(antMatcher(GET, "/api/v1/case-definition/{documentDefinitionKey}/zaaktype/documenttype")).authenticated()
-                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{documentDefinitionKey}/zaaktype/roltype")).authenticated()
-                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{documentDefinitionKey}/zaaktype/statustype")).authenticated()
-                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{documentDefinitionKey}/zaaktype/resultaattype")).authenticated()
-                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{documentDefinitionKey}/zaaktype/besluittype")).authenticated()
+                requests.requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/documenttype")).authenticated()
+                requests.requestMatchers(antMatcher(GET, "/api/v1/document/{documentId}/zaaktype/documenttype")).authenticated()
+                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/roltype")).authenticated()
+                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/statustype")).authenticated()
+                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/resultaattype")).authenticated()
+                    .requestMatchers(antMatcher(GET, "/api/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/besluittype")).authenticated()
 
                     .requestMatchers(antMatcher(GET, "/api/management/v1/zgw/zaaktype")).hasAuthority(ADMIN)
-                    .requestMatchers(antMatcher(GET, "/api/management/v1/case-definition/{documentDefinitionKey}/catalogi-eigenschappen")).hasAuthority(ADMIN)
+                    .requestMatchers(antMatcher(GET, "/api/management/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/catalogi-eigenschappen")).hasAuthority(ADMIN)
             }
         } catch (e: Exception) {
             throw HttpConfigurerConfigurationException(e)

--- a/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/web/rest/CatalogiResource.kt
+++ b/zgw/catalogi-api/src/main/kotlin/com/ritense/catalogiapi/web/rest/CatalogiResource.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.catalogiapi.web.rest
 
+import com.ritense.case.service.CaseDefinitionService
 import com.ritense.case_.service.ActiveCaseDefinitionService
 import com.ritense.catalogiapi.service.CatalogiService
 import com.ritense.catalogiapi.web.rest.result.BesluittypeDto
@@ -25,6 +26,9 @@ import com.ritense.catalogiapi.web.rest.result.ResultaattypeDto
 import com.ritense.catalogiapi.web.rest.result.RoltypeDto
 import com.ritense.catalogiapi.web.rest.result.StatustypeDto
 import com.ritense.catalogiapi.web.rest.result.ZaaktypeDto
+import com.ritense.document.domain.impl.JsonSchemaDocument
+import com.ritense.document.domain.impl.JsonSchemaDocumentId
+import com.ritense.document.service.DocumentService
 import com.ritense.logging.LoggableResource
 import com.ritense.valtimo.contract.annotation.SkipComponentScan
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
@@ -36,19 +40,24 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 @SkipComponentScan
 @RequestMapping("/api", produces = [APPLICATION_JSON_UTF8_VALUE])
 class CatalogiResource(
     private val catalogiService: CatalogiService,
-    private val activeCaseDefinitionService: ActiveCaseDefinitionService
+    private val activeCaseDefinitionService: ActiveCaseDefinitionService,
+    private val caseDefinitionService: CaseDefinitionService,
+    private val documentService: DocumentService
 ) {
-    @GetMapping("/v1/case-definition/{caseDefinitionKey}/zaaktype/documenttype")
+    @GetMapping("/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/documenttype")
     fun getZaakObjecttypes(
         @LoggableResource("caseDefinitionKey") @PathVariable(name = "caseDefinitionKey") caseDefinitionKey: String,
+        @LoggableResource("caseDefinitionVersionTag") @PathVariable(name = "versionTag") caseDefinitionVersionTag: String,
     ): ResponseEntity<List<InformatieobjecttypeDto>> {
-        val caseDefinitionId = activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey).id
+        val caseDefinitionId =
+            caseDefinitionService.getCaseDefinition(CaseDefinitionId.of(caseDefinitionKey, caseDefinitionVersionTag)).id
         val zaakObjectTypes =
             catalogiService.getInformatieobjecttypes(caseDefinitionId).map {
                 InformatieobjecttypeDto(
@@ -59,6 +68,23 @@ class CatalogiResource(
         return ResponseEntity.ok(zaakObjectTypes)
     }
 
+    @GetMapping("/v1/document/{documentId}/zaaktype/documenttype")
+    fun getZaakObjecttypes(
+        @LoggableResource(resourceType = JsonSchemaDocument::class) @PathVariable documentId: UUID,
+    ): ResponseEntity<List<InformatieobjecttypeDto>> {
+        val caseDefinitionId =
+            documentService.findBy(JsonSchemaDocumentId.existingId(documentId)).get().definitionId().caseDefinitionId()
+        val zaakObjectTypes =
+            catalogiService.getInformatieobjecttypes(caseDefinitionId).map {
+                InformatieobjecttypeDto(
+                    it.url!!,
+                    it.omschrijving
+                )
+            }
+        return ResponseEntity.ok(zaakObjectTypes)
+    }
+
+    //TODO: ???
     @GetMapping("/v1/case-definition/{caseDefinitionKey}/zaaktype/roltype")
     fun getZaakRoltypes(
         @LoggableResource("caseDefinitionKey") @PathVariable(name = "caseDefinitionKey") caseDefinitionKey: String,
@@ -78,11 +104,13 @@ class CatalogiResource(
         return ResponseEntity.ok(zaakRolTypes)
     }
 
-    @GetMapping("/v1/case-definition/{caseDefinitionKey}/zaaktype/statustype")
+    @GetMapping("/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/statustype")
     fun getZaakStatustypen(
         @LoggableResource("caseDefinitionKey") @PathVariable(name = "caseDefinitionKey") caseDefinitionKey: String,
+        @LoggableResource("caseDefinitionVersionTag") @PathVariable(name = "versionTag") caseDefinitionVersionTag: String,
     ): ResponseEntity<List<StatustypeDto>> {
-        val caseDefinitionId = activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey).id
+        val caseDefinitionId =
+            caseDefinitionService.getCaseDefinition(CaseDefinitionId.of(caseDefinitionKey, caseDefinitionVersionTag)).id
         val zaakStatusTypes = catalogiService.getStatustypen(caseDefinitionId).map {
             StatustypeDto(
                 it.url!!,
@@ -92,11 +120,13 @@ class CatalogiResource(
         return ResponseEntity.ok(zaakStatusTypes)
     }
 
-    @GetMapping("/v1/case-definition/{caseDefinitionKey}/zaaktype/resultaattype")
+    @GetMapping("/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/resultaattype")
     fun getZaakResultaattypen(
         @LoggableResource("caseDefinitionKey") @PathVariable(name = "caseDefinitionKey") caseDefinitionKey: String,
+        @LoggableResource("caseDefinitionVersionTag") @PathVariable(name = "versionTag") caseDefinitionVersionTag: String,
     ): ResponseEntity<List<ResultaattypeDto>> {
-        val caseDefinitionId = activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey).id
+        val caseDefinitionId =
+            caseDefinitionService.getCaseDefinition(CaseDefinitionId.of(caseDefinitionKey, caseDefinitionVersionTag)).id
         val zaakResultaatTypes =
             catalogiService.getResultaattypen(caseDefinitionId).map {
                 ResultaattypeDto(
@@ -107,11 +137,13 @@ class CatalogiResource(
         return ResponseEntity.ok(zaakResultaatTypes)
     }
 
-    @GetMapping("/v1/case-definition/{caseDefinitionKey}/zaaktype/besluittype")
+    @GetMapping("/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/zaaktype/besluittype")
     fun getZaakBesuilttypen(
         @LoggableResource("caseDefinitionKey") @PathVariable(name = "caseDefinitionKey") caseDefinitionKey: String,
+        @LoggableResource("caseDefinitionVersionTag") @PathVariable(name = "versionTag") caseDefinitionVersionTag: String,
     ): ResponseEntity<List<BesluittypeDto>> {
-        val caseDefinitionId = activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey).id
+        val caseDefinitionId =
+            caseDefinitionService.getCaseDefinition(CaseDefinitionId.of(caseDefinitionKey, caseDefinitionVersionTag)).id
         val zaakBesluitTypes = catalogiService.getBesluittypen(caseDefinitionId).map {
             BesluittypeDto(
                 it.url!!,
@@ -127,11 +159,13 @@ class CatalogiResource(
         return ResponseEntity.ok(zaakTypen)
     }
 
-    @GetMapping("/management/v1/case-definition/{caseDefinitionKey}/catalogi-eigenschappen")
+    @GetMapping("/management/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/catalogi-eigenschappen")
     fun getEigenschappen(
         @LoggableResource("caseDefinitionKey") @PathVariable(name = "caseDefinitionKey") caseDefinitionKey: String,
+        @LoggableResource("caseDefinitionVersionTag") @PathVariable(name = "versionTag") caseDefinitionVersionTag: String,
     ): ResponseEntity<List<EigenschapDto>> {
-        val caseDefinitionId = activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey).id
+        val caseDefinitionId =
+            caseDefinitionService.getCaseDefinition(CaseDefinitionId.of(caseDefinitionKey, caseDefinitionVersionTag)).id
         val eigenschappen = catalogiService.getEigenschappen(caseDefinitionId)
             .map { EigenschapDto.of(it) }
             .sortedBy { it.name }

--- a/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/web/rest/CatalogiResourceTest.kt
+++ b/zgw/catalogi-api/src/test/kotlin/com/ritense/catalogiapi/web/rest/CatalogiResourceTest.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.catalogiapi.web.rest
 
+import com.ritense.case.service.CaseDefinitionService
 import com.ritense.case_.domain.definition.CaseDefinition
 import com.ritense.case_.service.ActiveCaseDefinitionService
 import com.ritense.catalogiapi.BaseTest
@@ -27,10 +28,14 @@ import com.ritense.catalogiapi.domain.Roltype
 import com.ritense.catalogiapi.domain.Specificatie
 import com.ritense.catalogiapi.domain.Statustype
 import com.ritense.catalogiapi.service.CatalogiService
+import com.ritense.document.domain.Document
+import com.ritense.document.domain.impl.JsonSchemaDocumentDefinitionId
+import com.ritense.document.service.DocumentService
 import com.ritense.valtimo.contract.case_.CaseDefinitionId
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.http.MediaType
@@ -41,6 +46,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.net.URI
 import java.nio.charset.StandardCharsets
+import java.util.Optional
+import java.util.UUID
 
 internal class CatalogiResourceTest : BaseTest() {
 
@@ -48,6 +55,8 @@ internal class CatalogiResourceTest : BaseTest() {
     lateinit var catalogiService: CatalogiService
     lateinit var catalogiResource: CatalogiResource
     lateinit var activeCaseDefinitionService: ActiveCaseDefinitionService
+    lateinit var caseDefinitionService: CaseDefinitionService
+    lateinit var documentService: DocumentService
 
     val caseDefinitionId = CaseDefinitionId("test", "1.0.0")
 
@@ -55,7 +64,10 @@ internal class CatalogiResourceTest : BaseTest() {
     fun init() {
         catalogiService = mock()
         activeCaseDefinitionService = mock()
-        catalogiResource = CatalogiResource(catalogiService, activeCaseDefinitionService)
+        caseDefinitionService = mock()
+        documentService = mock()
+        catalogiResource =
+            CatalogiResource(catalogiService, activeCaseDefinitionService, caseDefinitionService, documentService)
 
         mockMvc = MockMvcBuilders
             .standaloneSetup(catalogiResource)
@@ -63,8 +75,8 @@ internal class CatalogiResourceTest : BaseTest() {
     }
 
     @Test
-    fun `should get documenttypes for caseDefinitionKey`() {
-        val caseDefinitionKey = "case-name"
+    fun `should get documenttypes for caseDefinitionId`() {
+        val caseDefinitionKey = caseDefinitionId.key
 
         val type1 = mock<Informatieobjecttype>()
         whenever(type1.url).thenReturn(URI("http://example.com/1"))
@@ -76,7 +88,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         val caseDefinition = mock<CaseDefinition>()
         whenever(caseDefinition.id).thenReturn(caseDefinitionId)
-        whenever(activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey))
+        whenever(caseDefinitionService.getCaseDefinition(any()))
             .thenReturn(caseDefinition)
 
         whenever(catalogiService.getInformatieobjecttypes(caseDefinitionId))
@@ -84,7 +96,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         mockMvc
             .perform(
-                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/zaaktype/documenttype")
+                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/version/${caseDefinitionId.versionTag}/zaaktype/documenttype")
                     .characterEncoding(StandardCharsets.UTF_8.name())
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -101,8 +113,47 @@ internal class CatalogiResourceTest : BaseTest() {
     }
 
     @Test
-    fun `should get roltypes for caseDefinitionKey`() {
-        val caseDefinitionKey = "case-name"
+    fun `should get documenttypes for jsonSchemaDocument`() {
+        val documentId = UUID.randomUUID()
+        val documentDefinitionId = JsonSchemaDocumentDefinitionId.of("test", caseDefinitionId)
+
+        val type1 = mock<Informatieobjecttype>()
+        whenever(type1.url).thenReturn(URI("http://example.com/1"))
+        whenever(type1.omschrijving).thenReturn("name 1")
+
+        val type2 = mock<Informatieobjecttype>()
+        whenever(type2.url).thenReturn(URI("http://example.com/2"))
+        whenever(type2.omschrijving).thenReturn("name 2")
+
+        val document = mock<Document>()
+        whenever(document.definitionId()).thenReturn(documentDefinitionId)
+        whenever(documentService.findBy(any()))
+            .thenReturn(Optional.of(document))
+
+        whenever(catalogiService.getInformatieobjecttypes(caseDefinitionId))
+            .thenReturn(listOf(type1, type2))
+
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.get("/api/v1/document/$documentId/zaaktype/documenttype")
+                    .characterEncoding(StandardCharsets.UTF_8.name())
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .accept(MediaType.APPLICATION_JSON_VALUE)
+            )
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().is2xxSuccessful)
+            .andExpect(MockMvcResultMatchers.jsonPath("$").isNotEmpty)
+            .andExpect(MockMvcResultMatchers.jsonPath("$").isArray)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.*", Matchers.hasSize<Int>(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[0].url").value("http://example.com/1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].url").value("http://example.com/2"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[0].name").value("name 1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.[1].name").value("name 2"))
+    }
+
+    @Test
+    fun `should get roltypes for caseDefinitionId`() {
+        val caseDefinitionKey = caseDefinitionId.key
 
         val type1 = mock<Roltype>()
         whenever(type1.url).thenReturn(URI("http://example.com/1"))
@@ -139,7 +190,7 @@ internal class CatalogiResourceTest : BaseTest() {
     }
 
     @Test
-    fun `should get statustypen for caseDefinitionKey`() {
+    fun `should get statustypen for caseDefinitionId`() {
         val caseDefinitionKey = "case-name"
 
         val type1 = mock<Statustype>()
@@ -152,7 +203,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         val caseDefinition = mock<CaseDefinition>()
         whenever(caseDefinition.id).thenReturn(caseDefinitionId)
-        whenever(activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey))
+        whenever(caseDefinitionService.getCaseDefinition(any()))
             .thenReturn(caseDefinition)
 
         whenever(catalogiService.getStatustypen(caseDefinitionId))
@@ -160,7 +211,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         mockMvc
             .perform(
-                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/zaaktype/statustype")
+                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/version/${caseDefinitionId.versionTag}/zaaktype/statustype")
                     .characterEncoding(StandardCharsets.UTF_8.name())
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -177,8 +228,8 @@ internal class CatalogiResourceTest : BaseTest() {
     }
 
     @Test
-    fun `should get resultaattypen for caseDefinitionKey`() {
-        val caseDefinitionKey = "case-name"
+    fun `should get resultaattypen for caseDefinitionId`() {
+        val caseDefinitionKey = caseDefinitionId.key
 
         val type1 = mock<Resultaattype>()
         whenever(type1.url).thenReturn(URI("http://example.com/1"))
@@ -190,7 +241,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         val caseDefinition = mock<CaseDefinition>()
         whenever(caseDefinition.id).thenReturn(caseDefinitionId)
-        whenever(activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey))
+        whenever(caseDefinitionService.getCaseDefinition(any()))
             .thenReturn(caseDefinition)
 
         whenever(catalogiService.getResultaattypen(caseDefinitionId))
@@ -198,7 +249,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         mockMvc
             .perform(
-                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/zaaktype/resultaattype")
+                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/version/${caseDefinitionId.versionTag}/zaaktype/resultaattype")
                     .characterEncoding(StandardCharsets.UTF_8.name())
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -215,8 +266,8 @@ internal class CatalogiResourceTest : BaseTest() {
     }
 
     @Test
-    fun `should get besluittypen for caseDefinitionKey`() {
-        val caseDefinitionKey = "case-name"
+    fun `should get besluittypen for caseDefinitionId`() {
+        val caseDefinitionKey = caseDefinitionId.key
 
         val type1 = mock<Besluittype>()
         whenever(type1.url).thenReturn(URI("http://example.com/1"))
@@ -228,7 +279,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         val caseDefinition = mock<CaseDefinition>()
         whenever(caseDefinition.id).thenReturn(caseDefinitionId)
-        whenever(activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey))
+        whenever(caseDefinitionService.getCaseDefinition(any()))
             .thenReturn(caseDefinition)
 
         whenever(catalogiService.getBesluittypen(caseDefinitionId))
@@ -236,7 +287,7 @@ internal class CatalogiResourceTest : BaseTest() {
 
         mockMvc
             .perform(
-                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/zaaktype/besluittype")
+                MockMvcRequestBuilders.get("/api/v1/case-definition/$caseDefinitionKey/version/${caseDefinitionId.versionTag}/zaaktype/besluittype")
                     .characterEncoding(StandardCharsets.UTF_8.name())
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -282,8 +333,8 @@ internal class CatalogiResourceTest : BaseTest() {
     }
 
     @Test
-    fun `should get eigenschappen`() {
-        val caseDefinitionKey = "test-case"
+    fun `should get eigenschappen for caseDefinitionId`() {
+        val caseDefinitionKey = caseDefinitionId.key
 
         val eigenschappen = IntRange(1, 2).map { n ->
             Eigenschap(
@@ -302,13 +353,17 @@ internal class CatalogiResourceTest : BaseTest() {
 
         val caseDefinition = mock<CaseDefinition>()
         whenever(caseDefinition.id).thenReturn(caseDefinitionId)
-        whenever(activeCaseDefinitionService.getActiveCaseDefinition(caseDefinitionKey))
+        whenever(caseDefinitionService.getCaseDefinition(any()))
             .thenReturn(caseDefinition)
 
         whenever(catalogiService.getEigenschappen(caseDefinitionId)).thenReturn(eigenschappen)
 
         mockMvc.perform(
-            MockMvcRequestBuilders.get("/api/management/v1/case-definition/{caseDefinitionKey}/catalogi-eigenschappen", caseDefinitionKey)
+            MockMvcRequestBuilders.get(
+                "/api/management/v1/case-definition/{caseDefinitionKey}/version/{versionTag}/catalogi-eigenschappen",
+                caseDefinitionKey,
+                caseDefinitionId.versionTag
+            )
                 .characterEncoding(StandardCharsets.UTF_8.name())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .accept(MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
Updated catalogi endpoints to work based on case definition key and version tag. Also added 1 additional endpoint to retrieve documenttypes within the context of a json schema document

**ONLY MERGE WHEN FE IS DONE** otherwise parts of the application will stop working.