### PR TITLE
bug fix: add null safety to node["properties"] field iteration.

### DIFF
--- a/process-document/src/main/kotlin/com/ritense/processdocument/resolver/DocumentJsonValueResolverFactory.kt
+++ b/process-document/src/main/kotlin/com/ritense/processdocument/resolver/DocumentJsonValueResolverFactory.kt
@@ -250,7 +250,7 @@ class DocumentJsonValueResolverFactory(
             if (isSimpleObject(propertyType)) {
                 options += ValueResolverOption(path, ValueResolverOptionType.FIELD)
             } else if (propertyType == "object") {
-                node["properties"].fields().forEach { jsonNode ->
+                node["properties"]?.fields()?.forEach { jsonNode ->
                     options += getPropertyNamesFromObjectNode(
                         definition,
                         jsonNode.value as ObjectNode,


### PR DESCRIPTION
<!-- Please consider the following points before creating a pull request. -->

### Describe the changes
Link to the related Github issue: 

<!-- Please add any additional comments that might be relevant for reviewing this pull request  -->
<!-- Why did you choose to make these changes? Were there any trade-offs you had to consider?   -->
<!-- Note: add an empty line with a > to use multiple lines  -->
**Relevant comments:**
> 

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

### Documentation
<!-- Release notes should be available in the Valtimo documentation.  -->
- [ ] Release notes have been written for these changes. 

Link to the pull request in the [Valtimo documentation repository](https://github.com/valtimo-platform/valtimo-documentation):
>

New features or changes that have been introduced have been documented.
- [ ] Yes
- [ ] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
