### PR TITLE
upgrade cve-report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ plugins {
     id "com.avast.gradle.docker-compose" version "${dockerComposePluginVersion}"
     id "com.github.jk1.dependency-license-report" version "${dependencyLicenseReportVersion}"
     id "project-report"
-    id "org.owasp.dependencycheck" version "8.4.3"
+    id "org.owasp.dependencycheck" version "12.1.3"
 }
 
 jacoco {

--- a/gradle/cve-report/build.gradle
+++ b/gradle/cve-report/build.gradle
@@ -16,16 +16,12 @@
 
 rootProject.configure(rootProject, {
     dependencyCheck {
-        cveValidForHours = 168
         failOnError = false
         formats = [ 'HTML', 'CSV' ]
         analyzedTypes = [ 'jar', 'aar', 'war', 'ear', 'zip' ]
         autoUpdate = true
         failBuildOnCVSS = 7
-        cve {
-            urlModified = 'http://cve-mirror.ritense.com/nvdcve-1.1-modified.json.gz'
-            urlBase = 'http://cve-mirror.ritense.com/nvdcve-1.1-%d.json.gz'
-        }
+        nvd.apiKey = findProperty("nvdApiKey")
         analyzers {
             // disables dotnet & js checking
             assemblyEnabled = false


### PR DESCRIPTION
Fix for the cve-report gradle fix. Upgraded to latest version and no longer using the mirror.