### PR TITLE
fix: deploying plugin action definitions

### DIFF
--- a/plugin/src/main/kotlin/com/ritense/plugin/PluginDeploymentListener.kt
+++ b/plugin/src/main/kotlin/com/ritense/plugin/PluginDeploymentListener.kt
@@ -114,6 +114,7 @@ open class PluginDeploymentListener(
             pluginAnnotation.description,
             clazz.name,
             mutableSetOf(),
+            mutableSetOf(),
             mutableSetOf()
         )
 
@@ -152,18 +153,20 @@ open class PluginDeploymentListener(
     private fun createActionDefinition(deployedPluginDefinition: PluginDefinition, clazz: Class<*>) {
         findPluginActions(clazz)
             .forEach { (method, actionAnnotation) ->
-                val actionDefinition = deployActionDefinition(
-                    PluginActionDefinition(
-                        PluginActionDefinitionId(
-                            actionAnnotation.key,
-                            deployedPluginDefinition
-                        ),
-                        actionAnnotation.title,
-                        actionAnnotation.description,
-                        method.name,
-                        actionAnnotation.activityTypes.toList()
-                    )
+                val actionDefinition = PluginActionDefinition(
+                    PluginActionDefinitionId(
+                        actionAnnotation.key,
+                        deployedPluginDefinition
+                    ),
+                    actionAnnotation.title,
+                    actionAnnotation.description,
+                    method.name,
+                    actionAnnotation.activityTypes.toList()
                 )
+
+                deployActionDefinition(actionDefinition)
+                (deployedPluginDefinition.actions as MutableSet).add(actionDefinition)
+
                 findPluginActionParameters(method)
                     .forEach { (parameter, _) ->
                         deployActionParameterDefinition(


### PR DESCRIPTION
Please test by first booting next-minor and letting plugin actions deploy. Verify they are deployed. Then reboot without resetting database. Verify plugin_action_definition_activity table is now empty. Then, check out this branch and also boot twice, and verify the tables are now correctly populated. Closes https://ritense.tpondemand.com/entity/140514-be-plugin-action-are-not-deployed