### PR TITLE
#106335 Find and implement an alternative to grouping on id in PBAC

### DIFF
--- a/authorization/src/main/kotlin/com/ritense/authorization/ValtimoAuthorizationService.kt
+++ b/authorization/src/main/kotlin/com/ritense/authorization/ValtimoAuthorizationService.kt
@@ -75,9 +75,9 @@ class ValtimoAuthorizationService(
         request: AuthorizationRequest<T>,
         permissions: List<Permission>?
     ): AuthorizationSpecification<T> {
-        val usedPermissions = permissions ?: getPermissions(request)
+        val userPermissions = permissions ?: getPermissions(request)
 
-        return getAuthorizationSpecification(request, usedPermissions, enablePermissionLogging = true)
+        return getAuthorizationSpecification(request, userPermissions, enablePermissionLogging = true)
     }
 
     override fun getPermissions(resourceType: Class<*>, action: Action<*>): List<Permission> {

--- a/case/src/main/kotlin/com/ritense/case/repository/CaseTabDocumentDefinitionMapper.kt
+++ b/case/src/main/kotlin/com/ritense/case/repository/CaseTabDocumentDefinitionMapper.kt
@@ -48,14 +48,22 @@ class CaseTabDocumentDefinitionMapper(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): AuthorizationEntityMapperResult<JsonSchemaDocumentDefinition> {
-        val documentDefinitionRoot: Root<JsonSchemaDocumentDefinition> = query.from(JsonSchemaDocumentDefinition::class.java)
-        return AuthorizationEntityMapperResult(
-            documentDefinitionRoot,
-            query,
-            criteriaBuilder.equal(
-                root.get<CaseTabId>("id").get<String>("caseDefinitionName"),
-                documentDefinitionRoot.get<JsonSchemaDocumentDefinitionId>("id").get<String>("name")
+
+        val subquery = query.subquery(Int::class.java)
+        val subRoot = subquery.from(JsonSchemaDocumentDefinition::class.java)
+
+        subquery.select(criteriaBuilder.literal(1))
+            .where(
+                criteriaBuilder.equal(
+                    root.get<CaseTabId>("id").get<String>("caseDefinitionName"),
+                    subRoot.get<JsonSchemaDocumentDefinitionId>("id").get<String>("name")
+                )
             )
+
+        return AuthorizationEntityMapperResult(
+            subRoot,
+            subquery,
+            criteriaBuilder.exists(subquery)
         )
     }
 

--- a/case/src/main/kotlin/com/ritense/case/repository/CaseTabSpecification.kt
+++ b/case/src/main/kotlin/com/ritense/case/repository/CaseTabSpecification.kt
@@ -27,7 +27,6 @@ import jakarta.persistence.criteria.AbstractQuery
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.Predicate
 import jakarta.persistence.criteria.Root
-import java.util.UUID
 
 class CaseTabSpecification(
     authRequest: AuthorizationRequest<CaseTab>,
@@ -40,12 +39,6 @@ class CaseTabSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        // Filter the permissions for the relevant ones and use those to  find the filters that are required
-        // Turn those filters into predicates
-        val groupList = query.groupList.toMutableList()
-        groupList.add(root.get<UUID>("id"))
-        query.groupBy(groupList)
-
         val predicates = permissions.stream()
             .filter { permission: Permission ->
                 CaseTab::class.java == permission.resourceType

--- a/core/src/main/kotlin/com/ritense/valtimo/camunda/authorization/CamundaExecutionProcessDefinitionMapper.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/camunda/authorization/CamundaExecutionProcessDefinitionMapper.kt
@@ -29,19 +29,27 @@ class CamundaExecutionProcessDefinitionMapper : AuthorizationEntityMapper<Camund
         return listOf(entity.processDefinition!!)
     }
 
-    override fun mapQuery(root: Root<CamundaExecution>, query: AbstractQuery<*>, criteriaBuilder: CriteriaBuilder): AuthorizationEntityMapperResult<CamundaProcessDefinition> {
-        val processDefinitionRoot: Root<CamundaProcessDefinition> = query.from(CamundaProcessDefinition::class.java)
-        val groupList = query.groupList.toMutableList()
-        groupList.add(root.get<CamundaProcessDefinition>("processDefinition").get<String>("id"))
-        query.groupBy(groupList)
+    override fun mapQuery(
+        root: Root<CamundaExecution>,
+        query: AbstractQuery<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): AuthorizationEntityMapperResult<CamundaProcessDefinition> {
+
+        val subquery = query.subquery(Int::class.java)
+        val processDefinitionRoot = subquery.from(CamundaProcessDefinition::class.java)
+
+        subquery.select(criteriaBuilder.literal(1))
+            .where(
+                criteriaBuilder.equal(
+                    root.get<CamundaProcessDefinition>("processDefinition").get<String>("id"),
+                    processDefinitionRoot.get<String>("id")
+                )
+            )
 
         return AuthorizationEntityMapperResult(
             processDefinitionRoot,
-            query,
-            criteriaBuilder.equal(
-                root.get<CamundaProcessDefinition>("processDefinition").get<String>("id"),
-                processDefinitionRoot.get<String>("id")
-            )
+            subquery,
+            criteriaBuilder.exists(subquery)
         )
     }
 

--- a/core/src/main/kotlin/com/ritense/valtimo/camunda/repository/CamundaTaskIdentityLinkMapper.kt
+++ b/core/src/main/kotlin/com/ritense/valtimo/camunda/repository/CamundaTaskIdentityLinkMapper.kt
@@ -36,14 +36,21 @@ class CamundaTaskIdentityLinkMapper : AuthorizationEntityMapper<CamundaTask, Cam
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): AuthorizationEntityMapperResult<CamundaIdentityLink> {
-        val subquery = query.subquery(String::class.java)
+
+        val subquery = query.subquery(Int::class.java)
         val subRoot = subquery.from(CamundaIdentityLink::class.java)
-        subquery.select(subRoot.get<CamundaTask>(TASK).get(ID))
+
+        subquery.select(criteriaBuilder.literal(1)).where(
+            criteriaBuilder.equal(
+                subRoot.get<CamundaTask>(TASK).get<String>(ID),
+                root.get<String>(ID)
+            )
+        )
 
         return AuthorizationEntityMapperResult(
             subRoot,
             subquery,
-            criteriaBuilder.`in`(root.get<Any>(ID)).value(subquery),
+            criteriaBuilder.exists(subquery)
         )
     }
 

--- a/dashboard/src/main/kotlin/com/ritense/dashboard/repository/DashboardSpecification.kt
+++ b/dashboard/src/main/kotlin/com/ritense/dashboard/repository/DashboardSpecification.kt
@@ -42,10 +42,6 @@ class DashboardSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        val groupList = query.groupList.toMutableList()
-        groupList.add(root.get<String>("key"))
-        query.groupBy(groupList)
-
         val predicates = permissions.stream()
             .filter { permission: Permission ->
                 Dashboard::class.java == permission.resourceType
@@ -56,7 +52,7 @@ class DashboardSpecification(
                     root,
                     query,
                     criteriaBuilder,
-                    authRequest.resourceType,
+                    authRequest,
                     queryDialectHelper
                 )
             }.toList()

--- a/document/src/main/kotlin/com/ritense/document/DocumentDocumentDefinitionMapper.kt
+++ b/document/src/main/kotlin/com/ritense/document/DocumentDocumentDefinitionMapper.kt
@@ -38,18 +38,25 @@ class DocumentDocumentDefinitionMapper(
 
     override fun mapQuery(
         root: Root<JsonSchemaDocument>,
-        query: AbstractQuery<*>, criteriaBuilder: CriteriaBuilder
+        query: AbstractQuery<*>,
+        criteriaBuilder: CriteriaBuilder
     ): AuthorizationEntityMapperResult<JsonSchemaDocumentDefinition> {
-        val definitionRoot: Root<JsonSchemaDocumentDefinition> = query.from(JsonSchemaDocumentDefinition::class.java)
-        query.groupBy(query.groupList + root.get<JsonSchemaDocumentDefinitionId>("documentDefinitionId"))
+
+        val subquery = query.subquery(Int::class.java)
+        val subRoot = subquery.from(JsonSchemaDocumentDefinition::class.java)
+
+        subquery.select(criteriaBuilder.literal(1))
+            .where(
+                criteriaBuilder.equal(
+                    root.get<JsonSchemaDocumentDefinitionId>("documentDefinitionId"),
+                    subRoot.get<JsonSchemaDocumentDefinitionId>("id")
+                )
+            )
 
         return AuthorizationEntityMapperResult(
-            definitionRoot,
-            query,
-            criteriaBuilder.equal(
-                root.get<JsonSchemaDocumentDefinitionId>("documentDefinitionId"),
-                definitionRoot.get<JsonSchemaDocumentDefinitionId>("id")
-            )
+            subRoot,
+            subquery,
+            criteriaBuilder.exists(subquery),
         )
     }
 

--- a/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentDefinitionSpecification.kt
+++ b/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentDefinitionSpecification.kt
@@ -39,6 +39,7 @@ class JsonSchemaDocumentDefinitionSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
+
         val predicates = permissions
             .filter { permission: Permission ->
                 JsonSchemaDocumentDefinition::class.java == permission.resourceType && authRequest.action == permission.action

--- a/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentDefinitionSpecification.kt
+++ b/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentDefinitionSpecification.kt
@@ -39,13 +39,6 @@ class JsonSchemaDocumentDefinitionSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        // Filter the permissions for the relevant ones and use those to  find the filters that are required
-        // Turn those filters into predicates
-        if (query.groupList.isEmpty()) {
-            val groupList = ArrayList(query.groupList)
-            groupList.add(root.get<Any>("id"))
-            query.groupBy(groupList)
-        }
         val predicates = permissions
             .filter { permission: Permission ->
                 JsonSchemaDocumentDefinition::class.java == permission.resourceType && authRequest.action == permission.action

--- a/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentSnapshotSpecification.kt
+++ b/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentSnapshotSpecification.kt
@@ -41,13 +41,6 @@ class JsonSchemaDocumentSnapshotSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        // Filter the permissions for the relevant ones and use those to  find the filters that are required
-        // Turn those filters into predicates
-        if (query.groupList.isEmpty()) {
-            val groupList = ArrayList(query.groupList)
-            groupList.add(root.get<Any>("id").get<Any>("id"))
-            query.groupBy(groupList)
-        }
         val predicates = permissions
             .filter { permission: Permission ->
                 JsonSchemaDocumentSnapshot::class.java == permission.resourceType && authRequest.action == permission.action

--- a/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentSpecification.kt
+++ b/document/src/main/kotlin/com/ritense/document/service/JsonSchemaDocumentSpecification.kt
@@ -18,7 +18,6 @@ package com.ritense.document.service
 import com.ritense.authorization.permission.Permission
 import com.ritense.authorization.request.AuthorizationRequest
 import com.ritense.authorization.specification.AuthorizationSpecification
-import com.ritense.authorization.utils.QueryUtils
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.domain.impl.JsonSchemaDocumentId
 import com.ritense.document.repository.impl.JsonSchemaDocumentRepository
@@ -43,13 +42,6 @@ class JsonSchemaDocumentSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        // Filter the permissions for the relevant ones and use those to  find the filters that are required
-        // Turn those filters into predicates
-        if (!QueryUtils.isCountQuery(query) && query.groupList.isEmpty()) {
-            val groupList = ArrayList(query.groupList)
-            groupList.add(root.get<Any>("id").get<Any>("id"))
-            query.groupBy(groupList)
-        }
         val predicates = permissions
             .filter { permission: Permission ->
                 JsonSchemaDocument::class.java == permission.resourceType && authRequest.action == permission.action

--- a/document/src/main/kotlin/com/ritense/document/service/SearchFieldSpecification.kt
+++ b/document/src/main/kotlin/com/ritense/document/service/SearchFieldSpecification.kt
@@ -36,11 +36,6 @@ class SearchFieldSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        if (query.groupList.isEmpty()) {
-            val groupList = ArrayList(query.groupList)
-            groupList.add(root.get<Any>("id").get<Any>("id"))
-            query.groupBy(groupList)
-        }
         val predicates = permissions
             .filter { permission: Permission ->
                 SearchField::class.java == permission.resourceType && authRequest.action == permission.action

--- a/document/src/test/java/com/ritense/document/BaseIntegrationTest.java
+++ b/document/src/test/java/com/ritense/document/BaseIntegrationTest.java
@@ -48,6 +48,7 @@ import com.ritense.document.service.JsonSchemaDocumentDefinitionActionProvider;
 import com.ritense.document.service.JsonSchemaDocumentSnapshotActionProvider;
 import com.ritense.document.service.SearchFieldActionProvider;
 import com.ritense.document.service.SearchFieldService;
+import com.ritense.document.service.impl.JsonSchemaDocumentService;
 import com.ritense.outbox.OutboxService;
 import com.ritense.resource.service.ResourceService;
 import com.ritense.testutilscommon.junit.extension.LiquibaseRunnerExtension;
@@ -83,7 +84,7 @@ public abstract class BaseIntegrationTest extends BaseTest {
     protected DocumentDefinitionService documentDefinitionService;
 
     @Inject
-    protected DocumentService documentService;
+    protected JsonSchemaDocumentService documentService;
 
     @SpyBean
     protected JsonSchemaDocumentRepository documentRepository;
@@ -144,7 +145,7 @@ public abstract class BaseIntegrationTest extends BaseTest {
             .build();
     }
 
-    protected Document createDocument(DocumentDefinition documentDefinition, String content) {
+    protected JsonSchemaDocument createDocument(DocumentDefinition documentDefinition, String content) {
         return AuthorizationContext
             .runWithoutAuthorization(
                 () -> documentService.createDocument(

--- a/document/src/test/kotlin/com/ritense/document/DocumentDocumentDefinitionMapperIntTest.kt
+++ b/document/src/test/kotlin/com/ritense/document/DocumentDocumentDefinitionMapperIntTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2024 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.document
+
+import com.ritense.authorization.AuthorizationContext.Companion.runWithoutAuthorization
+import com.ritense.authorization.AuthorizationService
+import com.ritense.authorization.request.EntityAuthorizationRequest
+import com.ritense.document.domain.impl.JsonSchemaDocument
+import com.ritense.document.service.JsonSchemaDocumentActionProvider.VIEW_LIST
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.context.support.WithMockUser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DocumentDocumentDefinitionMapperIntTest @Autowired constructor(
+    private val authorizationService: AuthorizationService,
+) : BaseIntegrationTest() {
+
+    @Test
+    @WithMockUser(username = USERNAME, authorities = ["ROLE_DUPLICATE_TEST"])
+    fun `should not get duplicate documents`() {
+        val documentDefinition = definitionOf("person")
+        val documents = runWithoutAuthorization {
+            listOf(
+                createDocument(documentDefinition, """{"firstName":"James"}"""),
+                createDocument(documentDefinition, """{"firstName":"Asha"}"""),
+                createDocument(documentDefinition, """{"firstName":"Morgan"}"""),
+            )
+        }
+
+        val spec = authorizationService.getAuthorizationSpecification(
+            EntityAuthorizationRequest(
+                JsonSchemaDocument::class.java,
+                VIEW_LIST
+            ),
+            null
+        )
+
+        val count = documentRepository.count(spec)
+
+        assertEquals(3, count)
+        documentRepository.deleteAll(documents)
+    }
+}

--- a/document/src/test/kotlin/com/ritense/document/DocumentDocumentDefinitionMapperIntTest.kt
+++ b/document/src/test/kotlin/com/ritense/document/DocumentDocumentDefinitionMapperIntTest.kt
@@ -21,6 +21,8 @@ import com.ritense.authorization.AuthorizationService
 import com.ritense.authorization.request.EntityAuthorizationRequest
 import com.ritense.document.domain.impl.JsonSchemaDocument
 import com.ritense.document.service.JsonSchemaDocumentActionProvider.VIEW_LIST
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.test.context.support.WithMockUser
 import kotlin.test.Test
@@ -29,6 +31,14 @@ import kotlin.test.assertEquals
 class DocumentDocumentDefinitionMapperIntTest @Autowired constructor(
     private val authorizationService: AuthorizationService,
 ) : BaseIntegrationTest() {
+
+    @BeforeEach
+    override fun beforeEachBase() {
+    }
+
+    @AfterEach
+    override fun afterEach() {
+    }
 
     @Test
     @WithMockUser(username = USERNAME, authorities = ["ROLE_DUPLICATE_TEST"])

--- a/document/src/test/resources/config/pbac/all.role.json
+++ b/document/src/test/resources/config/pbac/all.role.json
@@ -2,6 +2,7 @@
     "changesetId": "role-v1",
     "roles": [
         "ROLE_USER",
-        "ROLE_ADMIN"
+        "ROLE_ADMIN",
+        "ROLE_DUPLICATE_TEST"
     ]
 }

--- a/document/src/test/resources/config/pbac/document.permission.json
+++ b/document/src/test/resources/config/pbac/document.permission.json
@@ -45,6 +45,38 @@
             "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
             "action": "delete",
             "roleKey": "ROLE_ADMIN"
+        },
+        {
+            "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+            "action": "view_list",
+            "roleKey": "ROLE_DUPLICATE_TEST",
+            "conditions": [
+                {
+                    "type": "field",
+                    "field": "documentDefinitionId.name",
+                    "operator": "!=",
+                    "value": "house"
+                }
+            ]
+        },
+        {
+            "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
+            "action": "view_list",
+            "roleKey": "ROLE_DUPLICATE_TEST",
+            "conditions": [
+                {
+                    "type": "container",
+                    "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocumentDefinition",
+                    "conditions": [
+                        {
+                            "type": "field",
+                            "field": "id.name",
+                            "operator": "==",
+                            "value": "person"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/notes/src/main/kotlin/com/ritense/note/autoconfigure/NoteAutoConfiguration.kt
+++ b/notes/src/main/kotlin/com/ritense/note/autoconfigure/NoteAutoConfiguration.kt
@@ -34,7 +34,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Lazy
 import org.springframework.core.annotation.Order
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
@@ -91,9 +90,9 @@ class NoteAutoConfiguration {
 
     @Bean
     fun noteSpecificationFactory(
-        @Lazy noteService: NoteService,
+        noteRepository: NoteRepository,
         queryDialectHelper: QueryDialectHelper
     ): NoteSpecificationFactory {
-        return NoteSpecificationFactory(noteService, queryDialectHelper)
+        return NoteSpecificationFactory(noteRepository, queryDialectHelper)
     }
 }

--- a/notes/src/main/kotlin/com/ritense/note/repository/NoteDocumentMapper.kt
+++ b/notes/src/main/kotlin/com/ritense/note/repository/NoteDocumentMapper.kt
@@ -35,16 +35,27 @@ class NoteDocumentMapper(
         return runWithoutAuthorization { listOf(documentRepository.findById(JsonSchemaDocumentId.existingId(entity.documentId)).get()) }
     }
 
-    override fun mapQuery(root: Root<Note>, query: AbstractQuery<*>, criteriaBuilder: CriteriaBuilder): AuthorizationEntityMapperResult<JsonSchemaDocument> {
-        val documentRoot: Root<JsonSchemaDocument> = query.from(JsonSchemaDocument::class.java)
-        val groupList = query.groupList.toMutableList()
-        groupList.add(root.get<UUID>("documentId"))
-        query.groupBy(groupList)
+    override fun mapQuery(
+        root: Root<Note>,
+        query: AbstractQuery<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): AuthorizationEntityMapperResult<JsonSchemaDocument> {
+
+        val subquery = query.subquery(Int::class.java)
+        val documentRoot = subquery.from(JsonSchemaDocument::class.java)
+
+        subquery.select(criteriaBuilder.literal(1))
+            .where(
+                criteriaBuilder.equal(
+                    root.get<UUID>("documentId"),
+                    documentRoot.get<JsonSchemaDocumentId>("id").get<UUID>("id")
+                )
+            )
 
         return AuthorizationEntityMapperResult(
             documentRoot,
-            query,
-            criteriaBuilder.equal(root.get<UUID>("documentId"), documentRoot.get<JsonSchemaDocumentId>("id").get<UUID>("id"))
+            subquery,
+            criteriaBuilder.exists(subquery)
         )
     }
 

--- a/notes/src/main/kotlin/com/ritense/note/repository/NoteSpecification.kt
+++ b/notes/src/main/kotlin/com/ritense/note/repository/NoteSpecification.kt
@@ -21,7 +21,6 @@ import com.ritense.authorization.permission.Permission
 import com.ritense.authorization.request.AuthorizationRequest
 import com.ritense.authorization.specification.AuthorizationSpecification
 import com.ritense.note.domain.Note
-import com.ritense.note.service.NoteService
 import com.ritense.valtimo.contract.database.QueryDialectHelper
 import jakarta.persistence.criteria.AbstractQuery
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -32,7 +31,7 @@ import java.util.UUID
 class NoteSpecification(
         authRequest: AuthorizationRequest<Note>,
         permissions: List<Permission>,
-        private val noteService: NoteService,
+        private val noteRepository: NoteRepository,
         private val queryDialectHelper: QueryDialectHelper
 ) : AuthorizationSpecification<Note>(authRequest, permissions) {
     override fun toPredicate(
@@ -40,12 +39,6 @@ class NoteSpecification(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        // Filter the permissions for the relevant ones and use those to  find the filters that are required
-        // Turn those filters into predicates
-        val groupList = query.groupList.toMutableList()
-        groupList.add(root.get<UUID>("id"))
-        query.groupBy(groupList)
-
         val predicates = permissions.stream()
             .filter { permission: Permission ->
                 Note::class.java == permission.resourceType
@@ -65,7 +58,7 @@ class NoteSpecification(
 
     override fun identifierToEntity(identifier: String): Note {
         return runWithoutAuthorization {
-            noteService.getNoteById(UUID.fromString(identifier))
+            noteRepository.getReferenceById(UUID.fromString(identifier))
         }
     }
 }

--- a/notes/src/main/kotlin/com/ritense/note/repository/NoteSpecificationFactory.kt
+++ b/notes/src/main/kotlin/com/ritense/note/repository/NoteSpecificationFactory.kt
@@ -21,11 +21,10 @@ import com.ritense.authorization.request.AuthorizationRequest
 import com.ritense.authorization.specification.AuthorizationSpecification
 import com.ritense.authorization.specification.AuthorizationSpecificationFactory
 import com.ritense.note.domain.Note
-import com.ritense.note.service.NoteService
 import com.ritense.valtimo.contract.database.QueryDialectHelper
 
 class NoteSpecificationFactory(
-    private val noteService: NoteService,
+    private val noteRepository: NoteRepository,
     private var queryDialectHelper: QueryDialectHelper
 ) : AuthorizationSpecificationFactory<Note> {
 
@@ -36,7 +35,7 @@ class NoteSpecificationFactory(
         return NoteSpecification(
             request,
             permissions,
-            noteService,
+            noteRepository,
             queryDialectHelper
         )
     }

--- a/process-document/src/main/kotlin/com/ritense/processdocument/camunda/authorization/CamundaTaskDocumentMapper.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/camunda/authorization/CamundaTaskDocumentMapper.kt
@@ -53,20 +53,24 @@ class CamundaTaskDocumentMapper(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): AuthorizationEntityMapperResult<JsonSchemaDocument> {
-        val documentRoot = query.from(JsonSchemaDocument::class.java)
+
+        val subquery = query.subquery(Int::class.java)
+        val documentRoot = subquery.from(JsonSchemaDocument::class.java)
+
         val processBusinessKey = root.get<CamundaExecution>(PROCESS_INSTANCE).get<String>(BUSINESS_KEY)
-        if (!QueryUtils.isCountQuery(query)) {
-            query.groupBy(query.groupList + root.get<String>(ID))
-        }
+
         val documentId = queryDialectHelper.uuidToString(
             criteriaBuilder,
             documentRoot.get<JsonSchemaDocumentId>(ID).get(ID)
         )
 
+        subquery.select(criteriaBuilder.literal(1))
+            .where(criteriaBuilder.equal(processBusinessKey, documentId))
+
         return AuthorizationEntityMapperResult(
             documentRoot,
-            query,
-            criteriaBuilder.equal(processBusinessKey, documentId)
+            subquery,
+            criteriaBuilder.exists(subquery)
         )
     }
 

--- a/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/service/CaseTaskListSearchService.kt
@@ -181,13 +181,6 @@ class CaseTaskListSearchService(
             )
         )
 
-        // Due to the JsonSchemaDocumentSpecification#toPredicate adding a groupBy (which is called when applying PBAC)
-        // ...we are forced to add all the columns we want to select, to the group by.
-        // This can be removed if we have a solution for this group by (TP story #106335)
-        val groupList = query.groupList.toMutableList()
-        groupList.addAll(selectCols)
-        query.groupBy(groupList)
-
         // TODO: look into ability to re-use where predicate in list and count query. improves performance
         query.where(constructWhere(cb, query, taskRoot, documentRoot, caseDefinitionName, advancedSearchRequest))
 
@@ -618,14 +611,6 @@ class CaseTaskListSearchService(
                         }
 
                         val path: Path<Any> = stringToPath(parent, docProperty)
-                        // This groupBy workaround is needed because PBAC adds a groupBy on 'id' by default.
-                        // Since sorting columns should be added to the groupBy, we do that here
-                        if (query.groupList.isNotEmpty() && !query.groupList.contains(path)) {
-                            val grouping =
-                                ArrayList(query.groupList)
-                            grouping.add(path)
-                            query.groupBy(grouping)
-                        }
                         expression = path
                     }
                 }


### PR DESCRIPTION
### ✅ Recommended: `EXISTS` Subquery

The most feasible solution is to use `EXISTS`. Modern databases optimize `EXISTS` to stop searching after finding the first matching record. It also performs better than the **implicit join** currently in use.
### 🔍 SQL — EXISTS with Subquery
```
SELECT *
FROM note n
WHERE EXISTS (
    SELECT 1
    FROM json_schema_document d
    WHERE n.document_id = d.id
      AND d.document_definition_name = 'bezwaar'
)
```
### ⚠️ Current Approach: Implicit Join

This style is less efficient and more error-prone. It may lead to duplicated rows.
### 🔍 SQL — Implicit Join (current)
```
SELECT *
FROM note n, json_schema_document d
WHERE n.document_id = d.json_schema_document_id
  AND d.document_definition_name = 'bezwaar'
```
### 🔐 PBAC Configuration
```
{
  "resourceType": "com.ritense.note.domain.Note",
  "action": "view_list",
  "conditions": [
    {
      "type": "container",
      "resourceType": "com.ritense.document.domain.impl.JsonSchemaDocument",
      "conditions": [
        {
          "type": "field",
          "field": "documentDefinitionId.name",
          "operator": "==",
          "value": "bezwaar"
        }
      ]
    }
  ]
}
```
### 🚀 Best Performance: Explicit Join

The best-performing solution is to use an **explicit** `JOIN`. It’s clearer and faster, and also simplifies PBAC configurations. However, it introduces **tight coupling** between modules, which may not always be acceptable.
### 🔍 SQL — Explicit Join
```
SELECT *
FROM note n
JOIN json_schema_document d ON n.document_id = d.json_schema_document_id
WHERE d.document_definition_name = 'bezwaar'
```
### 🔐 PBAC Configuration for Explicit Join
```
{
  "resourceType": "com.ritense.note.domain.Note",
  "action": "view_list",
  "conditions": [
    {
      "type": "field",
      "field": "document.documentDefinitionId.name",
      "operator": "==",
      "value": "bezwaar"
    }
  ]
}
```
### 🔧 JPA Entity Mapping Required for Explicit Join

To support an explicit join in JPA/Hibernate, a `@ManyToOne` relationship must be defined:
```
@Entity
@Table(name = "note")
data class Note(
    // ...

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "document_id", referencedColumnName = "json_schema_document_id")
    val document: JsonSchemaDocument? = null
)
```


### ⚠️ Not recommended: `IN` Subquery

Using a subquery with `IN` is **not safe** in our case. The subquery can return **more than 65,000 rows**, exceeding memory limits and causing performance issues.

### 🔍 SQL — `IN` Subquery
```
SELECT *
FROM note n
WHERE n.document_id IN (
    SELECT d.json_schema_document_id
    FROM json_schema_document d
    WHERE n.document_id = d.id
      AND d.document_definition_name = 'bezwaar'
)
```