### PR TITLE
Added NoContext as a contextResourceType

### DIFF
--- a/authorization/src/main/kotlin/com/ritense/authorization/NoContext.kt
+++ b/authorization/src/main/kotlin/com/ritense/authorization/NoContext.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.authorization
+
+class NoContext {
+}

--- a/authorization/src/main/kotlin/com/ritense/authorization/permission/Permission.kt
+++ b/authorization/src/main/kotlin/com/ritense/authorization/permission/Permission.kt
@@ -17,6 +17,7 @@
 package com.ritense.authorization.permission
 
 import com.ritense.authorization.Action
+import com.ritense.authorization.NoContext
 import com.ritense.authorization.criteriabuilder.AbstractQueryWrapper
 import com.ritense.authorization.request.AuthorizationRequest
 import com.ritense.authorization.request.EntityAuthorizationRequest
@@ -182,6 +183,7 @@ data class Permission(
         contextEntity: Any?
     ): Boolean {
         return this.contextResourceType == null
+            || (this.contextResourceType == NoContext::class.java && contextResourceType == null)
             || (contextResourceType == this.contextResourceType
                 && contextConditionContainer?.let { container ->
                     container.conditions


### PR DESCRIPTION
Solves https://github.com/generiekzaakafhandelcomponent/gzac-issues/issues/161 by introducing the NoContext resource type. If this is set for a permission, that permission can only evaluate to true if there is no context provided in the check (e.g. when wanting to start a new process from the case list).