### PR TITLE
Zaken API plugin: fixed issues discovered during user test

### DIFF
--- a/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
+++ b/zgw/zaken-api/src/main/kotlin/com/ritense/zakenapi/ZakenApiPlugin.kt
@@ -480,7 +480,7 @@ class ZakenApiPlugin(
         @PluginActionProperty identificatie: String,
         @PluginActionProperty achternaam: String,
         @PluginActionProperty voorletters: String,
-        @PluginActionProperty voorvoegselAchternaam: String,
+        @PluginActionProperty voorvoegselAchternaam: String? = null,
         @PluginActionProperty afwijkendeNaamBetrokkene: String? = null,
         @PluginActionProperty indicatieMachtiging: String? = null,
         @PluginActionProperty beginGeldigheid: LocalDate? = null,
@@ -509,7 +509,7 @@ class ZakenApiPlugin(
                         identificatie = identificatie,
                         achternaam = achternaam,
                         voorletters = voorletters,
-                        voorvoegselAchternaam = voorvoegselAchternaam
+                        voorvoegselAchternaam = voorvoegselAchternaam ?: ""
                     ),
                     afwijkendeNaamBetrokkene = afwijkendeNaamBetrokkene,
                     indicatieMachtigingString = indicatieMachtiging,
@@ -595,6 +595,7 @@ class ZakenApiPlugin(
         @PluginActionProperty rolToelichting: String,
         @PluginActionProperty kvkNummer: String,
         @PluginActionProperty vestigingsNummer: String,
+        @PluginActionProperty handelsnaam: String? = null,
         @PluginActionProperty beginGeldigheid: LocalDate? = null,
         @PluginActionProperty eindeGeldigheid: LocalDate? = null
     ) {
@@ -616,6 +617,7 @@ class ZakenApiPlugin(
                     roltoelichting = rolToelichting,
                     betrokkeneType = BetrokkeneType.VESTIGING,
                     betrokkeneIdentificatie = RolVestiging(
+                        handelsnaam = handelsnaam?.let { listOf(handelsnaam) },
                         kvkNummer = kvkNummer,
                         vestigingsNummer = vestigingsNummer
                     ),

--- a/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
+++ b/zgw/zaken-api/src/test/kotlin/com/ritense/zakenapi/ZakenApiPluginTest.kt
@@ -356,7 +356,45 @@ internal class ZakenApiPluginTest {
     }
 
     @Test
-    fun `should create zaakrol for medewerker`() {
+    fun `should create zaakrol for medewerker without voorvoegselAchternaam`() {
+        val zakenApiClient: ZakenApiClient = mock()
+        val executionMock = mock<DelegateExecution>()
+
+        val plugin = zakenApiPluginAndMocksForZaakRol(
+            zakenApiClient = zakenApiClient,
+            executionMock = executionMock
+        )
+
+        plugin.createMedewerkerZaakRol(
+            execution = executionMock,
+            roltypeUrl = roltypeUrl(),
+            rolToelichting = "rolToelichting",
+            identificatie = "identificatie",
+            achternaam = "achternaam",
+            voorletters = "voorletters",
+            indicatieMachtiging = "gemachtigde"
+        )
+
+        val rolCaptor = argumentCaptor<Rol>()
+        verify(zakenApiClient).createZaakRol(any(), any(), rolCaptor.capture())
+
+        val rol = rolCaptor.firstValue
+
+        assertThat(rol.zaak).isEqualTo(zaakUri())
+        assertThat(rol.roltype).isEqualTo(roltypeUri())
+        assertThat(rol.roltoelichting).isEqualTo("rolToelichting")
+        assertThat(rol.indicatieMachtiging).isNotNull
+        assertThat(rol.indicatieMachtiging!!.key).isEqualTo("gemachtigde")
+
+        val betrokkeneIdentificatie = rol.betrokkeneIdentificatie as RolMedewerker
+        assertThat(betrokkeneIdentificatie.identificatie).isEqualTo("identificatie")
+        assertThat(betrokkeneIdentificatie.achternaam).isEqualTo("achternaam")
+        assertThat(betrokkeneIdentificatie.voorletters).isEqualTo("voorletters")
+        assertThat(betrokkeneIdentificatie.voorvoegselAchternaam).isEmpty()
+    }
+
+    @Test
+    fun `should create zaakrol for medewerker with voorvoegselAchternaam`() {
         val zakenApiClient: ZakenApiClient = mock()
         val executionMock = mock<DelegateExecution>()
 
@@ -431,7 +469,7 @@ internal class ZakenApiPluginTest {
     }
 
     @Test
-    fun `should create zaakrol for vestiging`() {
+    fun `should create zaakrol for vestiging without handelsnaam`() {
         val zakenApiClient: ZakenApiClient = mock()
         val executionMock = mock<DelegateExecution>()
 
@@ -457,6 +495,41 @@ internal class ZakenApiPluginTest {
         assertThat(rol.roltoelichting).isEqualTo("rolToelichting")
 
         val betrokkeneIdentificatie = rol.betrokkeneIdentificatie as RolVestiging
+        assertThat(betrokkeneIdentificatie.handelsnaam).isNull()
+        assertThat(betrokkeneIdentificatie.kvkNummer).isEqualTo("kvkNummer")
+        assertThat(betrokkeneIdentificatie.vestigingsNummer).isEqualTo("vestigingsNummer")
+    }
+
+    @Test
+    fun `should create zaakrol for vestiging with handelsnaam`() {
+        val zakenApiClient: ZakenApiClient = mock()
+        val executionMock = mock<DelegateExecution>()
+
+        val plugin = zakenApiPluginAndMocksForZaakRol(
+            zakenApiClient = zakenApiClient,
+            executionMock = executionMock
+        )
+
+        plugin.createVestigingZaakRol(
+            execution = executionMock,
+            roltypeUrl = roltypeUrl(),
+            rolToelichting = "rolToelichting",
+            handelsnaam = "handelsnaam",
+            kvkNummer = "kvkNummer",
+            vestigingsNummer = "vestigingsNummer",
+        )
+
+        val rolCaptor = argumentCaptor<Rol>()
+        verify(zakenApiClient).createZaakRol(any(), any(), rolCaptor.capture())
+
+        val rol = rolCaptor.firstValue
+        assertThat(rol.zaak).isEqualTo(zaakUri())
+        assertThat(rol.roltype).isEqualTo(roltypeUri())
+        assertThat(rol.roltoelichting).isEqualTo("rolToelichting")
+
+        val betrokkeneIdentificatie = rol.betrokkeneIdentificatie as RolVestiging
+        assertThat(betrokkeneIdentificatie.handelsnaam).isNotNull
+        assertThat(betrokkeneIdentificatie.handelsnaam!!.first()).isEqualTo("handelsnaam")
         assertThat(betrokkeneIdentificatie.kvkNummer).isEqualTo("kvkNummer")
         assertThat(betrokkeneIdentificatie.vestigingsNummer).isEqualTo("vestigingsNummer")
     }


### PR DESCRIPTION
Plugin action:
- _create-medewerker-zaak-rol_: Changed voorvoegselAchternaam property to support null
- _create-vestiging-zaakrol_: Added handelsnaam property