### PR TITLE
Forcing `searchColumn` to be treated as a `String`

### DIFF
--- a/contract/src/main/java/com/ritense/valtimo/contract/database/MysqlQueryDialectHelper.java
+++ b/contract/src/main/java/com/ritense/valtimo/contract/database/MysqlQueryDialectHelper.java
@@ -74,7 +74,7 @@ public class MysqlQueryDialectHelper implements QueryDialectHelper {
         Expression<?> searchPath = cb.literal(path);
         Expression<?> searchValue = cb.literal("%" + value.trim() + "%");
         if (column.getJavaType() == String.class || column.getJavaType() == Object.class) {
-            searchColumn = cb.function(LOWER_CASE_FUNCTION, String.class, searchColumn);
+            searchColumn = cb.function(LOWER_CASE_FUNCTION, String.class, searchColumn.as(String.class));
             searchPath = cb.function(LOWER_CASE_FUNCTION, String.class, searchPath);
             searchValue = cb.function(LOWER_CASE_FUNCTION, String.class, searchValue);
         }


### PR DESCRIPTION
### Forcing `searchColumn` to be treated as a `String` to avoid a "FunctionArgumentException: Parameter 1 of function 'lower()' has type 'STRING', but argument is of type 'java.lang.Object'".

In one of our implementations we use the following piece of code:

```java
var searchRequest = new SearchRequest();
searchRequest.setDocumentDefinitionName(documentDefinitionName);
searchRequest.setOtherFilters(List.of(
    new SearchCriteria("$.reference", reference)
));

return ((List<JsonSchemaDocument>) documentSearchService.search(
    searchRequest,
    PageRequest.of(0, 1000)
).getContent());
```

In the past we have received tickets for this implementation that functionality using the code above was broken with the above-mentioned error. But when retrying this functionality (with the exact same steps) at a later point, the error was gone and everything worked correctly. At the time we never were able to reproduce the error, so we left it as is.

Last week I setup the project again for local development, and lo and behold, every time I try to use this functionality, I consistently get this error.

Unfortunately I have not been able to find a definitive reason for why this behavior differs between environments/builds/sessions. The code passes a hard-coded string that is used as `searchColumn`. From research this seems to be related to how different versions of Hibernate work, though I can't really see why these would be different between builds with the same source code. But I did find a fix, which is to force `searchColumn` to be treated as a String. Given that `lower()` expects a String as an argument, this fix wont break anything, since non-strings would result in errors anyway.

<!-- Please consider the following points before creating a pull request. -->

### Breaking changes
<!-- Valtimo aims to comply with the SemVer specification.  -->
<!-- Breaking changes are only allowed in the `next-major` branch.  -->
- [x] The contribution only contains changes that are not breaking.

New features or changes that have been introduced have been documented.
- [ ] Yes
- [x] Not applicable

### Tests
Unit tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

Integration tests have been added that cover these changes
- [ ] Yes
- [x] Not applicable

### Security
The [Secure by Design principle](https://en.wikipedia.org/wiki/Secure_by_design) has been applied to these changes
- [ ] Yes
- [x] Not applicable

Added or changed REST API endpoints have authentication and authorization in place
- [ ] Yes
- [x] Not applicable

Valtimo access control checks have been implemented
- [ ] Yes
- [x] Not applicable

### Dependencies
Newly added dependencies do not introduce known vulnerabilities/CVE's and are in line with the Valtimo license
- [ ] Yes
- [x] Not applicable
